### PR TITLE
feat(gui): validasi peminjaman aktif sebelum cetak Bebas Pustaka

### DIFF
--- a/src/perpustakaan/gui/views/anggota_view.py
+++ b/src/perpustakaan/gui/views/anggota_view.py
@@ -195,9 +195,21 @@ class AnggotaView(ctk.CTkFrame):
             widgets.report_exception(self, e, "Gagal cetak KTA")
 
     def _cetak_bebas(self) -> None:
+        from perpustakaan.models import peminjaman as peminjaman_repo
+
         sel = self.table.selected()
         if sel is None:
             widgets.show_toast(self, "Pilih anggota terlebih dahulu.", kind="warning")
+            return
+        aktif = peminjaman_repo.list_aktif_anggota(int(sel["id"]))
+        if aktif:
+            judul_list = ", ".join(r.get("judul", "?") for r in aktif[:5])
+            widgets.warn(
+                self,
+                f"Anggota masih memiliki {len(aktif)} peminjaman aktif:\n"
+                f"{judul_list}\n\n"
+                "Selesaikan semua peminjaman terlebih dahulu.",
+            )
             return
         try:
             path = pdf_service.cetak_bebas_pustaka(sel)


### PR DESCRIPTION
## Summary

Implementasi validasi otomatis pada flow Bebas Pustaka (Jalur B.2 roadmap).

Sebelumnya, tombol Bebas Pustaka langsung generate PDF tanpa cek apakah anggota masih memiliki peminjaman aktif. Sekarang:

1. Cek `list_aktif_anggota()` sebelum generate PDF
2. Jika masih ada peminjaman aktif → tampilkan warning dengan daftar judul buku (maks 5)
3. Blokir cetak sampai semua peminjaman diselesaikan
4. Jika tidak ada peminjaman aktif → generate PDF seperti biasa

## Review & Testing Checklist for Human
- [ ] Test dengan anggota yang punya peminjaman aktif → harus blocked
- [ ] Test dengan anggota tanpa peminjaman → harus generate PDF

### Notes
- Backend `cetak_bebas_pustaka()` dan `list_aktif_anggota()` sudah ada, PR ini hanya menambah validasi di UI

---
Devin session: https://app.devin.ai/sessions/501ad69a8e7e436baf75a5484cc87a0f