### PR TITLE
docs: tambah quickstart 1-pager PDF untuk pustakawan non-teknis

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart 1-Pager — Perpustakaan Offline v0.3.0
+
+> **Untuk pustakawan**: panduan singkat install + alur harian. Tidak butuh tahu komputer secara teknis.
+> Versi PDF: [`quickstart.pdf`](./quickstart.pdf).
+
+---
+
+## 1. Install (sekali saja)
+
+1. Download **`PerpustakaanOffline-Setup-v0.3.0.exe`** dari halaman rilis:
+   <https://github.com/alviarts/perpustakaan-offline/releases>
+2. Klik 2x file `.exe` → klik **Yes** di dialog Windows → **Next** → **Install**
+3. Setelah selesai, ada shortcut **"Perpustakaan Offline"** di Desktop. Klik 2x untuk buka.
+
+---
+
+## 2. Login Pertama Kali
+
+| Field | Isi |
+|-------|-----|
+| Username | `admin` |
+| Password | `admin123` |
+
+> **Wajib ganti password setelah login pertama**: Settings → Manajemen Akun → klik admin → "Ubah Password".
+
+---
+
+## 3. Alur Harian — Peminjaman
+
+1. Klik menu **Peminjaman** di kiri
+2. Ketik / scan **kode anggota** (mis `A0001`) → Enter
+3. Ketik / scan **kode buku** (mis `B0010`) → klik **Tambah Item** (boleh > 1 buku)
+4. Atur **tanggal jatuh tempo** (default: 7 hari dari sekarang)
+5. Klik **Simpan**
+6. Dialog muncul: **"Cetak nota peminjaman?"**
+   - **Ya, Cetak** → PDF nota tersimpan di `exports/` dan otomatis terbuka untuk dicetak
+   - **Tidak** → transaksi tetap tersimpan, hanya skip nota
+
+---
+
+## 4. Alur Harian — Pengembalian
+
+1. Klik menu **Pengembalian** di kiri
+2. Ketik **kode peminjaman** atau **kode anggota** → Enter → list buku peminjaman muncul
+3. Centang buku yang dikembalikan → klik **Simpan Pengembalian**
+4. Kalau telat: **denda otomatis dihitung** (per hari, sesuai pengaturan di Settings → Transaksi)
+5. Dialog: **"Cetak nota pengembalian?"** → pilih sesuai kebutuhan
+
+---
+
+## 5. Cetak
+
+Menu **Setting → Cetak**: **KTA** (kartu siswa + barcode), **Label Barcode** buku (Code 128), **Surat Bebas Pustaka**. Plus **Nota peminjaman/pengembalian** (auto setelah simpan, lihat #3 & #4). Output PDF → folder `exports/`.
+
+## 6. Backup Rutin (PENTING)
+
+**Setting → Manajemen Akun → Backup Database** → file `.zip` di folder `backups/` → **copy ke flashdisk / Google Drive** tiap akhir minggu. Restore: **Restore dari Backup** → pilih `.zip`.
+
+## 7. Lokasi Data
+
+| OS | Folder |
+|----|--------|
+| Windows | `%APPDATA%\PerpustakaanOffline\` |
+| macOS | `~/Library/Application Support/PerpustakaanOffline/` |
+| Linux | `~/.local/share/PerpustakaanOffline/` |
+
+Isi: `perpustakaan.db` (database SQLite), `backups/`, `exports/`, `photos/`, `covers/`.
+
+## 8. Bantuan
+
+Manual lengkap: <https://github.com/alviarts/perpustakaan-offline/blob/main/docs/manual.md> · Demo video: `docs/demo/perpustakaan-offline-v0.3.0-demo.mp4` (~4 menit) · Setup sync Google Sheets (opsional): [`docs/google-sheets-setup.md`](./google-sheets-setup.md) · Lapor bug: <https://github.com/alviarts/perpustakaan-offline/issues>
+
+*Quickstart v0.3.0 — alviarts/perpustakaan-offline*

--- a/docs/quickstart.pdf
+++ b/docs/quickstart.pdf
@@ -1,0 +1,138 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R /F5 6 0 R /F6 9 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (./quickstart.pdf)
+>> /Border [ 0 0 0 ] /Rect [ 72.9651 764.3126 131.7651 772.7126 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/alviarts/perpustakaan-offline/releases)
+>> /Border [ 0 0 0 ] /Rect [ 37.1811 709.5376 230.0985 719.0376 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/BaseFont /Symbol /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+10 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/alviarts/perpustakaan-offline/blob/main/docs/manual.md)
+>> /Border [ 0 0 0 ] /Rect [ 96.5781 120.3526 353.2215 129.7126 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (./google-sheets-setup.md)
+>> /Border [ 0 0 0 ] /Rect [ 429.5601 110.8526 555.9201 120.2126 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/alviarts/perpustakaan-offline/issues)
+>> /Border [ 0 0 0 ] /Rect [ 80.9781 101.3526 266.5245 110.7126 ] /Subtype /Link /Type /Annot
+>>
+endobj
+13 0 obj
+<<
+/Annots [ 7 0 R 8 0 R 10 0 R 11 0 R 12 0 R ] /Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/PageMode /UseNone /Pages 16 0 R /Type /Catalog
+>>
+endobj
+15 0 obj
+<<
+/Author (alviarts/perpustakaan-offline) /CreationDate (D:20260502132436+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260502132436+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Panduan singkat install + alur harian untuk pustakawan) /Title (Perpustakaan Offline v0.3.0 \204 Quickstart) /Trapped /False
+>>
+endobj
+16 0 obj
+<<
+/Count 1 /Kids [ 13 0 R ] /Type /Pages
+>>
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3330
+>>
+stream
+GauHO>B?:T&q9SYkfVJJP-ZlPL:\PQQ4q;ADnLo?.qe0Il")-[dMN)iL,_1(q<b)j8B)8D,bZe;[\SK=HhZ,ZMh$[L,l^#5!5'Ahn;74>0Y.L`.lrW,i9fahlNo#De1?=+KRi/d$743?gMg.i%GRa@.&s$T`rq*`\tti,cVAFPZD)sJ/s$.R]lONm[f>8a.]-Mr=Y,,oh6IoZ@8*X([lf[Kr7kd5J<0I!^'H]G;\`#(:LWkqUR)j:TCAb=5>ACTrbC%:HaWj\L.NcQCj;e-Pqf<&.$\Q-?PL\&5VY#K$-EL*07ce[-lIGD6-e3R8h]TPS3t3r2an#c&^3?a5m2G3n&'(Zr%s-gMZjJ&(^ZOS0M,h:#Kc*WGi9i=,q:.u;\h0Ng^?NE[#8g:>t!/r7JdUV'*5S/=6ECPAX#+c@\JK340+[,G,H8+/1nX$lcPYgjPE,Q7ME$ZK$fk0eZKjW@R'[a%ZbkVT-oNXA6a^qCBepC=`dZgd,=N-P9Aak!<uO=LM/`_n_n@)H%RSM'7"u!4cs*OL`3:G`(f!^QE_#66nsu^iFFSr-qGBn7"O[P;9"6AHd!:fYQm'MD:auKYOkZ':5p!`A]1A'1>7b_R:XI?q+]2g4i>dB=;ejUnr/JS)S31Fj6O:tq%gNN2c],MTu8XUMHAb@gW[@k140N.OLZ)r>i)jD'rqY:bTCJA>c,nOO[Tu`SX94r@KKen<=E!%/MNc+iJZd0h&972FrSu7H>Q`mYmRt>QnDJ'?nQ#TS.CB2+m8)XR>-VCo=kS?a(-#eoPkW^$5pk=k:GR`X!"9L+5Le62#;0\pV--IIYW:/o:9-!B@eOb2V7=NVM;Xqd;f]/N4j7s/lr;X/WEW<"'n^\5N[_Wpfdl=pmCD<EJ)mKr`sD>lY#ZAJ[Kij9iiLBY@l6@c`5@U_m;%XE1bC[3;YgHiY=/65r&s\3DJV4.ULVUR2<8C^>t+u_ao?To;4ObR%td=YE>\V)KWZ-X,YfRZja$h8#r>\V'6+W+E&*tottPn<T#3oM',0K&p#tDa"#fG6EKcR,EHU23mm5'fLRd.k3s_X8Te[!inKj<rQ>kn_&B>Ko/X7Z3AgW&l$Rb$h/XH("H__6q<(t*0A0M*>NiNT\QLSih?*a8EMGk5`dMS/(0s]T=+^>;<hiIoZasRK]op$'f"I`F>Uo8G.m3MXV.I,ILT\&]9>]_>/U4o":GfP,;a!ibSL/Co,1mq=Gqen:hCVB`a"Zphg^;G8j<IX)+o3ScIqVGcMMCA5'pY&KQG:bOg6Q9Yr)g(-=h//!<qI7EqQu>SC1SiD?S#)R/X2Q<]6^g;p=$IO7S%U_<Lq.2AiP+50HALps32V'"D03H!ditE7Bh^djj_WJF]@GfNE-sUY/Ds(MLBO"Y@A6ZqDnJm!qsDG4Fdem%<f?B7qfG/m<7BF0,'R^)$)DE$b,).NV5)C7o>=KQjm7uN$e+m]imY50P_##A7m!6jC]RXdiMKZ6e5DJlcM%c\u8mnbS@J)l;Xc?HL"PW8(13!\>G[:]]b3^*Rkoe=fLai&A(Q0(R8rr3Z17>A\k6E][5cUK%V]>Cf<"I_*TD/FaP"*WfgXk^@CH:D:70(o!mL`e2Z*9[5NY;B`(4%__*;'_cj7k=R&+ZXnif]`"lL)^Qs7E-d<q/q&KBnR`sj[E+ESmp#,>hgT4\Sd>,+_,\HNTc,_F]R1BfZ5KMuF.'1mZbO8U!bB#5'f`?>;ZBcMP`cut<L$8k5%LirD7:B17]qtK5L#%SSe=l$hQ?09cQu)n/:9P^Z=WCNqdU8O?k;A#=Dn'=!"IR";nh#dTmk<C[@;>J$+ngATN[\H$c%A"L$??o/3Zu&J]IJT"fn5R6lrj;D-116k;4*p8mW`Ie5UaMRPF,mCFEWgH*\+^0\rs6oiOW=`)>u$IIg4JfZ6a+GKR&D>OX5pWFT)V':@Nm%ie]'B7gJ:\7_G_d7O*0/&K$Yj@<Z!5'XNWYDIW<oh=Xt<*m?TE6sk&XAAhegUNTqN=6pt9]iSnf*PJZ@AhX(b@=(P*N8LZmqLaFn3&#+2Bp`EgH>LUuq]kY0DY6FBF)Y3CUb$WT[^<,g*P;j8=)%;8b;VQ)OBj%#O6i,^]Y^d6(A%p8$Tte#9$p=YE-/J'k:2HtU4`:*k1Q`#XFWhn%p\g-[9YL'1(@i<:cdUT&BQH@cUl7^H=S]soGnb;U?9[9#9/Yg<O;iTf6$Ul^M^sM<>tg%e5gD^jGUe)4LEj9Z]XarHtb?skCZ!)>[;8#p6r-C<``":.ap\s@hDGa)eX7Li`,*\%`BQG;ShOU=sIY>3#HeZ[[AR2'Y:n`rDeaZb#n#i0H1P)[WE]NY5<Zi;3rZ7\!AHg,'d_g)ba?r`JQ]?IC6W%%@_;Y?5H[ZDO&h(n_d,BO9r=1\%'?J,N1MPYQSj%kM@-s.<+UNal^8Y.[YVQ<*k>W,E`rU==V5=K7kQ%`um`=IaR(\n;BIo<T%@:UK$BhfNrQE+8YC=C,fDKf)EU<g.l.V;+p@4e4^#d@d9d%Hqr(E;;J^"5E)a0]^&B2W(!/M:H(@*+75f8KAp_5j.[Rf-rkDH:_k:K-AM58]q)'gr[4GrNXE]gr]SB"h=4HR0+DaYMJ3q+_!27#5"k%@8@%:=G@<Hu7:!pm>E.dA?kG)2/n2W?17P*II--7oA%nDnWtHi4M?D#<XM"[cA"'_k%agch25P_eCFbmpnQ7"+^h@A@[M3SY2m*feY<nfB5o`8JCCFkQr6DW7S8H_9/\<*?IReJU)Q!7S\(-G<l&PbA?0/V2NT)Rs4-_7hK?%3=3Qu[BX$dI=Du'(cp@e&dFRe[A>Vk1u*cDRh*p8h)Ctckrr=(@W*8ZKCbi0_^M^\/8'RSgnJ@dY\E7M0^&]5qYo]H97,"TIm:dfg,s#F'VE6A)eJh94U.XLj2-f\@-B;jX`SlXIncTG49Bq29iD]Hnr)i(,C79_5HBe51\0X_&6I81rg'61`"&u\Rr/+-pqi&)Rc,qOb^:H(U@HbcDm^"k+'dkL/Y+e"0A4=5Vnpl3=B[sZ-@Rf--jH\?0Xf(&u"m;OOD1o!((<)R/kq=L>k:W-Y)Q80P0SpdLh.YDB7^jCG\B&\T0iIZnok_@Oh?Y/koKj,1)MQcBojs=Afn4gDTXE52J*%*,sipF.$Q/>h-b:ZU,OhP>ds4"BQ<'hd(aP"eP%0ak7@(P]nmcL%_">:4Z"H+i&a/?PGVO[Zh^=cYPDg%FW<0k,]`b^+tPI#MO0GhMMSK5Pf,"^2mhgBJ27d%4^B.'_6-==5MSIT6DF`upH"?3Z0KAmUj(BuNChi03=?T`:E'^OjYTX3gnQ1Dc5rrF&HWL3~>endstream
+endobj
+xref
+0 18
+0000000000 65535 f 
+0000000061 00000 n 
+0000000142 00000 n 
+0000000249 00000 n 
+0000000361 00000 n 
+0000000480 00000 n 
+0000000595 00000 n 
+0000000700 00000 n 
+0000000867 00000 n 
+0000001075 00000 n 
+0000001152 00000 n 
+0000001377 00000 n 
+0000001554 00000 n 
+0000001761 00000 n 
+0000002012 00000 n 
+0000002082 00000 n 
+0000002448 00000 n 
+0000002509 00000 n 
+trailer
+<<
+/ID 
+[<6dd838e140df4096f78b3fa280f799c1><6dd838e140df4096f78b3fa280f799c1>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 15 0 R
+/Root 14 0 R
+/Size 18
+>>
+startxref
+5931
+%%EOF

--- a/scripts/build_quickstart_pdf.py
+++ b/scripts/build_quickstart_pdf.py
@@ -1,0 +1,338 @@
+"""Build docs/quickstart.pdf dari docs/quickstart.md via reportlab.
+
+Usage:
+    .venv/bin/python scripts/build_quickstart_pdf.py
+
+Hasil:
+    docs/quickstart.pdf (target ~1 halaman A4 untuk pustakawan non-teknis)
+
+Pendekatan: parse markdown sederhana (heading, list, table, code) -> reportlab
+flowables. Bukan markdown engine penuh -- cukup untuk format quickstart yang
+strukturnya stabil.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.platypus import (
+    HRFlowable,
+    ListFlowable,
+    ListItem,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC_MD = ROOT / "docs" / "quickstart.md"
+OUT_PDF = ROOT / "docs" / "quickstart.pdf"
+
+
+def _styles() -> dict[str, ParagraphStyle]:
+    base = getSampleStyleSheet()
+    return {
+        "h1": ParagraphStyle(
+            "h1", parent=base["Heading1"], fontSize=14, leading=16,
+            textColor=colors.HexColor("#0f172a"), spaceBefore=0, spaceAfter=2,
+            fontName="Helvetica-Bold",
+        ),
+        "h2": ParagraphStyle(
+            "h2", parent=base["Heading2"], fontSize=9.5, leading=11,
+            textColor=colors.HexColor("#1e40af"), spaceBefore=4, spaceAfter=1,
+            fontName="Helvetica-Bold",
+        ),
+        "body": ParagraphStyle(
+            "body", parent=base["BodyText"], fontSize=7.8, leading=9.5,
+            textColor=colors.HexColor("#1f2937"), spaceAfter=1,
+            fontName="Helvetica",
+        ),
+        "li": ParagraphStyle(
+            "li", parent=base["BodyText"], fontSize=7.8, leading=9.5,
+            textColor=colors.HexColor("#1f2937"), spaceAfter=0,
+            fontName="Helvetica", leftIndent=0,
+        ),
+        "code": ParagraphStyle(
+            "code", parent=base["Code"], fontSize=7.5, leading=9,
+            textColor=colors.HexColor("#0f172a"), fontName="Courier",
+            backColor=colors.HexColor("#f3f4f6"), borderPadding=3,
+            spaceBefore=2, spaceAfter=2,
+        ),
+        "muted": ParagraphStyle(
+            "muted", parent=base["BodyText"], fontSize=7, leading=9,
+            textColor=colors.HexColor("#6b7280"),
+            fontName="Helvetica-Oblique",
+        ),
+        "footer": ParagraphStyle(
+            "footer", parent=base["BodyText"], fontSize=6.5, leading=8,
+            textColor=colors.HexColor("#6b7280"), alignment=1,
+            fontName="Helvetica-Oblique", spaceBefore=3,
+        ),
+    }
+
+
+_INLINE_BOLD = re.compile(r"\*\*(.+?)\*\*")
+_INLINE_CODE = re.compile(r"`([^`]+)`")
+_INLINE_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_AUTO_LINK = re.compile(r"<(https?://[^>]+)>")
+
+
+def _inline(text: str) -> str:
+    """Convert markdown inline markers ke <b>/<font face=Courier>/<a>."""
+    text = _INLINE_BOLD.sub(r"<b>\1</b>", text)
+    text = _INLINE_CODE.sub(
+        lambda m: f'<font face="Courier" color="#1e293b">{m.group(1)}</font>',
+        text,
+    )
+    text = _INLINE_LINK.sub(
+        lambda m: f'<a href="{m.group(2)}" color="#1e40af">{m.group(1)}</a>',
+        text,
+    )
+    text = _AUTO_LINK.sub(
+        lambda m: f'<a href="{m.group(1)}" color="#1e40af">{m.group(1)}</a>',
+        text,
+    )
+    return text
+
+
+def _parse_table(lines: list[str], i: int) -> tuple[Table | None, int]:
+    """Parse markdown pipe table dimulai dari index i. Return (Table, next_idx)."""
+    header_line = lines[i].strip()
+    if not (header_line.startswith("|") and header_line.endswith("|")):
+        return None, i
+    if i + 1 >= len(lines):
+        return None, i
+    sep_line = lines[i + 1].strip()
+    if not re.match(r"^\|[\s\-:|]+\|$", sep_line):
+        return None, i
+
+    def split_row(line: str) -> list[str]:
+        return [c.strip() for c in line.strip("|").split("|")]
+
+    header = split_row(header_line)
+    rows: list[list[str]] = []
+    j = i + 2
+    while j < len(lines):
+        line = lines[j].strip()
+        if not (line.startswith("|") and line.endswith("|")):
+            break
+        rows.append(split_row(line))
+        j += 1
+
+    styles = _styles()
+    th_style = ParagraphStyle(
+        "th", parent=styles["li"], textColor=colors.whitesmoke,
+        fontName="Helvetica-Bold",
+    )
+    data: list[list] = [[Paragraph(_inline(c), th_style) for c in header]]
+    for row in rows:
+        data.append([Paragraph(_inline(c), styles["li"]) for c in row])
+
+    tbl = Table(data, colWidths=None, hAlign="LEFT", repeatRows=1)
+    tbl.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1e293b")),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 7.8),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1),
+         [colors.HexColor("#f8fafc"), colors.white]),
+        ("GRID", (0, 0), (-1, -1), 0.3, colors.HexColor("#cbd5e1")),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 3),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+        ("TOPPADDING", (0, 0), (-1, -1), 1.5),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 1.5),
+    ]))
+    return tbl, j
+
+
+def _parse_list(
+    lines: list[str], i: int, *, ordered: bool
+) -> tuple[list, int]:
+    """Parse markdown list (ordered / bullet) -> list of flowables.
+
+    Sub-bullets (indented with 3+ spaces + ``-``) are rendered as separate
+    Paragraphs outside the main ListFlowable supaya tidak dapat ordered number.
+    """
+    styles = _styles()
+    flows: list = []
+    items: list[ListItem] = []
+
+    def flush_main() -> None:
+        if items:
+            flows.append(ListFlowable(
+                list(items), bulletType="1" if ordered else "bullet",
+                leftIndent=12, bulletFontSize=7.8, bulletDedent=9,
+                spaceBefore=0, spaceAfter=0,
+            ))
+            items.clear()
+
+    pat = re.compile(r"^(\s*)" + (r"\d+\." if ordered else r"-") + r"\s+(.*)$")
+    sub_indent = ParagraphStyle(
+        "sub", parent=styles["li"], leftIndent=18, spaceAfter=0,
+    )
+
+    j = i
+    while j < len(lines):
+        m = pat.match(lines[j])
+        if not m:
+            break
+        text = m.group(2)
+        items.append(ListItem(
+            Paragraph(_inline(text), styles["li"]),
+            leftIndent=8, value="circle" if not ordered else None,
+        ))
+        j += 1
+        # sub-bullets: render setelah flush main list
+        sub_collected: list[str] = []
+        while (
+            j < len(lines)
+            and lines[j].startswith("   ")
+            and lines[j].strip().startswith("-")
+        ):
+            sub_collected.append(lines[j].strip().lstrip("-").strip())
+            j += 1
+        if sub_collected:
+            flush_main()
+            for sub in sub_collected:
+                flows.append(Paragraph(
+                    f"\u00b7 {_inline(sub)}", sub_indent,
+                ))
+
+    flush_main()
+    return flows, j
+
+
+def md_to_flowables(md: str) -> list:
+    styles = _styles()
+    lines = md.splitlines()
+    flows: list = []
+    i = 0
+    in_code = False
+    code_buf: list[str] = []
+
+    while i < len(lines):
+        line = lines[i]
+
+        # fenced code block
+        if line.strip().startswith("```"):
+            if in_code:
+                code_text = "\n".join(code_buf)
+                flows.append(Paragraph(
+                    code_text.replace("&", "&amp;").replace("<", "&lt;")
+                    .replace(">", "&gt;").replace("\n", "<br/>"),
+                    styles["code"],
+                ))
+                code_buf = []
+                in_code = False
+            else:
+                in_code = True
+            i += 1
+            continue
+        if in_code:
+            code_buf.append(line)
+            i += 1
+            continue
+
+        stripped = line.strip()
+
+        # headings
+        if stripped.startswith("# "):
+            flows.append(Paragraph(_inline(stripped[2:]), styles["h1"]))
+            i += 1
+            continue
+        if stripped.startswith("## "):
+            flows.append(Paragraph(_inline(stripped[3:]), styles["h2"]))
+            i += 1
+            continue
+        if stripped.startswith("### "):
+            flows.append(Paragraph(_inline(stripped[4:]), styles["h2"]))
+            i += 1
+            continue
+
+        # horizontal rule
+        if stripped == "---":
+            flows.append(HRFlowable(width="100%", thickness=0.4,
+                                    color=colors.HexColor("#cbd5e1"),
+                                    spaceBefore=4, spaceAfter=4))
+            i += 1
+            continue
+
+        # block quote (single-line)
+        if stripped.startswith("> "):
+            flows.append(Paragraph(_inline(stripped[2:]), styles["muted"]))
+            i += 1
+            continue
+
+        # ordered list
+        if re.match(r"^\d+\.\s+", stripped):
+            sub_flows, i = _parse_list(lines, i, ordered=True)
+            flows.extend(sub_flows)
+            flows.append(Spacer(1, 1))
+            continue
+
+        # bullet list
+        if stripped.startswith("- "):
+            sub_flows, i = _parse_list(lines, i, ordered=False)
+            flows.extend(sub_flows)
+            flows.append(Spacer(1, 1))
+            continue
+
+        # table
+        if stripped.startswith("|") and stripped.endswith("|"):
+            tbl, ni = _parse_table(lines, i)
+            if tbl is not None:
+                flows.append(Spacer(1, 2))
+                flows.append(tbl)
+                flows.append(Spacer(1, 2))
+                i = ni
+                continue
+
+        # blank line
+        if not stripped:
+            flows.append(Spacer(1, 1.5))
+            i += 1
+            continue
+
+        # paragraph (default)
+        if stripped.startswith("*") and stripped.endswith("*") and not stripped.startswith("**"):
+            flows.append(Paragraph(_inline(stripped), styles["footer"]))
+        else:
+            flows.append(Paragraph(_inline(stripped), styles["body"]))
+        i += 1
+
+    return flows
+
+
+def main() -> int:
+    if not SRC_MD.exists():
+        print(f"ERROR: {SRC_MD} not found")
+        return 2
+
+    md_text = SRC_MD.read_text(encoding="utf-8")
+    flows = md_to_flowables(md_text)
+
+    OUT_PDF.parent.mkdir(parents=True, exist_ok=True)
+    doc = SimpleDocTemplate(
+        str(OUT_PDF), pagesize=A4,
+        leftMargin=11 * mm, rightMargin=11 * mm,
+        topMargin=8 * mm, bottomMargin=8 * mm,
+        title="Perpustakaan Offline v0.3.0 \u2014 Quickstart",
+        author="alviarts/perpustakaan-offline",
+        subject="Panduan singkat install + alur harian untuk pustakawan",
+    )
+    doc.build(flows)
+    size_kb = OUT_PDF.stat().st_size / 1024
+    print(f"-> wrote {OUT_PDF.relative_to(ROOT)} ({size_kb:.1f} KB)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Jalur C item #4 — quickstart 1-page PDF target audience pustakawan tanpa background teknis. Format A4 fit di 1 halaman, kalimat pendek + tabel referensi.

### Konten quickstart

1. **Install (sekali saja)** — download `.exe` → install → shortcut Desktop
2. **Login Pertama Kali** — tabel admin/admin123 + reminder ganti password
3. **Alur Harian — Peminjaman** — 6 step + dialog cetak nota (Ya/Tidak)
4. **Alur Harian — Pengembalian** — 5 step + denda otomatis + cetak nota
5. **Cetak** — KTA, Label Barcode, Surat Bebas Pustaka, Nota → folder `exports/`
6. **Backup Rutin (PENTING)** — Settings → Manajemen Akun → Backup → copy ke flashdisk/Drive
7. **Lokasi Data** — tabel folder per OS (Windows / macOS / Linux)
8. **Bantuan** — link manual lengkap, demo video, sheets setup, GitHub issues

### File yang ditambahkan

- `docs/quickstart.md` — source markdown (~80 baris, 8 section)
- `docs/quickstart.pdf` — output 1-page A4, **6.4 KB**, generated via reportlab Platypus
- `scripts/build_quickstart_pdf.py` — script parser markdown → flowables (heading, list ordered/bullet dengan sub-bullet, table pipe, code, link, hr)

### Cara reproduce

```bash
.venv/bin/python scripts/build_quickstart_pdf.py
# -> docs/quickstart.pdf
```

Script membaca `docs/quickstart.md` dan output `docs/quickstart.pdf`. Kalau kontennya butuh update, edit markdown lalu rebuild.

### Pertimbangan desain

- **Font kecil** (7.8 pt body, 9.5 leading) supaya muat 1 halaman dengan tetap readable
- **Tabel header** dark slate + white text, alternating row bg supaya scanable
- **Code styling** pakai monospace + abu-abu muda, keyword UI di-bold
- **Sub-bullet** (mis di alur Peminjaman step 6) tidak ikut auto-number — render terpisah supaya alur tetap sequential
- Margins **11mm L/R, 8mm T/B** — kompak tapi tidak crowded
- **Hyperlink** ke GitHub repo + manual.md + sheets-setup.md tetap clickable di PDF reader

## Review & Testing Checklist for Human

- [ ] Buka `docs/quickstart.pdf` di PDF reader pilihan (Chrome/Edge/Adobe) — pastikan layout 1 halaman, font readable, tabel rapi
- [ ] Verifikasi konten match aktual UI app v0.3.0 (mis username default `admin`, dialog "Cetak nota peminjaman?", lokasi backup `.zip` di `backups/`)
- [ ] Print test (opsional) — pustakawan kemungkinan mau print ini di kertas dan tempel di meja
- [ ] Decide apakah perlu juga generate versi B/W friendly (mis untuk printer ekonomis tanpa color)

### Notes

- Local checks: `ruff check src/ tests/ scripts/` → All checks passed; `pytest tests/ -q --ignore=tests/test_smoke_gui.py` → 17 passed
- Lanjut: PR 5 — Inno Setup installer.iss bump ke v0.3.0