### PR TITLE
feat(seed): tambah --demo flag untuk seed demo data (Jalur A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ pip install -r requirements.txt
 
 # 4. Jalankan aplikasi (DB + seed data otomatis dibuat saat pertama jalan)
 python -m perpustakaan
+
+# Atau dengan demo data (5 anggota + 10 buku + 2 peminjaman aktif)
+# berguna untuk training / demo tanpa input data manual
+python -m perpustakaan --demo
 ```
 
 Database (SQLite) akan dibuat otomatis di:

--- a/src/perpustakaan/__main__.py
+++ b/src/perpustakaan/__main__.py
@@ -1,14 +1,37 @@
 """Entry point untuk `python -m perpustakaan` dan PyInstaller bootloader."""
 from __future__ import annotations
 
+import argparse
 import sys
 
 
-def main() -> int:
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="perpustakaan",
+        description="Perpustakaan Offline — SIM-Perpus reborn (Python + SQLite + CustomTkinter)",
+    )
+    parser.add_argument(
+        "--demo",
+        action="store_true",
+        help=(
+            "Seed demo data (5 anggota + 10 buku + 2 peminjaman aktif) saat database masih kosong. "
+            "Berguna untuk demo/training tanpa input data manual."
+        ),
+    )
+    parser.add_argument(
+        "--no-gui",
+        action="store_true",
+        help="Hanya inisialisasi DB + (opsional) seed demo, lalu exit. Tidak buka GUI.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
     """Bootstrap aplikasi GUI."""
+    args = _parse_args(argv)
     from perpustakaan.app import run
 
-    return run()
+    return run(demo=args.demo, headless=args.no_gui)
 
 
 if __name__ == "__main__":

--- a/src/perpustakaan/app.py
+++ b/src/perpustakaan/app.py
@@ -26,12 +26,22 @@ def _setup_logging() -> None:
     )
 
 
-def _init_database() -> None:
+def _init_database(demo: bool = False) -> None:
     from perpustakaan.db.connection import init_db
-    from perpustakaan.db.seed import seed_all
+    from perpustakaan.db.seed import seed_all, seed_demo
 
     init_db()
     seed_all()
+    if demo:
+        log = logging.getLogger("perpustakaan.app")
+        result = seed_demo()
+        if any(result.values()):
+            log.info(
+                "Demo data seeded: %d anggota, %d buku, %d peminjaman",
+                result["anggota"], result["buku"], result["peminjaman"],
+            )
+        else:
+            log.info("Demo data dilewati (database sudah berisi data).")
 
 
 def _apply_locale_from_settings() -> None:
@@ -45,17 +55,28 @@ def _apply_locale_from_settings() -> None:
         set_locale("id")
 
 
-def run() -> int:
-    """Entry point — return exit code."""
+def run(demo: bool = False, headless: bool = False) -> int:
+    """Entry point — return exit code.
+
+    Args:
+        demo: kalau True, seed demo data (5 anggota + 10 buku + 2 peminjaman)
+            saat DB masih kosong. Idempotent — di-skip kalau sudah ada data.
+        headless: kalau True, tidak buka GUI; hanya init DB lalu exit
+            (berguna untuk CI / scripting).
+    """
     _setup_logging()
     log = logging.getLogger("perpustakaan.app")
     try:
-        _init_database()
+        _init_database(demo=demo)
         _apply_locale_from_settings()
     except Exception:  # pragma: no cover - bootstrap error
         log.exception("Gagal inisialisasi database")
         traceback.print_exc()
         return 2
+
+    if headless:
+        log.info("Mode --no-gui: inisialisasi selesai, exit.")
+        return 0
 
     try:
         from perpustakaan.gui.login import run_login_then_main

--- a/src/perpustakaan/db/seed.py
+++ b/src/perpustakaan/db/seed.py
@@ -128,3 +128,91 @@ def seed_all(db: Database | None = None) -> None:
     seed_admin(db)
     seed_ddc(db)
     seed_kelas(db)
+
+
+_DEMO_ANGGOTA: list[dict[str, str]] = [
+    {"nama": "Aulia Rahma", "kelas": "VII A", "jenis_kelamin": "P",
+     "tempat_lahir": "Jakarta", "tanggal_lahir": "2011-03-12", "no_telp": "081234567001"},
+    {"nama": "Budi Pratama", "kelas": "VII A", "jenis_kelamin": "L",
+     "tempat_lahir": "Bandung", "tanggal_lahir": "2011-07-08", "no_telp": "081234567002"},
+    {"nama": "Citra Dewi", "kelas": "VIII B", "jenis_kelamin": "P",
+     "tempat_lahir": "Surabaya", "tanggal_lahir": "2010-11-23", "no_telp": "081234567003"},
+    {"nama": "Dimas Saputra", "kelas": "VIII B", "jenis_kelamin": "L",
+     "tempat_lahir": "Yogyakarta", "tanggal_lahir": "2010-05-19", "no_telp": "081234567004"},
+    {"nama": "Eka Putri", "kelas": "IX A", "jenis_kelamin": "P",
+     "tempat_lahir": "Medan", "tanggal_lahir": "2009-09-01", "no_telp": "081234567005"},
+]
+
+_DEMO_BUKU: list[dict[str, object]] = [
+    {"judul": "Bahasa Indonesia Kelas VII", "pengarang": "Tim Kemdikbud",
+     "isbn": "978-602-100-001-1", "kode_ddc": "410", "jumlah_eksemplar": 3, "harga": 50000},
+    {"judul": "Matematika Kelas VIII", "pengarang": "Tim Kemdikbud",
+     "isbn": "978-602-100-002-2", "kode_ddc": "510", "jumlah_eksemplar": 3, "harga": 55000},
+    {"judul": "IPA Terpadu Kelas IX", "pengarang": "Tim Kemdikbud",
+     "isbn": "978-602-100-003-3", "kode_ddc": "500", "jumlah_eksemplar": 3, "harga": 60000},
+    {"judul": "Sejarah Indonesia", "pengarang": "Marwati",
+     "isbn": "978-979-100-004-4", "kode_ddc": "959", "jumlah_eksemplar": 2, "harga": 65000},
+    {"judul": "Atlas Geografi Dunia", "pengarang": "Bambang H",
+     "isbn": "978-602-100-005-5", "kode_ddc": "912", "jumlah_eksemplar": 2, "harga": 75000},
+    {"judul": "Bumi Manusia", "pengarang": "Pramoedya Ananta Toer",
+     "isbn": "978-979-100-006-6", "kode_ddc": "813", "jumlah_eksemplar": 2, "harga": 85000},
+    {"judul": "Laskar Pelangi", "pengarang": "Andrea Hirata",
+     "isbn": "978-979-100-007-7", "kode_ddc": "813", "jumlah_eksemplar": 3, "harga": 70000},
+    {"judul": "Hujan", "pengarang": "Tere Liye",
+     "isbn": "978-602-100-008-8", "kode_ddc": "813", "jumlah_eksemplar": 2, "harga": 78000},
+    {"judul": "Bahasa Inggris untuk SMP", "pengarang": "Tim Erlangga",
+     "isbn": "978-602-100-009-9", "kode_ddc": "420", "jumlah_eksemplar": 3, "harga": 52000},
+    {"judul": "Pendidikan Pancasila", "pengarang": "Tim Kemdikbud",
+     "isbn": "978-602-100-010-0", "kode_ddc": "320", "jumlah_eksemplar": 2, "harga": 48000},
+]
+
+
+def seed_demo(db: Database | None = None) -> dict[str, int]:
+    """Insert demo data (5 anggota + 10 buku + 2 peminjaman aktif).
+
+    Idempotent: skip jika sudah ada anggota atau buku.
+    Return ringkasan jumlah baris yang berhasil di-insert.
+    """
+    db = db or get_db()
+    summary = {"anggota": 0, "buku": 0, "peminjaman": 0}
+
+    existing_anggota = int(db.scalar("SELECT COUNT(*) FROM anggota") or 0)
+    existing_buku = int(db.scalar("SELECT COUNT(*) FROM buku") or 0)
+    if existing_anggota > 0 or existing_buku > 0:
+        return summary
+
+    from perpustakaan.models import anggota as anggota_model
+    from perpustakaan.models import buku as buku_model
+    from perpustakaan.models import peminjaman as peminjaman_model
+
+    anggota_ids: list[int] = []
+    for data in _DEMO_ANGGOTA:
+        try:
+            new_id = anggota_model.create(dict(data), db=db)
+        except Exception:  # noqa: BLE001 - demo seed best-effort
+            continue
+        anggota_ids.append(new_id)
+        summary["anggota"] += 1
+
+    buku_ids: list[int] = []
+    for data in _DEMO_BUKU:
+        try:
+            new_id = buku_model.create(dict(data), db=db)
+        except Exception:  # noqa: BLE001 - demo seed best-effort
+            continue
+        buku_ids.append(new_id)
+        summary["buku"] += 1
+
+    if len(anggota_ids) >= 2 and len(buku_ids) >= 3:
+        try:
+            peminjaman_model.pinjam(anggota_ids[0], buku_ids[:2], db=db)
+            summary["peminjaman"] += 1
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            peminjaman_model.pinjam(anggota_ids[2], [buku_ids[2]], db=db)
+            summary["peminjaman"] += 1
+        except Exception:  # noqa: BLE001
+            pass
+
+    return summary

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -25,3 +25,34 @@ def test_seed_kelas(fresh_db):
     db = get_db()
     n = int(db.scalar("SELECT COUNT(*) FROM kelas") or 0)
     assert n >= 9  # minimal SMP+SMA preset
+
+
+def test_seed_demo_inserts_anggota_buku_peminjaman(fresh_db):
+    from perpustakaan.db.connection import get_db
+    from perpustakaan.db.seed import seed_demo
+
+    db = get_db()
+    summary = seed_demo()
+    assert summary["anggota"] == 5
+    assert summary["buku"] == 10
+    assert summary["peminjaman"] == 2
+
+    assert int(db.scalar("SELECT COUNT(*) FROM anggota") or 0) == 5
+    assert int(db.scalar("SELECT COUNT(*) FROM buku") or 0) == 10
+    aktif = int(
+        db.scalar(
+            "SELECT COUNT(*) FROM peminjaman_item WHERE status = 'dipinjam'"
+        )
+        or 0
+    )
+    assert aktif == 3  # 2 buku peminjaman pertama + 1 buku peminjaman kedua
+
+
+def test_seed_demo_idempotent_when_data_exists(fresh_db):
+    from perpustakaan.db.seed import seed_demo
+
+    first = seed_demo()
+    assert first["anggota"] == 5
+    second = seed_demo()
+    # Sudah ada data → semua nol
+    assert second == {"anggota": 0, "buku": 0, "peminjaman": 0}


### PR DESCRIPTION
## Jalur A — Item #1: Seed demo data

Seed demo data otomatis supaya user yang baru install bisa langsung coba alur peminjaman tanpa harus input data anggota/buku manual dulu.

## CLI baru

```bash
python -m perpustakaan --demo            # buka GUI + seed demo data (kalau DB kosong)
python -m perpustakaan --demo --no-gui   # headless: cuma init DB + seed, lalu exit
python -m perpustakaan --help            # show argparse usage
```

`--demo` aman dijalankan berulang — idempotent (di-skip kalau sudah ada anggota/buku).

## Demo data

**5 anggota:** Aulia Rahma (VII A), Budi Pratama (VII A), Citra Dewi (VIII B), Dimas Saputra (VIII B), Eka Putri (IX A) — masing-masing dengan tempat lahir, tanggal lahir, no telp dummy.

**10 buku:**
| Kode DDC | Judul | Pengarang | Eksemplar |
|---|---|---|---|
| 410 | Bahasa Indonesia Kelas VII | Tim Kemdikbud | 3 |
| 510 | Matematika Kelas VIII | Tim Kemdikbud | 3 |
| 500 | IPA Terpadu Kelas IX | Tim Kemdikbud | 3 |
| 959 | Sejarah Indonesia | Marwati | 2 |
| 912 | Atlas Geografi Dunia | Bambang H | 2 |
| 813 | Bumi Manusia | Pramoedya Ananta Toer | 2 |
| 813 | Laskar Pelangi | Andrea Hirata | 3 |
| 813 | Hujan | Tere Liye | 2 |
| 420 | Bahasa Inggris untuk SMP | Tim Erlangga | 3 |
| 320 | Pendidikan Pancasila | Tim Kemdikbud | 2 |

**2 peminjaman aktif:**
- Aulia Rahma meminjam Bahasa Indonesia + Matematika
- Citra Dewi meminjam IPA Terpadu

Dashboard akan menampilkan KPI ber-isi (5 anggota, 10 buku, 25 eksemplar, 3 dipinjam) — bukan zero-state yang kosong tidak menarik untuk demo.

## Tests

Ditambahkan di `tests/test_seed.py`:
- `test_seed_demo_inserts_anggota_buku_peminjaman` — verifikasi 5+10+2 records
- `test_seed_demo_idempotent_when_data_exists` — call kedua return semua nol

Total: 17 tests passing, ruff clean.

## Files

- `src/perpustakaan/db/seed.py` — fungsi `seed_demo()` baru
- `src/perpustakaan/__main__.py` — argparse `--demo` + `--no-gui` flags
- `src/perpustakaan/app.py` — `run()` accept `demo` + `headless` kwargs
- `tests/test_seed.py` — 2 test baru
- `README.md` — dokumentasi `--demo` flag di Quick Start

## Risk

🟢 Green — penambahan fitur opsional, tidak ubah default behavior. Kalau user tidak pass `--demo`, app jalan persis seperti sebelumnya (init DB + seed admin/DDC/kelas saja).
