### PR TITLE
feat(gui): tombol Cetak Nota di Peminjaman & Pengembalian

### DIFF
--- a/src/perpustakaan/gui/views/peminjaman_view.py
+++ b/src/perpustakaan/gui/views/peminjaman_view.py
@@ -1,6 +1,9 @@
 """View transaksi peminjaman."""
 from __future__ import annotations
 
+import os
+import sys
+
 import customtkinter as ctk
 
 from perpustakaan.gui import widgets
@@ -9,6 +12,7 @@ from perpustakaan.i18n import t
 from perpustakaan.models import anggota as anggota_repo
 from perpustakaan.models import buku as buku_repo
 from perpustakaan.models import peminjaman as peminjaman_repo
+from perpustakaan.services import pdf_service
 
 
 class PeminjamanView(ctk.CTkFrame):
@@ -198,6 +202,42 @@ class PeminjamanView(ctk.CTkFrame):
                 kind="success",
                 duration_ms=4500,
             )
+            self._cetak_nota_peminjaman(pid)
             self._reset()
         except Exception as e:
             widgets.report_exception(self, e, "Gagal simpan peminjaman")
+
+    def _cetak_nota_peminjaman(self, peminjaman_id: int) -> None:
+        if not widgets.confirm(self, "Cetak nota peminjaman?"):
+            return
+        try:
+            header = peminjaman_repo.get_header(peminjaman_id)
+            if header is None:
+                return
+            items = peminjaman_repo.list_items(peminjaman_id)
+            path = pdf_service.cetak_nota(
+                judul_nota="Nota Peminjaman",
+                nomor=header["nomor_pinjam"],
+                tanggal=header["tanggal_pinjam"],
+                anggota=self._anggota or {},
+                items=items,
+            )
+            _open_file(path)
+            widgets.show_toast(self, f"Nota tersimpan: {path.name}", kind="success")
+        except Exception as e:
+            widgets.report_exception(self, e, "Gagal cetak nota peminjaman")
+
+
+def _open_file(path) -> None:
+    import logging as _logging
+    try:
+        if sys.platform.startswith("win"):
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            os.system(f'open "{path}"')
+        else:
+            os.system(f'xdg-open "{path}"')
+    except Exception as exc:  # noqa: BLE001
+        _logging.getLogger("perpustakaan.gui").warning(
+            "Gagal buka file %s: %s", path, exc
+        )

--- a/src/perpustakaan/gui/views/pengembalian_view.py
+++ b/src/perpustakaan/gui/views/pengembalian_view.py
@@ -5,6 +5,9 @@ scan eksemplar -> input bayar -> simpan.
 """
 from __future__ import annotations
 
+import os
+import sys
+
 import customtkinter as ctk
 
 from perpustakaan.gui import widgets
@@ -12,6 +15,7 @@ from perpustakaan.gui.widgets import StyledTreeview, fmt_rupiah
 from perpustakaan.i18n import t
 from perpustakaan.models import anggota as anggota_repo
 from perpustakaan.models import peminjaman as peminjaman_repo
+from perpustakaan.services import pdf_service
 
 
 class PengembalianView(ctk.CTkFrame):
@@ -187,6 +191,46 @@ class ProsesDialog(ctk.CTkToplevel):
                     text=f"Buku ditandai hilang. Denda: {fmt_rupiah(res['denda'])}",
                     text_color="#f59e0b",
                 )
-            self.after(1000, self.destroy)
+            self._offer_nota(res)
+            self.after(1500, self.destroy)
         except Exception as e:
             self.message.configure(text=str(e), text_color="#ef4444")
+
+    def _offer_nota(self, res: dict) -> None:
+        if not widgets.confirm(self, "Cetak nota pengembalian?"):
+            return
+        try:
+            peminjaman_id = int(self.item.get("peminjaman_id") or self.item.get("id", 0))
+            header = peminjaman_repo.get_header(peminjaman_id)
+            if header is None:
+                return
+            items = peminjaman_repo.list_items(peminjaman_id)
+            anggota = {}
+            if self.parent_view._anggota:
+                anggota = self.parent_view._anggota
+            path = pdf_service.cetak_nota(
+                judul_nota="Nota Pengembalian",
+                nomor=header["nomor_pinjam"],
+                tanggal=header.get("tanggal_kembali") or header["tanggal_pinjam"],
+                anggota=anggota,
+                items=items,
+                total_denda=int(res.get("denda", 0)),
+            )
+            _open_file(path)
+        except Exception as e:
+            widgets.report_exception(self, e, "Gagal cetak nota")
+
+
+def _open_file(path) -> None:
+    import logging as _logging
+    try:
+        if sys.platform.startswith("win"):
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            os.system(f'open "{path}"')
+        else:
+            os.system(f'xdg-open "{path}"')
+    except Exception as exc:  # noqa: BLE001
+        _logging.getLogger("perpustakaan.gui").warning(
+            "Gagal buka file %s: %s", path, exc
+        )


### PR DESCRIPTION
## Summary

Tambah tombol cetak nota di flow Peminjaman dan Pengembalian (Jalur B.3 roadmap).

### Perubahan
- **Peminjaman**: setelah simpan berhasil, prompt "Cetak nota peminjaman?" → generate PDF via `cetak_nota()`
- **Pengembalian**: setelah proses kembali/hilang berhasil, prompt "Cetak nota pengembalian?" → generate PDF dengan info denda
- Nota PDF berisi: header perpustakaan, data anggota, daftar buku, status, denda, tanda tangan petugas

## Review & Testing Checklist for Human
- [ ] Test peminjaman → simpan → cetak nota → verifikasi PDF
- [ ] Test pengembalian → proses kembali → cetak nota → verifikasi denda di PDF

### Notes
- `cetak_nota()` dari `pdf_service` sudah ada, PR ini hanya menghubungkan ke UI

---
Devin session: https://app.devin.ai/sessions/501ad69a8e7e436baf75a5484cc87a0f