### PR TITLE
docs: review google-sheets-setup.md untuk v0.3.0

### DIFF
--- a/docs/google-sheets-setup.md
+++ b/docs/google-sheets-setup.md
@@ -9,8 +9,14 @@ ini opsional — gunakan kalau kamu mau:
 - **View di browser** — kepala sekolah bisa lihat laporan via spreadsheet di HP/laptop tanpa install apa-apa
 - **Sharing** dengan guru/staff lain via Google Drive permission
 
-Mode saat ini (v0.1): **manual export one-way** (Aplikasi → Sheets). Sync 2-arah otomatis
+Mode saat ini (**v0.3.0**): **manual export one-way** (Aplikasi → Sheets). Sync 2-arah otomatis
 direncanakan di v0.5.
+
+> **Catatan v0.3.0**: tidak ada perubahan API/scope dari v0.1 — flow setup
+> Google Cloud Console + OAuth consent + credentials JSON masih sama persis.
+> Hanya labelling tombol di Settings yang berubah dari beberapa tombol jadi
+> satu tombol **"Ekspor ke Google Sheets"** yang menangani auth + export
+> sekaligus.
 
 ---
 
@@ -97,56 +103,66 @@ Klik **Save and Continue**.
 
 ---
 
-## Langkah 5: Letakkan client_secret.json di Folder Aplikasi
+## Langkah 5: Simpan File Credentials di Komputer
 
-1. **Rename** file ke persis `client_secret.json` (tanpa angka di belakang)
-2. Pindahkan ke folder data aplikasi:
+1. File yang baru kamu download bernama `client_secret_xxxxxxxxx.json`
+2. **Boleh kamu rename** jadi nama yang lebih pendek (mis `credentials.json`) atau biarkan apa adanya — aplikasi tidak peduli nama filenya, kamu cukup pilih path-nya nanti dari dialog
+3. **Letakkan di folder yang aman dan mudah di-backup**, contohnya:
 
-| OS       | Lokasi target                                                           |
-|----------|-------------------------------------------------------------------------|
-| Windows  | `%APPDATA%\PerpustakaanOffline\client_secret.json`                      |
-| macOS    | `~/Library/Application Support/PerpustakaanOffline/client_secret.json`  |
-| Linux    | `~/.local/share/PerpustakaanOffline/client_secret.json`                 |
+| OS       | Saran lokasi                                                             |
+|----------|--------------------------------------------------------------------------|
+| Windows  | `%APPDATA%\PerpustakaanOffline\credentials.json`                         |
+| macOS    | `~/Library/Application Support/PerpustakaanOffline/credentials.json`     |
+| Linux    | `~/.local/share/PerpustakaanOffline/credentials.json`                    |
 
-> **Penting**: File ini **mengandung secret OAuth** (bukan password Google kamu, tapi
-> credential aplikasi). Jangan upload ke GitHub atau share publik.
+> **Penting**: File ini **mengandung secret OAuth** (bukan password Google kamu,
+> tapi credential aplikasi). Jangan upload ke GitHub atau share publik.
+
+> **Tip**: Path-nya bisa di mana saja — kalau kamu lebih nyaman naruh di Desktop,
+> Documents, atau bahkan flashdisk, bisa juga. Aplikasi cuma minta kamu pilih
+> file-nya lewat dialog "Pilih credentials.json..." sekali saja.
 
 ---
 
-## Langkah 6: Login Pertama Kali di Aplikasi
+## Langkah 6: Login + Ekspor Pertama Kali di Aplikasi
 
 1. Buka Perpustakaan Offline
 2. **Setting → Sync / Export**
-3. Klik **Login Google**
-4. Browser otomatis terbuka → login dengan akun Google yang terdaftar di Test Users
-5. Halaman warning "Google hasn't verified this app" → klik **Advanced** → **Go to Perpustakaan Offline (unsafe)**
+3. Klik **"Pilih credentials.json..."** → pilih file JSON yang baru kamu simpan di Langkah 5
+4. Klik tombol besar **"Ekspor ke Google Sheets"**
+5. Browser otomatis terbuka (tab baru) → login dengan akun Google yang terdaftar di Test Users
+6. Halaman warning **"Google hasn't verified this app"** → klik **Advanced** → **"Go to Perpustakaan Offline (unsafe)"**
    - Ini normal selama app belum verified Google
-6. Klik **Continue** untuk grant permission ke Sheets + Drive
-7. Halaman menampilkan kode → copy-paste ke aplikasi (atau aplikasi otomatis ambil)
-8. Selesai — token disimpan di `token.json` (di folder data app)
+7. Klik **Continue** untuk grant permission ke Sheets + Drive
+8. Browser otomatis tampilkan halaman *"The authentication flow has completed"* → bisa di-close
+9. Aplikasi otomatis lanjut push semua data → muncul status hijau di bagian bawah:
+   ```
+   Berhasil ekspor ke spreadsheet.
+   URL : https://docs.google.com/spreadsheets/d/...
+   ID  : 1AbCdEfGhIjKlMn...
+   Sheets: Anggota, Buku, Peminjaman, Pengembalian, Kunjungan, Kas
+   ```
+10. Klik / copy URL → buka spreadsheet di browser
 
