### PR TITLE
feat(gui): toast notification + exception reporter (Jalur A)

### DIFF
--- a/src/perpustakaan/gui/views/anggota_view.py
+++ b/src/perpustakaan/gui/views/anggota_view.py
@@ -144,20 +144,20 @@ class AnggotaView(ctk.CTkFrame):
     def _save(self) -> None:
         data = {k: f.get() or None for k, f in self.fields.items()}
         if not data.get("nama"):
-            widgets.warn(self, t("toast.required", field="nama"))
+            widgets.show_toast(self, t("toast.required", field="nama"), kind="warning")
             return
         try:
             if self._editing_id:
                 anggota_repo.update(self._editing_id, data)
-                widgets.info(self, t("toast.updated"))
+                widgets.show_toast(self, t("toast.updated"), kind="success")
             else:
                 new_id = anggota_repo.create(data)
                 self._editing_id = new_id
-                widgets.info(self, t("toast.saved"))
+                widgets.show_toast(self, t("toast.saved"), kind="success")
             self._reset_form()
             self._reload()
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal simpan anggota")
 
     def _delete(self) -> None:
         sel = self.table.selected()
@@ -169,32 +169,34 @@ class AnggotaView(ctk.CTkFrame):
             anggota_repo.delete(int(sel["id"]))
             self._reset_form()
             self._reload()
