### PR TITLE
feat(gui): reminder jatuh tempo otomatis saat login

### DIFF
--- a/src/perpustakaan/gui/views/dashboard_view.py
+++ b/src/perpustakaan/gui/views/dashboard_view.py
@@ -13,6 +13,7 @@ class DashboardView(ctk.CTkFrame):
     def __init__(self, parent, app) -> None:
         super().__init__(parent, fg_color="transparent")
         self.app = app
+        self._first_show = True
 
         # Header
         header = ctk.CTkFrame(self, fg_color="transparent")
@@ -82,4 +83,22 @@ class DashboardView(ctk.CTkFrame):
             self.cards[key].set_value(str(stats.get(key, 0)))
         self.kas_card.set_value(fmt_rupiah(stats.get("kas_saldo", 0)))
 
-        self.reminder.set_rows(peminjaman_repo.list_jatuh_tempo_segera(days_ahead=2))
+        overdue = peminjaman_repo.list_jatuh_tempo_segera(days_ahead=3)
+        self.reminder.set_rows(overdue)
+
+        if self._first_show and overdue:
+            self._first_show = False
+            terlambat = [r for r in overdue if int(r.get("sisa_hari", 0)) < 0]
+            segera = [r for r in overdue if int(r.get("sisa_hari", 0)) >= 0]
+            msg_parts = []
+            if terlambat:
+                msg_parts.append(f"{len(terlambat)} buku TERLAMBAT")
+            if segera:
+                msg_parts.append(f"{len(segera)} buku jatuh tempo dalam 3 hari")
+            from perpustakaan.gui import widgets
+            widgets.show_toast(
+                self, f"Reminder: {', '.join(msg_parts)}.",
+                kind="warning", duration_ms=6000,
+            )
+        elif self._first_show:
+            self._first_show = False


### PR DESCRIPTION
## Summary

Implementasi reminder otomatis untuk peminjaman jatuh tempo (Jalur B.5 roadmap).

### Perubahan
- **Popup toast warning** muncul otomatis saat pertama kali Dashboard ditampilkan (login)
- Menampilkan jumlah buku **terlambat** dan buku **jatuh tempo dalam 3 hari**
- Expand `days_ahead` dari 2 → 3 hari (H+0, H+1, H+3)
- Tabel reminder di Dashboard sudah ada sebelumnya, popup notifikasi baru ditambahkan

### Flow
1. User login → Dashboard terbuka
2. Jika ada peminjaman terlambat/jatuh tempo → toast warning 6 detik
3. Detail terlihat di tabel "Reminder Jatuh Tempo / Terlambat"

## Review & Testing Checklist for Human
- [ ] Login dengan data demo → jika ada pinjaman jatuh tempo, toast muncul
- [ ] Klik Refresh → tabel update, toast tidak muncul lagi (hanya pertama kali)

---
Devin session: https://app.devin.ai/sessions/501ad69a8e7e436baf75a5484cc87a0f