-> Setelah login pertama, token otomatis ter-refresh tiap kali expired. Kamu tidak
-> perlu login ulang kecuali ganti akun Google.
-
----
-
-## Langkah 7: Push Data ke Spreadsheet
-
-1. **Setting → Sync / Export → Push ke Google Sheets**
-2. Aplikasi akan:
-   - Bikin spreadsheet baru di Drive kamu (judul: `Perpustakaan Offline - YYYY-MM-DD`)
-   - Upload semua tabel (anggota, buku, peminjaman, pengembalian, kunjungan, kas) ke sheets terpisah
-   - Tampilkan link spreadsheet → klik untuk buka di browser
-3. URL spreadsheet juga otomatis disimpan di Setting (untuk push ulang ke spreadsheet yang sama)
+> Setelah login pertama, token disimpan di folder `credentials/` di [folder data aplikasi](#data-location). Token otomatis ter-refresh tiap kali expired. Kamu tidak perlu login ulang kecuali ganti akun Google.
 
 ---
 
-## Push Berikutnya (Update Spreadsheet)
+## Langkah 7: Ekspor Berikutnya (Update Spreadsheet)
 
-Setelah push pertama, Setting → Sync / Export akan menampilkan:
-- URL spreadsheet
-- Tombol **Push Update** — overwrite isi spreadsheet dengan data terbaru
-- Tombol **Buat Spreadsheet Baru** — bikin spreadsheet baru (untuk arsip / snapshot)
+Flow-nya sama persis dengan Langkah 6, **tanpa perlu login ulang**:
+
+1. **Setting → Sync / Export**
+2. Path `credentials.json` masih ter-isi (kalau belum, klik Pilih lagi)
+3. Klik **"Ekspor ke Google Sheets"**
+4. Aplikasi cari spreadsheet yang dulu pernah dibuat (judul `Perpustakaan-<username>`) di Drive kamu
+   - Kalau ada → **overwrite** dengan data terbaru
+   - Kalau tidak ada (mis manual dihapus) → bikin baru
+5. Field "Ekspor Terakhir" akan ter-update dengan timestamp terbaru
+
+> Mode push selalu **overwrite** spreadsheet yang sama. Kalau kamu ingin
+> snapshot (mis arsip akhir bulan), buat duplikat manual di Google Sheets dulu
+> sebelum push ulang.
 
 ---
 
@@ -175,7 +191,11 @@ Pastikan:
 
 ### "Token expired" / login terus-menerus
 
-Hapus `token.json` di folder data → login ulang dari aplikasi.
+Hapus `token.json` di folder `credentials/` di dalam folder data app, contohnya:
+- Windows: `%APPDATA%\PerpustakaanOffline\credentials\token.json`
+- Linux: `~/.local/share/PerpustakaanOffline/credentials/token.json`
+
+Lalu login ulang dari aplikasi (klik tombol **Ekspor** lagi).
 
 ### "API has not been enabled"
 
@@ -201,7 +221,12 @@ A: Data tersimpan di Drive **akun Google kamu** — tidak dilihat siapa pun kecu
 A: Data lokal aplikasi tetap di komputer lama. Tapi spreadsheet di Drive tetap accessible dari mana saja. Untuk migrasi data lokal, lihat bab "Pindah Komputer" di [manual.md](manual.md).
 
 **Q: Kalau saya edit di spreadsheet, apa otomatis sync ke aplikasi?**  
-A: Belum (v0.1 hanya 1-arah: app → Sheets). Untuk 2-arah, tunggu v0.5 (Opsi A di [roadmap](../README.md#roadmap)).
+A: Belum (v0.3.0 masih 1-arah: app → Sheets). Untuk 2-arah, tunggu v0.5 (Opsi A di [roadmap](../README.md#roadmap)).
+
+**Q: Apa beda dengan fitur "Cetak Nota" di v0.3.0?**  
+A: Cetak Nota = PDF lokal untuk struk peminjaman/pengembalian per transaksi. Sync
+Google Sheets = ekspor batch semua data (anggota, buku, transaksi) ke spreadsheet.
+Dua fitur berbeda untuk dua tujuan berbeda.
 
 **Q: Bisa pakai akun Google Workspace sekolah?**  
 A: Bisa. Saat OAuth consent screen pilih **Internal** kalau kamu admin Workspace. Atau **External** kalau bukan admin (akun Workspace tetap bisa login).
@@ -219,17 +244,20 @@ A: Bisa. Saat OAuth consent screen pilih **Internal** kalau kamu admin Workspace
 2. Enable **Google Sheets API** + **Google Drive API** in the API Library
 3. Configure **OAuth consent screen** (External, add scopes `spreadsheets` + `drive.file`, add your email as test user)
 4. Create **OAuth client ID** (type: Desktop app), download JSON
-5. Rename JSON to `client_secret.json`, place in app data folder:
-   - Windows: `%APPDATA%\PerpustakaanOffline\`
-   - macOS: `~/Library/Application Support/PerpustakaanOffline/`
-   - Linux: `~/.local/share/PerpustakaanOffline/`
-6. In app: **Setting → Sync / Export → Login Google** (browser opens, grant access)
-7. **Push to Google Sheets** — creates a new spreadsheet in your Drive with all data
+5. Save the JSON file somewhere safe (e.g. `%APPDATA%\PerpustakaanOffline\credentials.json`). The exact path / filename doesn't matter — you'll pick it from a file dialog inside the app.
+6. In app: **Setting → Sync / Export → "Pilih credentials.json..."**, choose the JSON file
+7. Click **"Export to Google Sheets"** — browser opens for one-time OAuth, then app pushes all data and shows the spreadsheet URL
+8. Subsequent exports: same button, no re-login needed (token cached). Data overwrites the same spreadsheet (`Perpustakaan-<username>`)
 
 ## Notes
 - Free tier is more than enough for school libraries
 - Data stays in your own Drive — neither the app nor the developer can access it
-- One-way only in v0.1 (app → Sheets). Two-way auto-sync planned for v0.5.
+- One-way only in v0.3.0 (app → Sheets). Two-way auto-sync planned for v0.5.
+- Token JSON is auto-saved at `<data_dir>/credentials/token.json`; delete it to force re-login.
 
 ## Need help?
 [GitHub Issues](https://github.com/alviarts/perpustakaan-offline/issues)
+
+---
+
+*Last updated: v0.3.0 — reviewed for accuracy against `src/perpustakaan/services/sheets_service.py` and `src/perpustakaan/gui/views/settings_view.py`. No API/scope changes from v0.1; only UI button labels updated.*


### PR DESCRIPTION
## Summary

Jalur C item #2 — review `docs/google-sheets-setup.md` (235 baris) untuk akurasi terhadap implementasi v0.3.0 di `src/perpustakaan/services/sheets_service.py` dan `src/perpustakaan/gui/views/settings_view.py`.

### Tidak ada perubahan API/scope

Flow Google Cloud Console + OAuth consent + scopes (`spreadsheets` + `drive.file`) **identik** dengan v0.1. Setup setup wizard 7 langkah masih valid.

### Yang diperbaiki agar match v0.3.0

1. **Header**: `v0.1` → `v0.3.0`, tambah catatan eksplisit tidak ada API change
2. **Langkah 5 (file naming)**: Hapus instruksi rename ke `client_secret.json`. UI v0.3.0 punya tombol *"Pilih credentials.json..."* yang accept JSON apapun lewat file dialog → user bebas naming file & lokasi
3. **Langkah 6 (login)**: Hapus referensi tombol *"Login Google"* yang **tidak ada** di v0.3.0. Flow benar adalah: Pilih credentials.json → klik *"Ekspor ke Google Sheets"* (single button trigger auth + push). Tambah expected output success message
4. **Langkah 7 (push berikutnya)**: Hapus referensi tombol *"Push Update"* dan *"Buat Spreadsheet Baru"* yang **tidak ada**. v0.3.0 selalu overwrite spreadsheet judul `Perpustakaan-<username>` (constant). Tambah note untuk snapshot manual
5. **Troubleshooting `token.json`**: Path lebih spesifik — token disimpan di subfolder `credentials/` di data dir (`USER_DATA_DIR/credentials/token.json`)
6. **FAQ**: Update `v0.1` → `v0.3.0`; tambah Q&A baru beda Cetak Nota (PDF lokal) vs Sync (batch ke Sheets) untuk fitur baru di v0.3.0
7. **English summary**: Rewrite step 5-7 + notes untuk match Indonesian content; tag akhir: "Last updated: v0.3.0 — reviewed for accuracy"

## Review & Testing Checklist for Human

- [ ] Verifikasi text edit match dengan UI di **Setting → Sync / Export** — ada tombol "Pilih credentials.json..." + tombol "Ekspor ke Google Sheets", **tidak ada** tombol "Login Google" / "Push Update" / "Buat Spreadsheet Baru"
- [ ] Coba alur dari clean state: hapus folder `credentials/` di data dir, jalankan ekspor, verifikasi pesan sukses match dengan output yang didokumentasikan
- [ ] Spot-check link internal (`#data-location`, `manual.md`, `../README.md#roadmap`) tetap valid

### Notes

- Pure docs change — tidak ada perubahan kode aplikasi atau dependency
- Local checks: `ruff check src/ tests/` → All checks passed; `pytest tests/ -q --ignore=tests/test_smoke_gui.py` → 17 passed.
- Lanjut: PR 3 (demo screencast 3-5 menit), PR 4 (quickstart 1-pager PDF), PR 5 (installer.iss v0.3.0).