### PR TITLE
installer: bump versi ke v0.3.0 + bundle quickstart docs

### DIFF
--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -12,7 +12,7 @@
 
 #define MyAppName "Perpustakaan Offline"
 #define MyAppShortName "PerpustakaanOffline"
-#define MyAppVersion "0.1.1"
+#define MyAppVersion "0.3.0"
 #define MyAppPublisher "alviarts"
 #define MyAppURL "https://github.com/alviarts/perpustakaan-offline"
 #define MyAppExeName "PerpustakaanOffline.exe"
@@ -66,10 +66,13 @@ Source: "..\README.md"; DestDir: "{app}"; Flags: ignoreversion isreadme
 Source: "..\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\docs\manual.md"; DestDir: "{app}\docs"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "..\docs\google-sheets-setup.md"; DestDir: "{app}\docs"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "..\docs\quickstart.md"; DestDir: "{app}\docs"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "..\docs\quickstart.pdf"; DestDir: "{app}\docs"; Flags: ignoreversion skipifsourcedoesntexist
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autoprograms}\Manual Pengguna"; Filename: "{app}\docs\manual.md"
+Name: "{autoprograms}\Quickstart (PDF)"; Filename: "{app}\docs\quickstart.pdf"
 Name: "{autoprograms}\Uninstall {#MyAppName}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 


### PR DESCRIPTION
## Summary

Jalur C item #5 (terakhir) — update Inno Setup installer ke v0.3.0 sesuai tag yang sudah dirilis.

### Perubahan

```diff
-#define MyAppVersion "0.1.1"
+#define MyAppVersion "0.3.0"
```

Karena semua field metadata pakai `{#MyAppVersion}` lewat `#define`, perubahan satu baris ini otomatis update:

- `AppVersion` → `0.3.0`
- `AppVerName` → `Perpustakaan Offline 0.3.0`
- `OutputBaseFilename` → `PerpustakaanOffline-Setup-v0.3.0`
- `VersionInfoVersion` → `0.3.0.0`
- `VersionInfoProductVersion` → `0.3.0.0`
- `UninstallDisplayName` → `Perpustakaan Offline 0.3.0`

### Plus: bundle quickstart docs

Karena PR 4 baru menambah `docs/quickstart.md` + `docs/quickstart.pdf`, sekalian di-bundle di installer:

```
[Files]
+ Source: "..\docs\quickstart.md"; DestDir: "{app}\docs"; Flags: ignoreversion skipifsourcedoesntexist
+ Source: "..\docs\quickstart.pdf"; DestDir: "{app}\docs"; Flags: ignoreversion skipifsourcedoesntexist

[Icons]
+ Name: "{autoprograms}\Quickstart (PDF)"; Filename: "{app}\docs\quickstart.pdf"
```

`skipifsourcedoesntexist` flag memastikan kalau ada build di mana quickstart belum di-generate (mis dev branch), installer tetap build (file di-skip, bukan error).

### AppId tidak berubah

`{{8E2C3A4D-9F3B-4A5E-B6F7-C1D2E3F4A5B6}` di-keep — ini wajib stable supaya upgrade dari v0.1.x ke v0.3.0 dideteksi sebagai upgrade (dan auto-uninstall versi lama) bukan install baru. Lihat `[Code]` block `IsUpgrade()` + `UnInstallOldVersion()` yang sudah ada.

## Review & Testing Checklist for Human

- [ ] Build installer di Windows / Wine: `ISCC.exe installer\installer.iss` → verifikasi output filename `PerpustakaanOffline-Setup-v0.3.0.exe`
- [ ] Atau cukup tunggu tag `v0.3.0` untuk trigger CI job `Build .exe + Installer (Windows)` (yang skipped saat ini karena bukan tag push)
- [ ] Test path upgrade di Windows VM: install v0.1.x lebih dulu → install v0.3.0 → pastikan deteksi upgrade jalan + data user di `%APPDATA%\PerpustakaanOffline\` tidak hilang
- [ ] Verifikasi shortcut Start Menu setelah install v0.3.0:
  - `Perpustakaan Offline` (launcher)
  - `Manual Pengguna` (markdown)
  - `Quickstart (PDF)` — baru
  - `Uninstall Perpustakaan Offline`

### Notes

- Local checks: `ruff check src/ tests/` → All checks passed; `pytest tests/ -q --ignore=tests/test_smoke_gui.py` → 17 passed
- File `installer/installer.iss` tidak punya CI lint khusus — syntax di-validate saat build job di-trigger via tag

### Status Jalur C

Ini PR terakhir di Jalur C:

1. ✅ PR #16 — Manual + 4 screenshot baru (v0.3.0 features)
2. ✅ PR #17 — Google Sheets setup guide review
3. ✅ PR #18 — Demo screencast 4 menit
4. ✅ PR #19 — Quickstart 1-pager PDF
5. ✅ PR ini — Inno Setup installer v0.3.0

Setelah ini di-merge, dokumentasi & onboarding untuk v0.3.0 lengkap.