### PR TITLE
ci: tambah build-linux job + Linux binary di release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,44 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  build-linux:
+    name: Build Linux binary
+    needs: lint-test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install system deps (Tk + build tools)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends python3-tk
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pyinstaller
+
+      - name: Build Linux binary (PyInstaller --onefile)
+        run: pyinstaller build.spec --noconfirm
+
+      - name: Rename artifact
+        run: mv dist/PerpustakaanOffline dist/PerpustakaanOffline-linux
+
+      - name: Upload Linux binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: perpustakaan-offline-linux
+          path: dist/PerpustakaanOffline-linux
+          if-no-files-found: error
+          retention-days: 30
+
   build-windows:
     name: Build .exe + Installer (Windows)
     needs: lint-test
@@ -126,7 +164,7 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: build-windows
+    needs: [build-windows, build-linux]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -146,10 +184,17 @@ jobs:
           name: perpustakaan-offline-installer
           path: artifacts/installer
 
+      - name: Download Linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: perpustakaan-offline-linux
+          path: artifacts/linux
+
       - name: List artifacts
         run: |
           ls -la artifacts/portable/
           ls -la artifacts/installer/
+          ls -la artifacts/linux/
 
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
@@ -161,3 +206,4 @@ jobs:
           files: |
             artifacts/portable/PerpustakaanOffline.exe
             artifacts/installer/*.exe
+            artifacts/linux/PerpustakaanOffline-linux


### PR DESCRIPTION
## Summary

Tambah CI job `build-linux` untuk build PyInstaller binary di Ubuntu, dan update `release` job untuk upload Linux binary ke GitHub Release bersama Windows artifacts.

### Perubahan
- **Job `build-linux`**: PyInstaller `--onefile` di `ubuntu-latest`, output `PerpustakaanOffline-linux`
- **Job `release`**: `needs: [build-windows, build-linux]`, download + upload Linux artifact
- Tag push otomatis upload 3 file: `PerpustakaanOffline.exe`, installer `.exe`, `PerpustakaanOffline-linux`

### Notes
- macOS build di-skip karena tkinter issues di GitHub Actions macOS runner (sesuai instruksi: skip kalau ada masalah tkinter)
- `build-linux` dan `build-windows` hanya jalan di push ke `main` atau tag `v*`, tidak di PR

## Review & Testing Checklist for Human
- [ ] Verifikasi `build-linux` job berhasil setelah merge ke main
- [ ] Test tag push: `git tag v0.2.0-test && git push --tags` lalu verifikasi Release punya 3 file

### Notes
- Linux binary belum di-test runtime (hanya build) — test runtime bisa dilakukan manual

---
Devin session: https://app.devin.ai/sessions/501ad69a8e7e436baf75a5484cc87a0f