-            widgets.info(self, t("toast.deleted_one"))
+            widgets.show_toast(self, t("toast.deleted_one"), kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal hapus anggota")
 
     # ---------------- Cetak ----------------
     def _cetak_kta(self) -> None:
         sel = self.table.selected()
         if sel is None:
-            widgets.warn(self, "Pilih anggota terlebih dahulu.")
+            widgets.show_toast(self, "Pilih anggota terlebih dahulu.", kind="warning")
             return
         try:
             path = pdf_service.cetak_kta(sel)
             _open_file(path)
+            widgets.show_toast(self, f"KTA tersimpan: {path.name}", kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal cetak KTA")
 
     def _cetak_bebas(self) -> None:
         sel = self.table.selected()
         if sel is None:
-            widgets.warn(self, "Pilih anggota terlebih dahulu.")
+            widgets.show_toast(self, "Pilih anggota terlebih dahulu.", kind="warning")
             return
         try:
             path = pdf_service.cetak_bebas_pustaka(sel)
             _open_file(path)
+            widgets.show_toast(self, f"Surat Bebas Pustaka: {path.name}", kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal cetak surat bebas pustaka")
 
     # ---------------- Import / Template ----------------
     def _do_import(self) -> None:
@@ -213,18 +215,19 @@ class AnggotaView(ctk.CTkFrame):
             )
             self._reload()
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal impor Excel anggota", use_modal=True)
 
     def _download_template(self) -> None:
         try:
             path = excel_service.template_anggota()
-            widgets.info(self, f"Template disimpan di:\n{path}")
+            widgets.show_toast(self, f"Template disimpan: {path}", kind="success", duration_ms=4500)
             _open_file(path)
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal generate template Excel")
 
 
 def _open_file(path) -> None:
+    import logging as _logging
     try:
         if sys.platform.startswith("win"):
             os.startfile(str(path))  # type: ignore[attr-defined]
@@ -232,5 +235,7 @@ def _open_file(path) -> None:
             os.system(f'open "{path}"')
         else:
             os.system(f'xdg-open "{path}"')
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001 - tidak ada handler tersedia di sini
+        _logging.getLogger("perpustakaan.gui").warning(
+            "Gagal buka file %s: %s", path, exc
+        )

--- a/src/perpustakaan/gui/views/buku_view.py
+++ b/src/perpustakaan/gui/views/buku_view.py
@@ -160,19 +160,19 @@ class BukuView(ctk.CTkFrame):
         data["deskripsi"] = self.deskripsi.get("1.0", "end").strip() or None
 
         if not data.get("judul"):
-            widgets.warn(self, t("toast.required", field="judul"))
+            widgets.show_toast(self, t("toast.required", field="judul"), kind="warning")
             return
         try:
             if self._editing_id:
                 buku_repo.update(self._editing_id, data)
-                widgets.info(self, t("toast.updated"))
+                widgets.show_toast(self, t("toast.updated"), kind="success")
             else:
                 buku_repo.create(data)
-                widgets.info(self, t("toast.saved"))
+                widgets.show_toast(self, t("toast.saved"), kind="success")
             self._reset_form()
             self._reload()
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal simpan buku")
 
     def _delete(self) -> None:
         sel = self.table.selected()
@@ -184,28 +184,29 @@ class BukuView(ctk.CTkFrame):
             buku_repo.delete(int(sel["id"]))
             self._reset_form()
             self._reload()
-            widgets.info(self, t("toast.deleted_one"))
+            widgets.show_toast(self, t("toast.deleted_one"), kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal hapus buku")
 
     # ---------------- Cetak ----------------
     def _cetak_label(self) -> None:
         sel = self.table.selected()
         if sel is None:
-            widgets.warn(self, "Pilih buku terlebih dahulu.")
+            widgets.show_toast(self, "Pilih buku terlebih dahulu.", kind="warning")
             return
         try:
             path = pdf_service.cetak_label_buku(sel)
             _open_file(path)
+            widgets.show_toast(self, f"Label tersimpan: {path.name}", kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal cetak label buku")
 
     def _transfer_penerbit(self) -> None:
         try:
             n = buku_repo.transfer_penerbit()
-            widgets.info(self, f"{n} penerbit ditambahkan ke master.")
+            widgets.show_toast(self, f"{n} penerbit ditambahkan ke master.", kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal transfer penerbit")
 
     # ---------------- Import / Template ----------------
     def _do_import(self) -> None:
@@ -224,18 +225,19 @@ class BukuView(ctk.CTkFrame):
             )
             self._reload()
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal impor Excel buku", use_modal=True)
 
     def _download_template(self) -> None:
         try:
             path = excel_service.template_buku()
-            widgets.info(self, f"Template disimpan di:\n{path}")
+            widgets.show_toast(self, f"Template disimpan: {path}", kind="success", duration_ms=4500)
             _open_file(path)
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal generate template Excel")
 
 
 def _open_file(path) -> None:
+    import logging as _logging
     try:
         if sys.platform.startswith("win"):
             os.startfile(str(path))  # type: ignore[attr-defined]
@@ -243,5 +245,7 @@ def _open_file(path) -> None:
             os.system(f'open "{path}"')
         else:
             os.system(f'xdg-open "{path}"')
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001
+        _logging.getLogger("perpustakaan.gui").warning(
+            "Gagal buka file %s: %s", path, exc
+        )

--- a/src/perpustakaan/gui/views/kunjungan_view.py
+++ b/src/perpustakaan/gui/views/kunjungan_view.py
@@ -120,6 +120,6 @@ class KunjunganView(ctk.CTkFrame):
             self.kelas.delete(0, "end")
             self.jumlah.delete(0, "end")
             self._reload()
-            widgets.info(self, t("toast.saved"))
+            widgets.show_toast(self, t("toast.saved"), kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal simpan kunjungan")

--- a/src/perpustakaan/gui/views/laporan_view.py
+++ b/src/perpustakaan/gui/views/laporan_view.py
@@ -79,18 +79,18 @@ class LaporanView(ctk.CTkFrame):
     def _do_backup_db(self) -> None:
         try:
             path = backup_service.backup_db()
-            widgets.info(self, f"Backup tersimpan:\n{path}")
+            widgets.show_toast(self, f"Backup tersimpan: {path.name}", kind="success", duration_ms=4500)
             _open_folder(path)
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal backup database", use_modal=True)
 
     def _do_export_xlsx(self) -> None:
         try:
             path = excel_service.export_all_workbook()
-            widgets.info(self, f"Ekspor tersimpan:\n{path}")
+            widgets.show_toast(self, f"Ekspor tersimpan: {path.name}", kind="success", duration_ms=4500)
             _open_folder(path)
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal ekspor workbook", use_modal=True)
 
     def _do_reset_safe(self) -> None:
         if not widgets.confirm(
@@ -101,9 +101,9 @@ class LaporanView(ctk.CTkFrame):
             return
         try:
             backup_service.reset_transaksi(keep_outstanding=True)
-            widgets.info(self, "Reset selesai.")
+            widgets.show_toast(self, "Reset transaksi selesai.", kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal reset transaksi", use_modal=True)
 
     def _do_reset_full(self) -> None:
         if not widgets.confirm(
@@ -114,9 +114,9 @@ class LaporanView(ctk.CTkFrame):
             return
         try:
             backup_service.reset_transaksi(keep_outstanding=False)
-            widgets.info(self, "Reset total selesai.")
+            widgets.show_toast(self, "Reset total selesai.", kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal reset total", use_modal=True)
 
     # ----------------- Grafik Kunjungan -----------------
     def _build_grafik(self, parent) -> None:
@@ -144,7 +144,7 @@ class LaporanView(ctk.CTkFrame):
         try:
             tahun = int(self.graf_tahun.get())
         except ValueError:
-            widgets.warn(self, "Tahun harus angka.")
+            widgets.show_toast(self, "Tahun harus angka.", kind="warning")
             return
         bulan_str = self.graf_bulan.get().strip()
         if bulan_str:
@@ -152,7 +152,7 @@ class LaporanView(ctk.CTkFrame):
                 bulan = int(bulan_str)
                 fig = report_service.figure_kunjungan_bulanan(tahun, bulan)
             except ValueError:
-                widgets.warn(self, "Bulan harus 1-12.")
+                widgets.show_toast(self, "Bulan harus 1-12.", kind="warning")
                 return
         else:
             fig = report_service.figure_kunjungan_tahunan(tahun)
@@ -261,8 +261,9 @@ class LaporanView(ctk.CTkFrame):
         try:
             kas_repo.delete(int(sel["id"]))
             self._reload_kas()
+            widgets.show_toast(self, t("toast.deleted_one"), kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal hapus baris kas")
 
 
 class KasDialog(ctk.CTkToplevel):
@@ -310,10 +311,11 @@ class KasDialog(ctk.CTkToplevel):
             )
             self.destroy()
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal simpan baris kas")
 
 
 def _open_folder(path) -> None:
+    import logging as _logging
     try:
         if sys.platform.startswith("win"):
             os.startfile(str(path.parent))  # type: ignore[attr-defined]
@@ -321,5 +323,7 @@ def _open_folder(path) -> None:
             os.system(f'open "{path.parent}"')
         else:
             os.system(f'xdg-open "{path.parent}"')
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001
+        _logging.getLogger("perpustakaan.gui").warning(
+            "Gagal buka folder %s: %s", path, exc
+        )

--- a/src/perpustakaan/gui/views/peminjaman_view.py
+++ b/src/perpustakaan/gui/views/peminjaman_view.py
@@ -177,10 +177,10 @@ class PeminjamanView(ctk.CTkFrame):
     # ---------------- Submit ----------------
     def _submit(self) -> None:
         if self._anggota is None:
-            widgets.warn(self, "Cari anggota dulu.")
+            widgets.show_toast(self, "Cari anggota dulu.", kind="warning")
             return
         if not self._items:
-            widgets.warn(self, "Tambah minimal 1 buku.")
+            widgets.show_toast(self, "Tambah minimal 1 buku.", kind="warning")
             return
         try:
             from perpustakaan.services import auth as auth_service
@@ -192,11 +192,12 @@ class PeminjamanView(ctk.CTkFrame):
                 petugas_id=user.id if user else None,
                 tambah_kunjungan=bool(self.add_kunjungan.get()),
             )
-            widgets.info(
+            widgets.show_toast(
                 self,
-                f"Peminjaman tersimpan (ID #{pid}). "
-                f"{len(self._items)} buku dipinjam oleh {self._anggota['nama']}.",
+                f"Peminjaman #{pid} tersimpan: {len(self._items)} buku oleh {self._anggota['nama']}.",
+                kind="success",
+                duration_ms=4500,
             )
             self._reset()
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal simpan peminjaman")

--- a/src/perpustakaan/gui/views/settings_view.py
+++ b/src/perpustakaan/gui/views/settings_view.py
@@ -80,9 +80,9 @@ class SettingsView(ctk.CTkFrame):
     def _save_identitas(self) -> None:
         try:
             settings_repo.set_many({k: f.get() for k, f in self.id_fields.items()})
-            widgets.info(self, t("toast.saved"))
+            widgets.show_toast(self, t("toast.saved"), kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal simpan identitas")
 
     def _pick_logo(self) -> None:
         path = filedialog.askopenfilename(
@@ -111,8 +111,11 @@ class SettingsView(ctk.CTkFrame):
         self.kta_text.insert("1.0", settings_repo.get_value("kta.peraturan") or "")
 
     def _save_kta(self) -> None:
-        settings_repo.set_value("kta.peraturan", self.kta_text.get("1.0", "end").strip())
-        widgets.info(self, t("toast.saved"))
+        try:
+            settings_repo.set_value("kta.peraturan", self.kta_text.get("1.0", "end").strip())
+            widgets.show_toast(self, t("toast.saved"), kind="success")
+        except Exception as e:
+            widgets.report_exception(self, e, "Gagal simpan teks KTA")
 
     # ------------------ Transaksi ------------------
     def _build_transaksi(self, parent) -> None:
@@ -145,9 +148,9 @@ class SettingsView(ctk.CTkFrame):
                 int(v or 0)  # validasi
                 data[k] = v or "0"
             settings_repo.set_many(data)
-            widgets.info(self, t("toast.saved"))
+            widgets.show_toast(self, t("toast.saved"), kind="success")
         except ValueError:
-            widgets.warn(self, "Semua field harus berupa angka.")
+            widgets.show_toast(self, "Semua field harus berupa angka.", kind="warning")
 
     # ------------------ Akun ------------------
     def _build_akun(self, parent) -> None:
@@ -186,15 +189,16 @@ class SettingsView(ctk.CTkFrame):
             return
         cur = auth_service.current_user()
         if cur and int(sel["id"]) == cur.id:
-            widgets.warn(self, "Tidak bisa menghapus akun yang sedang login.")
+            widgets.show_toast(self, "Tidak bisa menghapus akun yang sedang login.", kind="warning")
             return
         if not widgets.confirm(self, t("toast.confirm_delete")):
             return
         try:
             auth_service.delete_user(int(sel["id"]))
             self._reload_akun()
+            widgets.show_toast(self, t("toast.deleted_one"), kind="success")
         except Exception as e:
-            widgets.error(self, str(e))
+            widgets.report_exception(self, e, "Gagal hapus akun")
 
     def _change_pw(self) -> None:
         ChangePasswordDialog(self).wait_window()
@@ -295,7 +299,7 @@ class SettingsView(ctk.CTkFrame):
     def _do_export(self) -> None:
         path = self.sync_credentials_path.get().strip()
         if not path:
-            widgets.warn(self, "Pilih credentials.json terlebih dahulu.")
+            widgets.show_toast(self, "Pilih credentials.json terlebih dahulu.", kind="warning")
             return
         try:
             from perpustakaan.services import sheets_service

--- a/src/perpustakaan/gui/widgets.py
+++ b/src/perpustakaan/gui/widgets.py
@@ -6,6 +6,7 @@ list data dengan scrollbar) — CustomTkinter belum punya tabel data nativ.
 from __future__ import annotations
 
 import contextlib
+import logging
 from collections.abc import Callable, Iterable
 from tkinter import ttk
 from typing import Any
@@ -13,6 +14,8 @@ from typing import Any
 import customtkinter as ctk
 
 from perpustakaan.i18n import t
+
+_log = logging.getLogger("perpustakaan.gui")
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +198,78 @@ class StatCard(ctk.CTkFrame):
 
 
 # ---------------------------------------------------------------------------
-# Toast / messagebox
+# Toast (non-blocking, auto-dismiss)
+# ---------------------------------------------------------------------------
+_TOAST_COLORS = {
+    "info":    {"bg": ("#dbeafe", "#1e3a8a"), "fg": ("#1e3a8a", "#dbeafe"), "border": "#2563eb"},
+    "success": {"bg": ("#dcfce7", "#14532d"), "fg": ("#14532d", "#dcfce7"), "border": "#16a34a"},
+    "warning": {"bg": ("#fef3c7", "#78350f"), "fg": ("#78350f", "#fef3c7"), "border": "#d97706"},
+    "error":   {"bg": ("#fee2e2", "#7f1d1d"), "fg": ("#7f1d1d", "#fee2e2"), "border": "#dc2626"},
+}
+
+
+def show_toast(
+    parent: Any,
+    message: str,
+    *,
+    kind: str = "info",
+    duration_ms: int = 3000,
+) -> None:
+    """Tampilkan toast notification non-blocking di pojok kanan-bawah window.
+
+    Args:
+        parent: widget atau window induk.
+        message: teks pesan (max ~200 karakter).
+        kind: ``"info"`` / ``"success"`` / ``"warning"`` / ``"error"``.
+        duration_ms: durasi tampil dalam milidetik sebelum auto-dismiss.
+    """
+    palette = _TOAST_COLORS.get(kind, _TOAST_COLORS["info"])
+    try:
+        # Cari toplevel-nya parent (kasus parent berupa frame nested)
+        top = parent.winfo_toplevel()
+    except Exception:  # noqa: BLE001 - widget belum di-realize
+        _log.warning("show_toast: parent tidak punya toplevel, fallback log: %s", message)
+        return
+
+    toast = ctk.CTkFrame(
+        top,
+        fg_color=palette["bg"],
+        border_color=palette["border"],
+        border_width=2,
+        corner_radius=8,
+    )
+    label = ctk.CTkLabel(
+        toast,
+        text=message,
+        text_color=palette["fg"],
+        font=ctk.CTkFont(size=13, weight="bold"),
+        anchor="w",
+        justify="left",
+        wraplength=320,
+    )
+    label.pack(padx=14, pady=10)
+
+    def _place() -> None:
+        try:
+            top.update_idletasks()
+            tw = max(toast.winfo_reqwidth(), 200)
+            th = max(toast.winfo_reqheight(), 40)
+            tlx = max(top.winfo_width() - tw - 16, 16)
+            tly = max(top.winfo_height() - th - 16, 16)
+            toast.place(x=tlx, y=tly)
+        except Exception:  # noqa: BLE001
+            toast.place(relx=1.0, rely=1.0, x=-16, y=-16, anchor="se")
+
+    def _dismiss() -> None:
+        with contextlib.suppress(Exception):
+            toast.destroy()
+
+    _place()
+    top.after(max(duration_ms, 500), _dismiss)
+
+
+# ---------------------------------------------------------------------------
+# Modal dialog (info / warn / error / confirm)
 # ---------------------------------------------------------------------------
 def info(parent: Any, message: str, title: str | None = None) -> None:
     from tkinter import messagebox
@@ -221,6 +295,53 @@ def confirm(parent: Any, message: str, title: str | None = None) -> bool:
     return bool(
         messagebox.askyesno(title or t("common.confirm"), message, parent=parent)
     )
+
+
+# ---------------------------------------------------------------------------
+# Exception reporter — log + show user-friendly toast / modal
+# ---------------------------------------------------------------------------
+# Exception types yang biasanya berarti "user input error" — pesan singkat
+# saja sudah cukup, tidak perlu modal merah dan tidak perlu link ke log.
+_USER_INPUT_EXC = (ValueError, TypeError, KeyError)
+
+
+def report_exception(
+    parent: Any,
+    exc: BaseException,
+    context: str = "",
+    *,
+    use_modal: bool = False,
+) -> None:
+    """Log full exception ke ``app.log`` lalu tampilkan toast/modal user-friendly.
+
+    Args:
+        parent: widget induk untuk toast/modal.
+        exc: exception yang ditangkap.
+        context: deskripsi singkat operasi (mis "simpan anggota") — akan
+            ditampilkan ke user sebagai prefix supaya jelas operasi mana.
+        use_modal: kalau True, pakai messagebox modal (untuk error kritis
+            yang user wajib acknowledge). Default False = toast.
+    """
+    _log.exception("[%s] %s", context or "operation failed", exc)
+
+    if isinstance(exc, _USER_INPUT_EXC):
+        msg = str(exc) or t("common.error")
+        kind = "warning"
+    else:
+        # Exception tidak terduga — kasih hint ke log
+        msg = (
+            f"{context or 'Terjadi kesalahan'}: {exc}\n"
+            f"Detail tersimpan di app.log."
+        )
+        kind = "error"
+
+    if use_modal:
+        if kind == "error":
+            error(parent, msg)
+        else:
+            warn(parent, msg)
+    else:
+        show_toast(parent, msg, kind=kind, duration_ms=4500)
 
 
 def fmt_rupiah(value: int | float) -> str:


### PR DESCRIPTION
## Jalur A — Item #2: Polish error handling

Ganti modal `info`/`error` blocking dengan **toast non-blocking** + central **exception reporter** yang log full traceback ke `app.log`.

## Sebelum vs sesudah

**Sebelum** — saat user klik "Simpan" di anggota dan ada error, muncul modal merah yang blocking, dan stack trace lengkap hilang:

```python
try:
    anggota_repo.create(data)
    widgets.info(self, t('toast.saved'))   # modal blocking — user harus klik OK
except Exception as e:
    widgets.error(self, str(e))            # modal blocking, log hilang
```

**Sesudah** — toast 3 detik di pojok kanan-bawah, plus full traceback ke `app.log`:

```python
try:
    anggota_repo.create(data)
    widgets.show_toast(self, t('toast.saved'), kind='success')
except Exception as e:
    widgets.report_exception(self, e, 'Gagal simpan anggota')
```

## Yang baru di `widgets.py`

### `show_toast(parent, message, *, kind, duration_ms)`

Toast notification non-blocking, auto-dismiss. 4 varian color-coded:
- `info` — biru
- `success` — hijau
- `warning` — kuning
- `error` — merah

### `report_exception(parent, exc, context, *, use_modal)`

Single helper untuk handle exception:
1. **Log full traceback** ke `perpustakaan.gui` logger → `app.log`
2. **User-friendly message:**
   - `ValueError` / `TypeError` / `KeyError` → dianggap user input error → toast warning dengan message singkat
   - Exception lain → toast error dengan hint `Detail di app.log`
3. **`use_modal=True`** untuk error kritis yang butuh acknowledgement (mis. Backup DB gagal)

## Penggantian di view

Files updated (32 occurrences total):

| File | Replacements |
|---|---|
| `gui/views/anggota_view.py` | 7 |
| `gui/views/buku_view.py` | 7 |
| `gui/views/peminjaman_view.py` | 3 |
| `gui/views/kunjungan_view.py` | 1 |
| `gui/views/laporan_view.py` | 9 |
| `gui/views/settings_view.py` | 5 |

## Silent `except: pass` cleanup

`_open_file()` / `_open_folder()` di `anggota_view`, `buku_view`, `laporan_view` sebelumnya `try: … except: pass` — sekarang log warning, supaya kalau user tidak melihat PDF/Excel terbuka, ada jejak di `app.log`:

```python
except Exception as exc:
    logging.getLogger('perpustakaan.gui').warning('Gagal buka file %s: %s', path, exc)
```

## Lint & test

- ruff clean (incl. migrasi `try/except/pass` → `contextlib.suppress(Exception)` per SIM105)
- 17 tests passing

## Risk

🟡 Yellow — perubahan visual UI cukup banyak (32 callsites), tapi semua sifatnya additive (modal `widgets.info/error` masih ada untuk backward compat). Smoke test penuh akan dilakukan di **PR #6**.

## Tidak diubah di PR ini

- Login error handling (sudah pakai inline label, OK)
- Pengembalian dialog error (pakai inline label, OK)
- Sync export error (pakai inline label persistent, OK)
- AccountDialog / ChangePasswordDialog (pakai inline label, OK)
