### PR TITLE
feat(v0.4.0): Backup Terjadwal + Toggle Tema Global + Tutorial Onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Beberapa flow di v0.1 cuma ada di backend; UI-nya belum lengkap.
 - [ ] **Opsi A: Sync 2-arah Google Sheets** — auto-sync background, conflict resolution last-write-wins by `updated_at`. Sebagai upgrade dari Opsi C yang sudah ada
 - [ ] **Multi-perpustakaan / multi-cabang** — kalau sekolah punya >1 perpus
 - [ ] **Mobile companion (PWA)** — siswa lihat status peminjaman sendiri, scan QR untuk pinjam mandiri
-- [ ] **Backup terjadwal** — auto-backup harian/mingguan ke folder lokal atau cloud
+- [x] **Backup terjadwal** — auto-backup harian/mingguan ke folder lokal (v0.4.0)
 - [ ] **Import dari SIM-Perpus.xlsb asli** — script konversi data lama → SQLite untuk migrasi user existing
 - [ ] **Code signing certificate** — sign `.exe` supaya Windows Defender / SmartScreen tidak warning
 
@@ -157,6 +157,7 @@ Beberapa flow di v0.1 cuma ada di backend; UI-nya belum lengkap.
 
 | Versi | Tanggal | Highlights |
 |-------|---------|-----------|
+| **v0.4.0** | 2026-05-02 | feat(backup): backup terjadwal harian/mingguan dengan retensi otomatis, catch-up saat startup, audit log + toast tiap selesai backup · feat(ui): tombol toggle tema **Sistem / Terang / Gelap** mengambang di pojok kanan atas — selalu visible di menu manapun · feat(ui): tutorial / guided tour interaktif yang muncul otomatis di first-run dengan tombol Lewati / Sebelumnya / Berikutnya, juga bisa diulang dari Setting → Bahasa & Tema |
 | **v0.3.1** | 2026-05-02 | docs: manual.md update + 4 screenshot fitur v0.3.0 · docs: review Google Sheets setup guide · docs: demo screencast 4 menit (`docs/demo/`) · docs: quickstart 1-pager PDF (`docs/quickstart.pdf`) · installer: bump Inno Setup AppVersion ke v0.3.1 + bundle quickstart docs |
 | **v0.3.0** | 2026-05-02 | feat(gui): UI Naik Kelas batch · feat(gui): Bebas Pustaka validasi peminjaman aktif · feat(gui): Cetak Nota di Peminjaman & Pengembalian · feat(gui): Cek Data Ganda (Settings → Tools) · feat(gui): Reminder jatuh tempo otomatis saat login · feat(gui): Audit Log viewer (Settings → Audit Log) |
 | **v0.2.0** | 2026-05-02 | feat(seed): `--demo` flag untuk seed 5 anggota + 10 buku + 2 peminjaman aktif · feat(gui): toast notification non-blocking + exception reporter dengan log ke `app.log` · test: full GUI smoke test passed di Xvfb (17 test cases) · fix: StyledTreeview crash pada duplicate iid · ci: Linux build artifact ditambahkan ke release |

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -15,20 +15,21 @@ sesuai urutan menu di sidebar.
 
 1. [Instalasi & Jalankan Pertama Kali](#instalasi--jalankan-pertama-kali)
 2. [Login & Akun](#login--akun)
-3. [Dashboard](#dashboard)
-4. [Master Data — Anggota](#master-data--anggota)
-5. [Master Data — Buku](#master-data--buku)
-6. [Transaksi — Kunjungan](#transaksi--kunjungan)
-7. [Transaksi — Peminjaman](#transaksi--peminjaman)
-8. [Transaksi — Pengembalian](#transaksi--pengembalian)
-9. [Laporan](#laporan)
-10. [Setting](#setting)
-11. [Tools — Cek Data Ganda](#tools--cek-data-ganda)
-12. [Audit Log Viewer](#audit-log-viewer)
-13. [Backup, Reset, & Lokasi Data](#backup-reset--lokasi-data)
-14. [Cetak (KTA, Label Barcode, Bebas Pustaka, Nota)](#cetak-kta-label-barcode-bebas-pustaka-nota)
-15. [Sync ke Google Sheets (Opsional)](#sync-ke-google-sheets-opsional)
-16. [Troubleshooting](#troubleshooting)
+3. [Tutorial Onboarding & Toggle Tema (v0.4.0)](#tutorial-onboarding--toggle-tema-v040)
+4. [Dashboard](#dashboard)
+5. [Master Data — Anggota](#master-data--anggota)
+6. [Master Data — Buku](#master-data--buku)
+7. [Transaksi — Kunjungan](#transaksi--kunjungan)
+8. [Transaksi — Peminjaman](#transaksi--peminjaman)
+9. [Transaksi — Pengembalian](#transaksi--pengembalian)
+10. [Laporan](#laporan)
+11. [Setting](#setting)
+12. [Tools — Cek Data Ganda](#tools--cek-data-ganda)
+13. [Audit Log Viewer](#audit-log-viewer)
+14. [Backup, Reset, & Lokasi Data](#backup-reset--lokasi-data)
+15. [Cetak (KTA, Label Barcode, Bebas Pustaka, Nota)](#cetak-kta-label-barcode-bebas-pustaka-nota)
+16. [Sync ke Google Sheets (Opsional)](#sync-ke-google-sheets-opsional)
+17. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -81,6 +82,45 @@ Klik **"More info"** → **"Run anyway"**. Ini normal untuk software open-source
 Klik **"Daftar Akun Baru"** di layar login untuk register operator/pustakawan tambahan.
 Akun pertama otomatis menjadi **administrator**; akun berikutnya berperan **operator**
 (tidak bisa hapus akun lain atau reset DB).
+
+---
+
+## Tutorial Onboarding & Toggle Tema (v0.4.0)
+
+### Tutorial Otomatis di First Run
+
+Saat aplikasi dibuka pertama kali, akan muncul **tour interaktif** yang
+menjelaskan tiap menu utama dan tombol penting satu per satu. Tiap popup
+nempel di tombol/menu yang sedang dijelaskan, dengan kontrol:
+
+- **Lewati** — tutup tutorial, tidak akan muncul lagi otomatis.
+- **Sebelumnya** — kembali ke step sebelumnya.
+- **Berikutnya** — lanjut ke step selanjutnya.
+- **Selesai** — di langkah terakhir; menutup tutorial.
+
+Tour mencakup: Dashboard → Anggota → Buku → Peminjaman → Pengembalian →
+Laporan → Setting → Toggle Tema, dengan deskripsi singkat untuk fitur-fitur
+penting di tiap menu (mis. tombol **Naik Kelas**, **Surat Bebas Pustaka**,
+**Cetak Label & Barcode**).
+
+### Mengulang Tutorial
+
+Buka **Setting → tab "Bahasa & Tema"**, lalu klik tombol
+**Mulai Ulang Tutorial** di paling bawah. Tour akan diputar ulang dari
+langkah pertama.
+
+### Toggle Tema (Sistem / Terang / Gelap)
+
+Di **pojok kanan atas window** ada tombol segmented dengan 3 pilihan:
+
+- **Sistem** — ikut setting OS (auto-switch siang/malam di Windows 10/11).
+- **Terang** — paksa light mode.
+- **Gelap** — paksa dark mode.
+
+Tombol ini **selalu muncul di menu manapun** (Dashboard, Anggota, Buku,
+Setting, dst.) sehingga kamu bisa ganti tema kapan saja tanpa harus
+buka Setting. Pilihan disimpan di tabel `settings` (`ui.theme`) dan
+diingat untuk sesi-sesi berikutnya.
 
 ---
 
@@ -407,6 +447,41 @@ Klik **Simpan** → UI berubah live tanpa restart.
 
 Untuk export manual ke Google Sheets — lihat
 [Sync ke Google Sheets](#sync-ke-google-sheets-opsional).
+
+### Tab "Backup Terjadwal" (v0.4.0)
+
+Aplikasi bisa **otomatis membuat backup database SQLite** secara harian atau
+mingguan ke folder lokal. File lama akan dihapus otomatis sesuai jumlah
+retensi yang dipilih.
+
+| Field          | Pilihan / Format                                            |
+|----------------|-------------------------------------------------------------|
+| Frekuensi      | `Mati` / `Harian` / `Mingguan`                              |
+| Jam            | `HH:MM` 24-jam (mis. `02:00`)                               |
+| Hari (mingguan)| `Senin` … `Minggu` — hanya muncul saat frekuensi mingguan   |
+| Folder Tujuan  | Path folder; kosongkan untuk pakai folder backup default    |
+| Retensi        | Jumlah file backup yang dipertahankan (sisanya dihapus)     |
+
+Tombol:
+- **Simpan Pengaturan** → menyimpan jadwal & folder, scheduler langsung memuat
+  ulang konfigurasi tanpa restart aplikasi.
+- **Backup Sekarang** → buat backup manual saat ini juga (juga di-prune sesuai
+  retensi). Sukses/gagal akan tampil sebagai toast notification.
+- **Buka Folder** → buka folder backup di File Explorer.
+
+Status terbawah menampilkan **Backup terakhir** (timestamp + status sukses/
+gagal) dan **Backup berikutnya** (perkiraan kapan scheduler akan jalan).
+Daftar file backup tersimpan ditampilkan di tabel paling bawah lengkap dengan
+ukuran & tanggal.
+
+**Catatan operasional:**
+- Scheduler berjalan sebagai daemon thread di dalam aplikasi — backup hanya
+  jalan saat aplikasi terbuka. Kalau jadwal terlewat (mis. PC dimatikan
+  semalam), saat aplikasi dibuka lagi backup akan langsung dijalankan
+  sebagai *catch-up*.
+- Setiap operasi backup tercatat di **Audit Log** dengan aksi `backup_ok`
+  atau `backup_failed`, lengkap dengan trigger (`scheduled` / `manual` /
+  `catchup`) dan jumlah file lama yang ter-prune.
 
 ### Tab "Tools"
 

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -12,7 +12,7 @@
 
 #define MyAppName "Perpustakaan Offline"
 #define MyAppShortName "PerpustakaanOffline"
-#define MyAppVersion "0.3.1"
+#define MyAppVersion "0.4.0"
 #define MyAppPublisher "alviarts"
 #define MyAppURL "https://github.com/alviarts/perpustakaan-offline"
 #define MyAppExeName "PerpustakaanOffline.exe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "perpustakaan-offline"
-version = "0.3.1"
+version = "0.4.0"
 description = "Aplikasi perpustakaan offline (Sistem Informasi Manajemen Perpustakaan / SIM-Perpus) berbasis Python + SQLite, dikemas ke .exe Windows. Inspirasi: SIM-Perpus by Kang Sur."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/perpustakaan/__init__.py
+++ b/src/perpustakaan/__init__.py
@@ -1,5 +1,5 @@
 """Perpustakaan Offline — SIM-Perpus reborn (Python + SQLite + CustomTkinter)."""
 from __future__ import annotations
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __all__ = ["__version__"]

--- a/src/perpustakaan/app.py
+++ b/src/perpustakaan/app.py
@@ -55,6 +55,13 @@ def _apply_locale_from_settings() -> None:
         set_locale("id")
 
 
+def _start_backup_scheduler() -> None:
+    """Mulai daemon scheduler backup terjadwal."""
+    from perpustakaan.services.backup_scheduler import get_scheduler
+
+    get_scheduler().start()
+
+
 def run(demo: bool = False, headless: bool = False) -> int:
     """Entry point — return exit code.
 
@@ -90,8 +97,20 @@ def run(demo: bool = False, headless: bool = False) -> int:
         return 3
 
     try:
+        _start_backup_scheduler()
+    except Exception:  # noqa: BLE001 - scheduler tidak boleh blokir app
+        log.exception("Gagal start backup scheduler (lanjut tanpa backup terjadwal)")
+
+    try:
         return run_login_then_main()
     except Exception:  # pragma: no cover
         log.exception("Aplikasi crash")
         traceback.print_exc()
         return 1
+    finally:
+        try:
+            from perpustakaan.services.backup_scheduler import get_scheduler
+
+            get_scheduler().stop(timeout=1.0)
+        except Exception:  # noqa: BLE001
+            log.warning("Gagal stop backup scheduler", exc_info=True)

--- a/src/perpustakaan/config.py
+++ b/src/perpustakaan/config.py
@@ -16,7 +16,7 @@ from typing import Final
 
 APP_NAME: Final = "PerpustakaanOffline"
 APP_DISPLAY_NAME: Final = "Perpustakaan Offline"
-APP_VERSION: Final = "0.3.0"
+APP_VERSION: Final = "0.4.0"
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +107,20 @@ DEFAULT_SETTINGS: Final[dict[str, str]] = {
     "sync.last_export_at": "",
     "sync.spreadsheet_id": "",
     "app.first_run": "1",
+    # Backup terjadwal — schedule = "off" | "daily" | "weekly".
+    # weekday: 0=Senin, 1=Selasa, ..., 6=Minggu (hanya dipakai saat schedule=weekly).
+    # folder kosong = pakai BACKUPS_DIR default.
+    "backup.schedule": "off",
+    "backup.time": "02:00",
+    "backup.weekday": "0",
+    "backup.folder": "",
+    "backup.retention": "7",
+    "backup.last_run_at": "",
+    "backup.last_run_status": "",
+    "backup.last_run_path": "",
+    "backup.last_run_error": "",
+    # Tutorial / guided tour. "1" = sudah selesai, kosong = belum.
+    "tutorial.completed": "",
 }
 
 

--- a/src/perpustakaan/gui/main_window.py
+++ b/src/perpustakaan/gui/main_window.py
@@ -16,7 +16,11 @@ from perpustakaan.gui.views.peminjaman_view import PeminjamanView
 from perpustakaan.gui.views.pengembalian_view import PengembalianView
 from perpustakaan.gui.views.settings_view import SettingsView
 from perpustakaan.i18n import t
+from perpustakaan.models import settings as settings_repo
 from perpustakaan.services.auth import SessionUser
+from perpustakaan.services.backup_scheduler import get_scheduler
+
+_THEME_KEYS = ("system", "light", "dark")
 
 
 class MainWindow(ctk.CTk):
@@ -48,7 +52,94 @@ class MainWindow(ctk.CTk):
         self._buttons: dict[str, ctk.CTkButton] = {}
         self._build_sidebar()
         self._build_views()
+        self._build_theme_toggle()
         self.show("dashboard")
+
+        # Hubungkan callback scheduler -> toast (marshal ke main thread).
+        with contextlib.suppress(Exception):
+            get_scheduler().set_callback(self._on_scheduled_backup)
+
+        # Auto-launch tutorial di first-run (kalau user belum pernah selesai).
+        with contextlib.suppress(Exception):
+            self.after(800, self._maybe_autostart_tour)
+
+    # ------------------------------------------------------------------
+    # Theme toggle (selalu visible di pojok kanan-atas, terlepas dari menu)
+    # ------------------------------------------------------------------
+    def _build_theme_toggle(self) -> None:
+        cur_theme = (settings_repo.get_value("ui.theme") or "system").lower()
+        if cur_theme not in _THEME_KEYS:
+            cur_theme = "system"
+        labels = [t(f"theme.{k}") for k in _THEME_KEYS]
+        self._theme_var = ctk.StringVar(value=t(f"theme.{cur_theme}"))
+        self._theme_btn = ctk.CTkSegmentedButton(
+            self.content,
+            values=labels,
+            variable=self._theme_var,
+            command=self._on_theme_changed,
+            font=ctk.CTkFont(size=12, weight="bold"),
+        )
+        # Anchor ke pojok kanan-atas content area.
+        self._theme_btn.place(relx=1.0, rely=0.0, x=-16, y=12, anchor="ne")
+        # Re-raise tiap kali user berpindah view supaya tetap di atas.
+        self._theme_btn.lift()
+
+    def _label_to_theme_key(self, label: str) -> str:
+        for k in _THEME_KEYS:
+            if t(f"theme.{k}") == label:
+                return k
+        return "system"
+
+    def _on_theme_changed(self, label: str) -> None:
+        key = self._label_to_theme_key(label)
+        color = settings_repo.get_value("ui.color_theme", "blue") or "blue"
+        with contextlib.suppress(Exception):
+            widgets.configure_theme(key, color)
+        with contextlib.suppress(Exception):
+            settings_repo.set_value("ui.theme", key)
+        with contextlib.suppress(Exception):
+            widgets.show_toast(self, t("theme.applied"), kind="success", duration_ms=2000)
+
+    # ------------------------------------------------------------------
+    # Tour
+    # ------------------------------------------------------------------
+    def _maybe_autostart_tour(self) -> None:
+        completed = (settings_repo.get_value("tutorial.completed") or "").strip()
+        if completed != "1":
+            self.start_tour()
+
+    def start_tour(self) -> None:
+        from perpustakaan.gui.tour import TourManager, build_default_steps
+
+        steps = build_default_steps(self)
+        TourManager(self, steps).start()
+
+    def _on_scheduled_backup(self, result: dict) -> None:
+        """Dipanggil dari worker thread saat backup terjadwal selesai."""
+        def _show() -> None:
+            with contextlib.suppress(Exception):
+                if result.get("status") == "success":
+                    name = ""
+                    path = result.get("path", "")
+                    if path:
+                        from pathlib import Path
+
+                        name = Path(path).name
+                    msg = (
+                        t("backup.toast.success", name=name)
+                        if name
+                        else t("backup.toast.success_noname")
+                    )
+                    widgets.show_toast(self, msg, kind="success", duration_ms=4500)
+                else:
+                    widgets.show_toast(
+                        self,
+                        t("backup.toast.failed", error=result.get("error", "")),
+                        kind="error",
+                        duration_ms=6000,
+                    )
+        with contextlib.suppress(Exception):
+            self.after(0, _show)
 
     # ------------------------------------------------------------------
     # Sidebar
@@ -164,9 +255,18 @@ class MainWindow(ctk.CTk):
                 btn.configure(fg_color=("#dbeafe", "#1e3a8a"))
             else:
                 btn.configure(fg_color="transparent")
+        # Pastikan theme toggle tetap di atas setelah view di-raise.
+        with contextlib.suppress(Exception):
+            self._theme_btn.lift()
 
     # ------------------------------------------------------------------
     def _do_logout(self) -> None:
         if widgets.confirm(self, t("toast.confirm_logout")):
             self.logout_requested = True
             self.destroy()
+
+    def destroy(self) -> None:
+        # Lepas callback supaya scheduler tidak panggil widget yang sudah hancur.
+        with contextlib.suppress(Exception):
+            get_scheduler().set_callback(None)
+        super().destroy()

--- a/src/perpustakaan/gui/tour.py
+++ b/src/perpustakaan/gui/tour.py
@@ -1,0 +1,362 @@
+"""Guided tour / onboarding tooltip overlay.
+
+Implementasi sederhana dari "product tour" yang sering dipakai aplikasi
+modern: rangkaian popup nempel di widget, dengan tombol Skip / Sebelumnya
+/ Berikutnya / Selesai.
+
+Pemakaian normal lewat ``MainWindow.start_tour()`` — instans
+:class:`TourManager` dibuat dari :func:`build_default_steps`.
+
+Kontrak target widget:
+- Setiap step boleh punya ``target_resolver`` yang return widget atau
+  ``None``. Kalau ``None`` (mis. step pembuka), popup ditampilkan di
+  tengah window — tanpa highlight.
+- ``before_show`` opsional dipanggil sebelum popup muncul (mis. untuk
+  pindah ke menu yang relevan dulu).
+"""
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import customtkinter as ctk
+
+from perpustakaan.i18n import t
+from perpustakaan.models import settings as settings_repo
+
+WidgetResolver = Callable[[], Any]
+PreShowHook = Callable[[], None]
+
+
+@dataclass(frozen=True)
+class TourStep:
+    """Satu langkah tutorial."""
+
+    key: str
+    title_key: str
+    body_key: str
+    target_resolver: WidgetResolver | None = None
+    placement: str = "right"  # right | left | top | bottom | center
+    before_show: PreShowHook | None = None
+
+
+def build_default_steps(main_window: Any) -> list[TourStep]:
+    """Daftar step default — sidebar + theme toggle + closing."""
+
+    def sidebar(key: str) -> WidgetResolver:
+        def _resolver() -> Any:
+            return main_window._buttons.get(key)
+
+        return _resolver
+
+    def show_view(key: str) -> PreShowHook:
+        def _hook() -> None:
+            with contextlib.suppress(Exception):
+                main_window.show(key)
+
+        return _hook
+
+    def theme_btn() -> Any:
+        return getattr(main_window, "_theme_btn", None)
+
+    return [
+        TourStep(
+            key="welcome",
+            title_key="tour.welcome.title",
+            body_key="tour.welcome.body",
+            placement="center",
+        ),
+        TourStep(
+            key="dashboard",
+            title_key="tour.dashboard.title",
+            body_key="tour.dashboard.body",
+            target_resolver=sidebar("dashboard"),
+            placement="right",
+            before_show=show_view("dashboard"),
+        ),
+        TourStep(
+            key="anggota",
+            title_key="tour.anggota.title",
+            body_key="tour.anggota.body",
+            target_resolver=sidebar("anggota"),
+            placement="right",
+            before_show=show_view("anggota"),
+        ),
+        TourStep(
+            key="buku",
+            title_key="tour.buku.title",
+            body_key="tour.buku.body",
+            target_resolver=sidebar("buku"),
+            placement="right",
+            before_show=show_view("buku"),
+        ),
+        TourStep(
+            key="peminjaman",
+            title_key="tour.peminjaman.title",
+            body_key="tour.peminjaman.body",
+            target_resolver=sidebar("peminjaman"),
+            placement="right",
+            before_show=show_view("peminjaman"),
+        ),
+        TourStep(
+            key="pengembalian",
+            title_key="tour.pengembalian.title",
+            body_key="tour.pengembalian.body",
+            target_resolver=sidebar("pengembalian"),
+            placement="right",
+            before_show=show_view("pengembalian"),
+        ),
+        TourStep(
+            key="laporan",
+            title_key="tour.laporan.title",
+            body_key="tour.laporan.body",
+            target_resolver=sidebar("laporan"),
+            placement="right",
+            before_show=show_view("laporan"),
+        ),
+        TourStep(
+            key="setting",
+            title_key="tour.setting.title",
+            body_key="tour.setting.body",
+            target_resolver=sidebar("setting"),
+            placement="right",
+            before_show=show_view("setting"),
+        ),
+        TourStep(
+            key="theme",
+            title_key="tour.theme.title",
+            body_key="tour.theme.body",
+            target_resolver=theme_btn,
+            placement="bottom",
+        ),
+        TourStep(
+            key="done",
+            title_key="tour.done.title",
+            body_key="tour.done.body",
+            placement="center",
+        ),
+    ]
+
+
+class TourPopup(ctk.CTkToplevel):
+    """Popup tooltip kecil untuk satu step tour."""
+
+    _MARGIN = 12  # px jarak dari widget target
+    _MAX_WIDTH = 380
+
+    def __init__(
+        self,
+        master: ctk.CTk,
+        *,
+        title: str,
+        body: str,
+        progress_text: str,
+        is_first: bool,
+        is_last: bool,
+        on_skip: Callable[[], None],
+        on_prev: Callable[[], None],
+        on_next: Callable[[], None],
+    ) -> None:
+        super().__init__(master)
+        self.title(title)
+        # Tanpa decoration window manager — tampilan tooltip yang clean.
+        with contextlib.suppress(Exception):
+            self.overrideredirect(True)
+        self.attributes("-topmost", True)
+        self.transient(master)
+        self.configure(fg_color=("#ffffff", "#1f2937"))
+
+        # Header: judul + step counter
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.pack(fill="x", padx=14, pady=(12, 4))
+        ctk.CTkLabel(
+            header, text=title,
+            font=ctk.CTkFont(size=14, weight="bold"),
+            anchor="w",
+        ).pack(side="left", fill="x", expand=True)
+        ctk.CTkLabel(
+            header, text=progress_text,
+            font=ctk.CTkFont(size=10),
+            text_color=("#6b7280", "#9ca3af"),
+        ).pack(side="right")
+
+        # Body
+        body_label = ctk.CTkLabel(
+            self,
+            text=body,
+            wraplength=self._MAX_WIDTH - 32,
+            justify="left",
+            anchor="w",
+            text_color=("#1f2937", "#e5e7eb"),
+        )
+        body_label.pack(fill="x", padx=14, pady=(4, 12))
+
+        # Footer: Skip kiri, Prev/Next kanan
+        footer = ctk.CTkFrame(self, fg_color="transparent")
+        footer.pack(fill="x", padx=14, pady=(0, 12))
+        ctk.CTkButton(
+            footer, text=t("tour.button.skip"),
+            command=on_skip, width=80,
+            fg_color="transparent", border_width=1,
+        ).pack(side="left")
+        next_label = t("tour.button.finish") if is_last else t("tour.button.next")
+        ctk.CTkButton(footer, text=next_label, command=on_next, width=110).pack(
+            side="right", padx=(4, 0)
+        )
+        if not is_first:
+            ctk.CTkButton(
+                footer, text=t("tour.button.prev"),
+                command=on_prev, width=110,
+                fg_color="transparent", border_width=1,
+            ).pack(side="right", padx=(4, 0))
+
+        # Force layout & set size sesuai requested.
+        self.update_idletasks()
+
+
+class TourManager:
+    """Orkestrasi seluruh tour."""
+
+    def __init__(self, main_window: Any, steps: list[TourStep]) -> None:
+        self.main_window = main_window
+        self.steps = list(steps)
+        self._index = 0
+        self._popup: TourPopup | None = None
+
+    @property
+    def current_index(self) -> int:
+        return self._index
+
+    @property
+    def current_step(self) -> TourStep | None:
+        if 0 <= self._index < len(self.steps):
+            return self.steps[self._index]
+        return None
+
+    def start(self) -> None:
+        if not self.steps:
+            return
+        self._index = 0
+        self._render()
+
+    def _close_popup(self) -> None:
+        if self._popup is not None:
+            with contextlib.suppress(Exception):
+                self._popup.destroy()
+            self._popup = None
+
+    def _next(self) -> None:
+        if self._index >= len(self.steps) - 1:
+            self._finish()
+            return
+        self._index += 1
+        self._render()
+
+    def _prev(self) -> None:
+        if self._index <= 0:
+            return
+        self._index -= 1
+        self._render()
+
+    def _skip(self) -> None:
+        self._close_popup()
+        # Tetap mark completed supaya tutorial tidak auto-muncul lagi.
+        with contextlib.suppress(Exception):
+            settings_repo.set_value("tutorial.completed", "1")
+
+    def _finish(self) -> None:
+        self._close_popup()
+        with contextlib.suppress(Exception):
+            settings_repo.set_value("tutorial.completed", "1")
+
+    def _render(self) -> None:
+        step = self.current_step
+        if step is None:
+            self._finish()
+            return
+        if step.before_show is not None:
+            with contextlib.suppress(Exception):
+                step.before_show()
+        # Beri Tk waktu menggambar view yang baru di-raise sebelum popup.
+        with contextlib.suppress(Exception):
+            self.main_window.update_idletasks()
+
+        target = None
+        if step.target_resolver is not None:
+            with contextlib.suppress(Exception):
+                target = step.target_resolver()
+
+        self._close_popup()
+        self._popup = TourPopup(
+            self.main_window,
+            title=t(step.title_key),
+            body=t(step.body_key),
+            progress_text=t(
+                "tour.progress",
+                current=self._index + 1,
+                total=len(self.steps),
+            ),
+            is_first=(self._index == 0),
+            is_last=(self._index == len(self.steps) - 1),
+            on_skip=self._skip,
+            on_prev=self._prev,
+            on_next=self._next,
+        )
+        # Posisikan setelah popup di-render (butuh ukuran).
+        self._position_popup(target, step.placement)
+
+    def _position_popup(self, target: Any, placement: str) -> None:
+        if self._popup is None:
+            return
+        popup = self._popup
+        with contextlib.suppress(Exception):
+            popup.update_idletasks()
+        win = self.main_window
+        with contextlib.suppress(Exception):
+            win.update_idletasks()
+
+        try:
+            popup_w = popup.winfo_reqwidth() or 380
+            popup_h = popup.winfo_reqheight() or 160
+        except Exception:  # noqa: BLE001
+            popup_w, popup_h = 380, 160
+        try:
+            win_x = win.winfo_rootx()
+            win_y = win.winfo_rooty()
+            win_w = win.winfo_width()
+            win_h = win.winfo_height()
+        except Exception:  # noqa: BLE001
+            win_x, win_y, win_w, win_h = 100, 100, 1100, 700
+
+        x = win_x + win_w // 2 - popup_w // 2
+        y = win_y + win_h // 2 - popup_h // 2
+
+        if target is not None and placement != "center":
+            try:
+                tx = target.winfo_rootx()
+                ty = target.winfo_rooty()
+                tw = target.winfo_width()
+                th = target.winfo_height()
+            except Exception:  # noqa: BLE001
+                tx = ty = tw = th = 0
+            margin = TourPopup._MARGIN
+            if placement == "right":
+                x = tx + tw + margin
+                y = ty + th // 2 - popup_h // 2
+            elif placement == "left":
+                x = tx - popup_w - margin
+                y = ty + th // 2 - popup_h // 2
+            elif placement == "top":
+                x = tx + tw // 2 - popup_w // 2
+                y = ty - popup_h - margin
+            elif placement == "bottom":
+                x = tx + tw // 2 - popup_w // 2
+                y = ty + th + margin
+
+        # Clamp ke dalam window utama.
+        x = max(win_x + 8, min(x, win_x + win_w - popup_w - 8))
+        y = max(win_y + 8, min(y, win_y + win_h - popup_h - 8))
+        with contextlib.suppress(Exception):
+            popup.geometry(f"{popup_w}x{popup_h}+{x}+{y}")

--- a/src/perpustakaan/gui/views/settings_view.py
+++ b/src/perpustakaan/gui/views/settings_view.py
@@ -1,7 +1,10 @@
-"""View Setting: identitas, KTA, transaksi, akun, bahasa/tema, sync."""
+"""View Setting: identitas, KTA, transaksi, akun, bahasa/tema, sync, backup."""
 from __future__ import annotations
 
 import contextlib
+import os
+import sys
+from pathlib import Path
 from tkinter import filedialog
 
 import customtkinter as ctk
@@ -14,6 +17,15 @@ from perpustakaan.models import audit_log as audit_log_repo
 from perpustakaan.models import buku as buku_repo
 from perpustakaan.models import settings as settings_repo
 from perpustakaan.services import auth as auth_service
+from perpustakaan.services import backup_service
+from perpustakaan.services.backup_scheduler import (
+    SCHEDULE_DAILY,
+    SCHEDULE_OFF,
+    SCHEDULE_WEEKLY,
+    BackupConfig,
+    compute_next_run,
+    get_scheduler,
+)
 
 
 class SettingsView(ctk.CTkFrame):
@@ -34,6 +46,7 @@ class SettingsView(ctk.CTkFrame):
         self.tabs.add(t("menu.setting.akun"))
         self.tabs.add(t("menu.setting.bahasa"))
         self.tabs.add(t("menu.setting.sync"))
+        self.tabs.add(t("backup.tab.title"))
         self.tabs.add("Tools")
         self.tabs.add("Audit Log")
 
@@ -43,6 +56,7 @@ class SettingsView(ctk.CTkFrame):
         self._build_akun(self.tabs.tab(t("menu.setting.akun")))
         self._build_bahasa(self.tabs.tab(t("menu.setting.bahasa")))
         self._build_sync(self.tabs.tab(t("menu.setting.sync")))
+        self._build_backup(self.tabs.tab(t("backup.tab.title")))
         self._build_tools(self.tabs.tab("Tools"))
         self._build_audit_log(self.tabs.tab("Audit Log"))
 
@@ -53,6 +67,7 @@ class SettingsView(ctk.CTkFrame):
         self._reload_akun()
         self._load_bahasa()
         self._load_sync()
+        self._load_backup()
         self._reload_tools()
         self._reload_audit_log()
 
@@ -237,6 +252,22 @@ class SettingsView(ctk.CTkFrame):
             row=3, column=1, padx=4, pady=12, sticky="e"
         )
 
+        # Tutorial restart
+        ctk.CTkLabel(
+            wrap, text=t("tour.restart.help"), wraplength=520, justify="left",
+            text_color=("#6b7280", "#9ca3af"),
+        ).grid(row=4, column=0, columnspan=2, padx=4, pady=(16, 2), sticky="w")
+        ctk.CTkButton(
+            wrap, text=t("tour.restart"), command=self._restart_tour,
+        ).grid(row=5, column=0, columnspan=2, padx=4, pady=(2, 12), sticky="w")
+
+    def _restart_tour(self) -> None:
+        # Reset flag completed lalu mulai tour ulang.
+        with contextlib.suppress(Exception):
+            settings_repo.set_value("tutorial.completed", "")
+        with contextlib.suppress(Exception):
+            self.app.start_tour()
+
     def _load_bahasa(self) -> None:
         cur_locale = settings_repo.get_value("ui.locale", "id") or "id"
         self.bahasa_menu.set(f"{cur_locale} — {LOCALE_NAMES.get(cur_locale, cur_locale)}")
@@ -329,6 +360,281 @@ class SettingsView(ctk.CTkFrame):
             self._load_sync()
         except Exception as e:
             self.sync_result.configure(text=f"Error: {e}", text_color="#ef4444")
+
+    # ------------------ Backup Terjadwal ------------------
+    _FREQ_OPTIONS = (SCHEDULE_OFF, SCHEDULE_DAILY, SCHEDULE_WEEKLY)
+
+    def _freq_label(self, key: str) -> str:
+        return {
+            SCHEDULE_OFF: t("backup.freq.off"),
+            SCHEDULE_DAILY: t("backup.freq.daily"),
+            SCHEDULE_WEEKLY: t("backup.freq.weekly"),
+        }.get(key, key)
+
+    def _freq_key(self, label: str) -> str:
+        for k in self._FREQ_OPTIONS:
+            if self._freq_label(k) == label:
+                return k
+        return SCHEDULE_OFF
+
+    def _weekday_label(self, idx: int) -> str:
+        return t(f"backup.weekday.{idx}")
+
+    def _weekday_idx(self, label: str) -> int:
+        for i in range(7):
+            if self._weekday_label(i) == label:
+                return i
+        return 0
+
+    @staticmethod
+    def _fmt_size(size_bytes: int) -> str:
+        size = float(size_bytes)
+        for unit in ("B", "KB", "MB", "GB"):
+            if size < 1024:
+                return f"{size:,.1f} {unit}" if unit != "B" else f"{int(size)} {unit}"
+            size /= 1024
+        return f"{size:,.1f} TB"
+
+    def _build_backup(self, parent) -> None:
+        wrap = ctk.CTkScrollableFrame(parent)
+        wrap.pack(fill="both", expand=True, padx=10, pady=10)
+
+        ctk.CTkLabel(
+            wrap, text=t("backup.help"), wraplength=720, justify="left",
+            text_color=("#374151", "#d1d5db"),
+        ).pack(anchor="w", pady=(4, 12))
+
+        # Frekuensi
+        row = ctk.CTkFrame(wrap, fg_color="transparent")
+        row.pack(fill="x", padx=4, pady=4)
+        ctk.CTkLabel(row, text=t("backup.frequency") + ":", width=180, anchor="w").pack(side="left")
+        self.backup_freq_menu = ctk.CTkOptionMenu(
+            row,
+            values=[self._freq_label(k) for k in self._FREQ_OPTIONS],
+            command=lambda _v: self._update_backup_visibility(),
+            width=200,
+        )
+        self.backup_freq_menu.pack(side="left", padx=4)
+
+        # Jam (HH:MM)
+        row = ctk.CTkFrame(wrap, fg_color="transparent")
+        row.pack(fill="x", padx=4, pady=4)
+        ctk.CTkLabel(row, text=t("backup.time") + ":", width=180, anchor="w").pack(side="left")
+        self.backup_time_entry = ctk.CTkEntry(row, width=120, placeholder_text="02:00")
+        self.backup_time_entry.pack(side="left", padx=4)
+
+        # Hari (weekly)
+        self.backup_weekday_row = ctk.CTkFrame(wrap, fg_color="transparent")
+        self.backup_weekday_row.pack(fill="x", padx=4, pady=4)
+        ctk.CTkLabel(
+            self.backup_weekday_row, text=t("backup.weekday") + ":", width=180, anchor="w",
+        ).pack(side="left")
+        self.backup_weekday_menu = ctk.CTkOptionMenu(
+            self.backup_weekday_row,
+            values=[self._weekday_label(i) for i in range(7)],
+            width=200,
+        )
+        self.backup_weekday_menu.pack(side="left", padx=4)
+
+        # Folder tujuan
+        row = ctk.CTkFrame(wrap, fg_color="transparent")
+        row.pack(fill="x", padx=4, pady=4)
+        ctk.CTkLabel(row, text=t("backup.folder") + ":", width=180, anchor="w").pack(side="left")
+        self.backup_folder_entry = ctk.CTkEntry(row, width=380)
+        self.backup_folder_entry.pack(side="left", padx=4)
+        ctk.CTkButton(
+            row, text="…", width=32, command=self._pick_backup_folder,
+        ).pack(side="left", padx=2)
+        ctk.CTkLabel(
+            wrap, text=t("backup.folder.default"),
+            text_color=("#6b7280", "#9ca3af"), font=ctk.CTkFont(size=11),
+        ).pack(anchor="w", padx=(184, 4), pady=(0, 4))
+
+        # Retensi
+        row = ctk.CTkFrame(wrap, fg_color="transparent")
+        row.pack(fill="x", padx=4, pady=4)
+        ctk.CTkLabel(row, text=t("backup.retention") + ":", width=180, anchor="w").pack(side="left")
+        self.backup_retention_entry = ctk.CTkEntry(row, width=80, placeholder_text="7")
+        self.backup_retention_entry.pack(side="left", padx=4)
+
+        # Tombol Simpan + Backup Sekarang
+        btnrow = ctk.CTkFrame(wrap, fg_color="transparent")
+        btnrow.pack(fill="x", padx=4, pady=12)
+        ctk.CTkButton(
+            btnrow, text=t("backup.button.save"),
+            command=self._save_backup, width=180,
+        ).pack(side="left", padx=2)
+        ctk.CTkButton(
+            btnrow, text=t("backup.button.now"),
+            command=self._do_backup_now, width=180,
+            fg_color="#10b981", hover_color="#059669",
+        ).pack(side="left", padx=2)
+        ctk.CTkButton(
+            btnrow, text=t("backup.button.open_folder"),
+            command=self._open_backup_folder, width=140,
+            fg_color="transparent", border_width=1,
+        ).pack(side="left", padx=2)
+
+        # Status terakhir + jadwal berikutnya
+        self.backup_last_label = ctk.CTkLabel(
+            wrap, text="", anchor="w", justify="left",
+        )
+        self.backup_last_label.pack(anchor="w", padx=4, pady=(2, 0))
+        self.backup_next_label = ctk.CTkLabel(
+            wrap, text="", anchor="w", justify="left",
+            text_color=("#6b7280", "#9ca3af"),
+        )
+        self.backup_next_label.pack(anchor="w", padx=4, pady=(0, 8))
+
+        # Daftar backup tersimpan
+        ctk.CTkLabel(
+            wrap, text=t("backup.list.title"),
+            font=ctk.CTkFont(size=13, weight="bold"),
+        ).pack(anchor="w", padx=4, pady=(8, 2))
+        self.backup_table = StyledTreeview(
+            wrap,
+            columns=[
+                ("name", t("backup.col.name"), 280),
+                ("size", t("backup.col.size"), 100),
+                ("mtime", t("backup.col.mtime"), 160),
+            ],
+            height=8,
+        )
+        self.backup_table.pack(fill="x", padx=4, pady=2)
+
+    def _update_backup_visibility(self) -> None:
+        freq_key = self._freq_key(self.backup_freq_menu.get())
+        if freq_key == SCHEDULE_WEEKLY:
+            if not self.backup_weekday_row.winfo_ismapped():
+                self.backup_weekday_row.pack(fill="x", padx=4, pady=4, before=self.backup_folder_entry.master)
+        else:
+            with contextlib.suppress(Exception):
+                self.backup_weekday_row.pack_forget()
+
+    def _load_backup(self) -> None:
+        cfg = BackupConfig.from_settings()
+        self.backup_freq_menu.set(self._freq_label(cfg.schedule))
+        self.backup_time_entry.delete(0, "end")
+        self.backup_time_entry.insert(0, f"{cfg.hour:02d}:{cfg.minute:02d}")
+        self.backup_weekday_menu.set(self._weekday_label(cfg.weekday))
+        self.backup_folder_entry.delete(0, "end")
+        self.backup_folder_entry.insert(0, cfg.folder)
+        self.backup_retention_entry.delete(0, "end")
+        self.backup_retention_entry.insert(0, str(cfg.retention))
+        self._update_backup_visibility()
+        self._refresh_backup_status(cfg)
+        self._refresh_backup_list(cfg)
+
+    def _refresh_backup_status(self, cfg: BackupConfig | None = None) -> None:
+        cfg = cfg or BackupConfig.from_settings()
+        last_at = settings_repo.get_value("backup.last_run_at") or ""
+        last_status = settings_repo.get_value("backup.last_run_status") or ""
+        if last_at:
+            status_label = (
+                t("backup.status.success") if last_status == "success"
+                else t("backup.status.failed")
+            )
+            self.backup_last_label.configure(
+                text=f"{t('backup.last_run')}: {last_at} — {status_label}",
+            )
+        else:
+            self.backup_last_label.configure(
+                text=f"{t('backup.last_run')}: {t('backup.never')}",
+            )
+        nxt = compute_next_run(cfg)
+        if nxt is None:
+            self.backup_next_label.configure(text=f"{t('backup.next_run')}: —")
+        else:
+            self.backup_next_label.configure(
+                text=f"{t('backup.next_run')}: {nxt.strftime('%Y-%m-%d %H:%M')}",
+            )
+
+    def _refresh_backup_list(self, cfg: BackupConfig | None = None) -> None:
+        cfg = cfg or BackupConfig.from_settings()
+        try:
+            rows = backup_service.list_backups(cfg.folder or None)
+        except Exception:  # noqa: BLE001
+            rows = []
+        display = [
+            {
+                "name": r["name"],
+                "size": self._fmt_size(r["size_bytes"]),
+                "mtime": r["mtime_str"],
+            }
+            for r in rows
+        ]
+        self.backup_table.set_rows(display)
+
+    def _pick_backup_folder(self) -> None:
+        path = filedialog.askdirectory(title=t("backup.folder"))
+        if path:
+            self.backup_folder_entry.delete(0, "end")
+            self.backup_folder_entry.insert(0, path)
+
+    def _open_backup_folder(self) -> None:
+        cfg = BackupConfig.from_settings()
+        folder = backup_service.resolve_backup_folder(cfg.folder or None)
+        with contextlib.suppress(OSError):
+            folder.mkdir(parents=True, exist_ok=True)
+        _open_path(folder)
+
+    def _save_backup(self) -> None:
+        time_str = self.backup_time_entry.get().strip()
+        try:
+            hh_str, mm_str = time_str.split(":", 1)
+            hh = int(hh_str)
+            mm = int(mm_str)
+            if not (0 <= hh <= 23 and 0 <= mm <= 59):
+                raise ValueError
+        except ValueError:
+            widgets.show_toast(self, t("backup.invalid_time"), kind="warning")
+            return
+        try:
+            retention = max(0, int(self.backup_retention_entry.get().strip() or "0"))
+        except ValueError:
+            retention = 7
+
+        freq_key = self._freq_key(self.backup_freq_menu.get())
+        weekday = self._weekday_idx(self.backup_weekday_menu.get())
+        folder = self.backup_folder_entry.get().strip()
+
+        settings_repo.set_many(
+            {
+                "backup.schedule": freq_key,
+                "backup.time": f"{hh:02d}:{mm:02d}",
+                "backup.weekday": str(weekday),
+                "backup.folder": folder,
+                "backup.retention": str(retention),
+            }
+        )
+        with contextlib.suppress(Exception):
+            get_scheduler().reload()
+        widgets.show_toast(self, t("toast.saved"), kind="success")
+        self._refresh_backup_status()
+
+    def _do_backup_now(self) -> None:
+        try:
+            user = auth_service.current_user()
+            uid = user.id if user else None
+            result = get_scheduler().trigger_now(user_id=uid)
+        except Exception as exc:  # noqa: BLE001
+            widgets.report_exception(self, exc, "Gagal backup", use_modal=True)
+            return
+        if result.get("status") == "success":
+            name = Path(result.get("path", "")).name or ""
+            msg = (
+                t("backup.toast.success", name=name)
+                if name
+                else t("backup.toast.success_noname")
+            )
+            widgets.show_toast(self, msg, kind="success", duration_ms=4500)
+        else:
+            widgets.show_toast(
+                self, t("backup.toast.failed", error=result.get("error", "")),
+                kind="error", duration_ms=6000,
+            )
+        self._refresh_backup_status()
+        self._refresh_backup_list()
 
     # ------------------ Tools (Cek Data Ganda) ------------------
     def _build_tools(self, parent) -> None:
@@ -545,3 +851,20 @@ class ChangePasswordDialog(ctk.CTkToplevel):
                 "password_too_short": "Password baru minimal 6 karakter.",
             }
             self.message.configure(text=mapping.get(str(e), str(e)))
+
+
+def _open_path(path) -> None:
+    """Buka folder di file manager native (cross-platform)."""
+    import logging as _logging
+    try:
+        target = str(path)
+        if sys.platform.startswith("win"):
+            os.startfile(target)  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            os.system(f"open \"{target}\"")
+        else:
+            os.system(f"xdg-open \"{target}\"")
+    except Exception as exc:  # noqa: BLE001
+        _logging.getLogger("perpustakaan.gui").warning(
+            "Gagal buka folder %s: %s", path, exc
+        )

--- a/src/perpustakaan/i18n.py
+++ b/src/perpustakaan/i18n.py
@@ -176,6 +176,207 @@ _STRINGS: Final[dict[str, dict[str, str]]] = {
             "authorization."
         ),
     },
+    # ----------------------------- theme toggle ----------------------------
+    "theme.system": {"id": "Sistem", "en": "System"},
+    "theme.light": {"id": "Terang", "en": "Light"},
+    "theme.dark": {"id": "Gelap", "en": "Dark"},
+    "theme.applied": {"id": "Tema diterapkan.", "en": "Theme applied."},
+    # ----------------------------- tutorial / guided tour ------------------
+    "tour.welcome.title": {
+        "id": "Selamat datang di Perpustakaan Offline!",
+        "en": "Welcome to Library Offline!",
+    },
+    "tour.welcome.body": {
+        "id": (
+            "Tutorial singkat ini akan menjelaskan menu utama dan tombol "
+            "penting. Klik 'Berikutnya' untuk lanjut, atau 'Lewati' untuk "
+            "menutup tutorial. Kamu bisa mengulang tutorial ini kapan saja "
+            "dari Setting → Bahasa & Tema."
+        ),
+        "en": (
+            "This short tour will walk you through the main menus and key "
+            "buttons. Click 'Next' to continue or 'Skip' to dismiss. You can "
+            "replay this tour anytime from Settings → Language & Theme."
+        ),
+    },
+    "tour.dashboard.title": {"id": "Menu Dashboard", "en": "Dashboard"},
+    "tour.dashboard.body": {
+        "id": "Ringkasan harian: total anggota, buku, peminjaman aktif, terlambat, dan kunjungan hari ini.",
+        "en": "Daily summary: total members, books, active loans, overdue, and visits today.",
+    },
+    "tour.anggota.title": {"id": "Data Anggota", "en": "Members"},
+    "tour.anggota.body": {
+        "id": (
+            "Kelola data anggota: tambah, edit, hapus, import Excel, cetak "
+            "kartu (KTA). Tombol 'Naik Kelas' di toolbar memindahkan kelas "
+            "siswa secara batch. 'Surat Bebas Pustaka' mencetak surat keterangan "
+            "untuk anggota yang sudah lunas."
+        ),
+        "en": (
+            "Manage member data: add, edit, delete, import Excel, print member "
+            "cards (KTA). The 'Promote Class' toolbar button moves students to "
+            "a new class in batch. 'Library Clearance Letter' prints clearance "
+            "letters for cleared members."
+        ),
+    },
+    "tour.buku.title": {"id": "Data Buku", "en": "Books"},
+    "tour.buku.body": {
+        "id": (
+            "Kelola koleksi buku: input judul, ISBN, klasifikasi DDC, jumlah "
+            "eksemplar. Cetak label & barcode tiap eksemplar. Tombol 'Transfer "
+            "Penerbit' membantu menyatukan data ganda akibat penulisan penerbit "
+            "yang beda-beda."
+        ),
+        "en": (
+            "Manage your book collection: title, ISBN, DDC classification, "
+            "number of copies. Print labels and barcodes per copy. The "
+            "'Transfer Publishers' button helps unify duplicate publisher "
+            "spellings."
+        ),
+    },
+    "tour.peminjaman.title": {"id": "Peminjaman", "en": "Borrow"},
+    "tour.peminjaman.body": {
+        "id": (
+            "Catat peminjaman buku: scan barcode atau pilih manual, atur "
+            "jatuh tempo, dan langsung cetak nota peminjaman PDF."
+        ),
+        "en": (
+            "Record book loans: scan barcode or pick manually, set the due "
+            "date, and instantly print a borrow receipt PDF."
+        ),
+    },
+    "tour.pengembalian.title": {"id": "Pengembalian", "en": "Return"},
+    "tour.pengembalian.body": {
+        "id": (
+            "Proses pengembalian dengan denda otomatis kalau terlambat. "
+            "Setelah simpan, nota pengembalian PDF langsung tersedia."
+        ),
+        "en": (
+            "Process returns with automatic late fines. After saving, the "
+            "return receipt PDF is ready for printing."
+        ),
+    },
+    "tour.laporan.title": {"id": "Laporan", "en": "Reports"},
+    "tour.laporan.body": {
+        "id": (
+            "Backup database manual, ekspor semua data ke Excel, lihat grafik "
+            "kunjungan tahunan/bulanan, top peminjam, top buku, dan laporan "
+            "kas."
+        ),
+        "en": (
+            "Manual database backup, export everything to Excel, view yearly/"
+            "monthly visit charts, top borrowers, top books, and cash reports."
+        ),
+    },
+    "tour.setting.title": {"id": "Setting", "en": "Settings"},
+    "tour.setting.body": {
+        "id": (
+            "Identitas perpustakaan, kartu anggota, parameter transaksi (lama "
+            "pinjam, denda), manajemen akun, bahasa & tema, sync Google Sheets, "
+            "Backup Terjadwal, Cek Data Ganda, dan Audit Log."
+        ),
+        "en": (
+            "Library identity, member card, transaction parameters (loan "
+            "duration, fines), account management, language & theme, Google "
+            "Sheets sync, Scheduled Backup, Duplicate Check, and Audit Log."
+        ),
+    },
+    "tour.theme.title": {"id": "Tema Terang / Gelap", "en": "Light / Dark Theme"},
+    "tour.theme.body": {
+        "id": (
+            "Tombol ini selalu ada di pojok kanan atas, di menu manapun. "
+            "Pilih 'Sistem' (ikut OS), 'Terang', atau 'Gelap' sesuai "
+            "kenyamanan mata kamu."
+        ),
+        "en": (
+            "This control is always pinned to the top-right corner, on every "
+            "menu. Choose 'System' (follow OS), 'Light', or 'Dark' depending "
+            "on what's most comfortable."
+        ),
+    },
+    "tour.done.title": {"id": "Tutorial Selesai!", "en": "Tour Complete!"},
+    "tour.done.body": {
+        "id": (
+            "Selamat menggunakan Perpustakaan Offline. Kamu bisa mengulang "
+            "tutorial ini kapan saja dari Setting → Bahasa & Tema → 'Mulai "
+            "Ulang Tutorial'."
+        ),
+        "en": (
+            "Enjoy using Library Offline. You can replay this tour anytime "
+            "from Settings → Language & Theme → 'Restart Tutorial'."
+        ),
+    },
+    "tour.button.skip": {"id": "Lewati", "en": "Skip"},
+    "tour.button.prev": {"id": "Sebelumnya", "en": "Previous"},
+    "tour.button.next": {"id": "Berikutnya", "en": "Next"},
+    "tour.button.finish": {"id": "Selesai", "en": "Finish"},
+    "tour.progress": {"id": "Langkah {current} dari {total}", "en": "Step {current} of {total}"},
+    "tour.restart": {"id": "Mulai Ulang Tutorial", "en": "Restart Tutorial"},
+    "tour.restart.help": {
+        "id": "Buka kembali tour singkat untuk mengenal menu dan fitur penting.",
+        "en": "Replay the short tour explaining menus and key features.",
+    },
+    # ----------------------------- backup ----------------------------------
+    "backup.tab.title": {"id": "Backup Terjadwal", "en": "Scheduled Backup"},
+    "backup.help": {
+        "id": (
+            "Aplikasi bisa otomatis membuat backup database SQLite secara harian "
+            "atau mingguan ke folder lokal. File lama akan dihapus otomatis sesuai "
+            "jumlah retensi yang dipilih."
+        ),
+        "en": (
+            "The app can automatically back up the SQLite database daily or "
+            "weekly to a local folder. Older files are pruned automatically "
+            "based on the retention setting."
+        ),
+    },
+    "backup.frequency": {"id": "Frekuensi", "en": "Frequency"},
+    "backup.freq.off": {"id": "Mati", "en": "Off"},
+    "backup.freq.daily": {"id": "Harian", "en": "Daily"},
+    "backup.freq.weekly": {"id": "Mingguan", "en": "Weekly"},
+    "backup.time": {"id": "Jam (HH:MM, 24-jam)", "en": "Time (HH:MM, 24-hour)"},
+    "backup.weekday": {"id": "Hari", "en": "Day"},
+    "backup.folder": {"id": "Folder Tujuan", "en": "Target Folder"},
+    "backup.folder.default": {
+        "id": "Kosongkan untuk pakai folder backup default.",
+        "en": "Leave blank to use the default backup folder.",
+    },
+    "backup.retention": {"id": "Retensi (jumlah file disimpan)", "en": "Retention (files to keep)"},
+    "backup.button.save": {"id": "Simpan Pengaturan", "en": "Save Settings"},
+    "backup.button.now": {"id": "Backup Sekarang", "en": "Backup Now"},
+    "backup.button.open_folder": {"id": "Buka Folder", "en": "Open Folder"},
+    "backup.list.title": {"id": "Backup Tersimpan", "en": "Stored Backups"},
+    "backup.col.name": {"id": "Nama File", "en": "File Name"},
+    "backup.col.size": {"id": "Ukuran", "en": "Size"},
+    "backup.col.mtime": {"id": "Tanggal", "en": "Date"},
+    "backup.last_run": {"id": "Backup terakhir", "en": "Last backup"},
+    "backup.next_run": {"id": "Backup berikutnya", "en": "Next backup"},
+    "backup.never": {"id": "Belum pernah", "en": "Never"},
+    "backup.status.success": {"id": "Sukses", "en": "Success"},
+    "backup.status.failed": {"id": "Gagal", "en": "Failed"},
+    "backup.invalid_time": {
+        "id": "Format jam tidak valid. Gunakan HH:MM (mis. 02:00).",
+        "en": "Invalid time format. Use HH:MM (e.g. 02:00).",
+    },
+    "backup.toast.success": {
+        "id": "Backup terjadwal sukses: {name}",
+        "en": "Scheduled backup succeeded: {name}",
+    },
+    "backup.toast.success_noname": {
+        "id": "Backup terjadwal sukses.",
+        "en": "Scheduled backup succeeded.",
+    },
+    "backup.toast.failed": {
+        "id": "Backup terjadwal gagal: {error}",
+        "en": "Scheduled backup failed: {error}",
+    },
+    "backup.weekday.0": {"id": "Senin", "en": "Monday"},
+    "backup.weekday.1": {"id": "Selasa", "en": "Tuesday"},
+    "backup.weekday.2": {"id": "Rabu", "en": "Wednesday"},
+    "backup.weekday.3": {"id": "Kamis", "en": "Thursday"},
+    "backup.weekday.4": {"id": "Jumat", "en": "Friday"},
+    "backup.weekday.5": {"id": "Sabtu", "en": "Saturday"},
+    "backup.weekday.6": {"id": "Minggu", "en": "Sunday"},
     # ----------------------------- toasts ----------------------------------
     "toast.saved": {"id": "Data tersimpan.", "en": "Data saved."},
     "toast.updated": {"id": "Data diperbarui.", "en": "Data updated."},

--- a/src/perpustakaan/models/audit_log.py
+++ b/src/perpustakaan/models/audit_log.py
@@ -1,7 +1,40 @@
 """Repository untuk tabel audit_log."""
 from __future__ import annotations
 
-from perpustakaan.db.connection import Database, get_db
+from perpustakaan.db.connection import Database, get_db, transaction
+
+
+def record(
+    *,
+    aksi: str,
+    entitas: str,
+    entitas_id: int | None = None,
+    detail: str | None = None,
+    user_id: int | None = None,
+    db: Database | None = None,
+) -> int:
+    """Tulis satu entri audit log.
+
+    Mengembalikan id baris yang dibuat. Tidak melempar — error di-log
+    via warning saja supaya operasi inti (mis. backup, login) tetap jalan
+    walau tabel audit_log kebetulan locked.
+    """
+    db = db or get_db()
+    try:
+        with transaction(db):
+            cur = db.execute(
+                "INSERT INTO audit_log (user_id, aksi, entitas, entitas_id, detail) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (user_id, aksi, entitas, entitas_id, detail),
+            )
+            return int(cur.lastrowid or 0)
+    except Exception:  # noqa: BLE001 - audit log harus tahan banting
+        import logging
+
+        logging.getLogger("perpustakaan.audit_log").warning(
+            "Gagal tulis audit log: %s/%s", aksi, entitas, exc_info=True
+        )
+        return 0
 
 
 def list_all(

--- a/src/perpustakaan/services/backup_scheduler.py
+++ b/src/perpustakaan/services/backup_scheduler.py
@@ -1,0 +1,305 @@
+"""Scheduler in-process untuk backup terjadwal (harian / mingguan).
+
+Implementasi sengaja sederhana — tanpa dependency tambahan (APScheduler dsb.)
+supaya bundle PyInstaller tidak membengkak. Karakteristik:
+
+- Satu daemon thread (singleton) yang loop sambil menunggu deadline
+  via :class:`threading.Event` — bisa di-stop / di-reload kapan saja.
+- "Catch-up" di startup: kalau jadwal terlewat (mis. PC mati semalam
+  saat seharusnya backup), backup langsung dijalankan begitu app dibuka.
+- Settings (frekuensi, jam, weekday, folder, retention) diambil ulang
+  dari tabel ``settings`` setiap iterasi loop, jadi perubahan UI
+  langsung berlaku tanpa perlu restart.
+- Notifikasi GUI dilewatkan via callback opsional (dipanggil dari
+  worker thread; pemanggil GUI bertanggung jawab marshal ke main loop
+  via ``Tk.after``).
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from perpustakaan.services import backup_service
+
+_log = logging.getLogger("perpustakaan.backup_scheduler")
+
+
+SCHEDULE_OFF = "off"
+SCHEDULE_DAILY = "daily"
+SCHEDULE_WEEKLY = "weekly"
+VALID_SCHEDULES = (SCHEDULE_OFF, SCHEDULE_DAILY, SCHEDULE_WEEKLY)
+
+# Toleransi catch-up: kalau jadwal terlewat dalam window ini, jalankan
+# segera saat startup. (24 jam = aman untuk schedule harian, 7 hari +
+# margin = aman untuk schedule mingguan.)
+_CATCHUP_GRACE = timedelta(hours=2)
+
+
+@dataclass(frozen=True)
+class BackupConfig:
+    """Snapshot config backup dari tabel ``settings``."""
+
+    schedule: str = SCHEDULE_OFF
+    hour: int = 2
+    minute: int = 0
+    weekday: int = 0  # 0 = Senin
+    folder: str = ""
+    retention: int = 7
+    last_run_at: str = ""
+
+    @classmethod
+    def from_settings(cls) -> BackupConfig:
+        from perpustakaan.models import settings as settings_repo
+
+        schedule = (settings_repo.get_value("backup.schedule") or SCHEDULE_OFF).strip().lower()
+        if schedule not in VALID_SCHEDULES:
+            schedule = SCHEDULE_OFF
+        time_str = (settings_repo.get_value("backup.time") or "02:00").strip()
+        hour, minute = _parse_hhmm(time_str)
+        weekday = _coerce_int(settings_repo.get_value("backup.weekday"), default=0, lo=0, hi=6)
+        retention = _coerce_int(
+            settings_repo.get_value("backup.retention"), default=7, lo=0, hi=999
+        )
+        folder = (settings_repo.get_value("backup.folder") or "").strip()
+        last_run_at = (settings_repo.get_value("backup.last_run_at") or "").strip()
+        return cls(
+            schedule=schedule,
+            hour=hour,
+            minute=minute,
+            weekday=weekday,
+            folder=folder,
+            retention=retention,
+            last_run_at=last_run_at,
+        )
+
+
+def _parse_hhmm(s: str) -> tuple[int, int]:
+    try:
+        hh_str, mm_str = s.split(":", 1)
+        hh = max(0, min(23, int(hh_str)))
+        mm = max(0, min(59, int(mm_str)))
+        return hh, mm
+    except (ValueError, AttributeError):
+        return 2, 0
+
+
+def _coerce_int(val: object, *, default: int, lo: int, hi: int) -> int:
+    try:
+        n = int(str(val).strip())
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, n))
+
+
+def compute_next_run(cfg: BackupConfig, *, now: datetime | None = None) -> datetime | None:
+    """Hitung kapan backup berikutnya seharusnya jalan.
+
+    Mengembalikan ``None`` kalau ``cfg.schedule == "off"``. Untuk
+    ``daily``/``weekly`` selalu mengembalikan datetime di masa depan
+    (relatif terhadap ``now``).
+    """
+    if cfg.schedule == SCHEDULE_OFF:
+        return None
+    now = now or datetime.now()
+    target = now.replace(hour=cfg.hour, minute=cfg.minute, second=0, microsecond=0)
+    if cfg.schedule == SCHEDULE_DAILY:
+        if target <= now:
+            target += timedelta(days=1)
+        return target
+    if cfg.schedule == SCHEDULE_WEEKLY:
+        # weekday di Python: Monday=0
+        delta_days = (cfg.weekday - now.weekday()) % 7
+        target = target + timedelta(days=delta_days)
+        if target <= now:
+            target += timedelta(days=7)
+        return target
+    return None
+
+
+def should_catchup(cfg: BackupConfig, *, now: datetime | None = None) -> bool:
+    """True kalau startup harus langsung jalankan backup karena terlewat.
+
+    Logika: kalau schedule aktif dan ``last_run_at`` lebih lama dari
+    interval (24 jam untuk daily / 7 hari untuk weekly) ditambah
+    :data:`_CATCHUP_GRACE`, jalankan sekarang. Kalau ``last_run_at``
+    kosong (pertama kali setting diaktifkan), tunggu jadwal pertama —
+    jangan langsung backup.
+    """
+    if cfg.schedule == SCHEDULE_OFF:
+        return False
+    if not cfg.last_run_at:
+        return False
+    try:
+        last = datetime.fromisoformat(cfg.last_run_at)
+    except ValueError:
+        return False
+    now = now or datetime.now()
+    if cfg.schedule == SCHEDULE_DAILY:
+        return (now - last) > timedelta(days=1) + _CATCHUP_GRACE
+    if cfg.schedule == SCHEDULE_WEEKLY:
+        return (now - last) > timedelta(days=7) + _CATCHUP_GRACE
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Scheduler thread
+# ---------------------------------------------------------------------------
+class BackupScheduler:
+    """Singleton scheduler thread.
+
+    Pemakaian normal lewat :func:`get_scheduler`, :func:`start`,
+    :func:`stop`, :func:`reload`, :func:`trigger_now`.
+    """
+
+    # Berapa lama maksimal sekali ``wait`` — dipotong agar reload settings
+    # cepat berlaku walau jadwal masih jauh.
+    _POLL_INTERVAL_SEC = 60.0
+
+    def __init__(self, on_result: Callable[[dict], None] | None = None) -> None:
+        self._on_result = on_result
+        self._wakeup = threading.Event()
+        self._stop_evt = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._last_result: dict | None = None
+        self._next_run_at: datetime | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def last_result(self) -> dict | None:
+        return self._last_result
+
+    @property
+    def next_run_at(self) -> datetime | None:
+        return self._next_run_at
+
+    def set_callback(self, cb: Callable[[dict], None] | None) -> None:
+        self._on_result = cb
+
+    def start(self) -> None:
+        with self._lock:
+            if self.is_running:
+                return
+            self._stop_evt.clear()
+            self._wakeup.clear()
+            self._thread = threading.Thread(
+                target=self._run_loop, name="backup-scheduler", daemon=True
+            )
+            self._thread.start()
+        _log.info("Backup scheduler started")
+
+    def stop(self, *, timeout: float = 2.0) -> None:
+        with self._lock:
+            t = self._thread
+            self._stop_evt.set()
+            self._wakeup.set()
+        if t is not None and t.is_alive():
+            t.join(timeout=timeout)
+        with self._lock:
+            self._thread = None
+        _log.info("Backup scheduler stopped")
+
+    def reload(self) -> None:
+        """Wake worker thread supaya re-evaluate config dari settings."""
+        self._wakeup.set()
+
+    def trigger_now(self, *, user_id: int | None = None) -> dict:
+        """Jalankan satu siklus backup sekarang (synchronous, untuk tombol UI).
+
+        Hasilnya juga tercatat ke ``last_result`` & dipanggil callback.
+        """
+        cfg = BackupConfig.from_settings()
+        return self._run_once(cfg, trigger="manual", user_id=user_id)
+
+    # ------------------------------------------------------------------
+    def _run_loop(self) -> None:
+        # Catch-up di startup
+        try:
+            cfg = BackupConfig.from_settings()
+            if should_catchup(cfg):
+                _log.info("Backup terjadwal terlewat, menjalankan catch-up.")
+                self._run_once(cfg, trigger="catchup", user_id=None)
+        except Exception:  # noqa: BLE001
+            _log.exception("Catch-up gagal")
+
+        while not self._stop_evt.is_set():
+            try:
+                cfg = BackupConfig.from_settings()
+            except Exception:  # noqa: BLE001
+                _log.exception("Gagal baca config backup")
+                cfg = BackupConfig()
+
+            if cfg.schedule == SCHEDULE_OFF:
+                self._next_run_at = None
+                # Tidur sampai di-wake (set settings = on) atau di-stop.
+                self._wakeup.clear()
+                self._wakeup.wait(timeout=self._POLL_INTERVAL_SEC)
+                continue
+
+            now = datetime.now()
+            target = compute_next_run(cfg, now=now)
+            self._next_run_at = target
+            if target is None:
+                self._wakeup.clear()
+                self._wakeup.wait(timeout=self._POLL_INTERVAL_SEC)
+                continue
+
+            wait_sec = (target - now).total_seconds()
+            wait_sec = min(max(wait_sec, 0.0), self._POLL_INTERVAL_SEC)
+            self._wakeup.clear()
+            woken = self._wakeup.wait(timeout=wait_sec)
+            if self._stop_evt.is_set():
+                return
+            if woken:
+                # Settings mungkin berubah — re-evaluate dari atas.
+                continue
+            # Cek lagi: kalau sudah lewat target, jalankan.
+            if datetime.now() >= target:
+                self._run_once(cfg, trigger="scheduled", user_id=None)
+
+    def _run_once(self, cfg: BackupConfig, *, trigger: str, user_id: int | None) -> dict:
+        folder: str | Path | None = cfg.folder or None
+        result = backup_service.run_scheduled_backup(
+            folder=folder,
+            keep=cfg.retention,
+            user_id=user_id,
+            trigger=trigger,
+        )
+        self._last_result = result
+        cb = self._on_result
+        if cb is not None:
+            try:
+                cb(result)
+            except Exception:  # noqa: BLE001
+                _log.exception("Backup result callback raised")
+        return result
+
+
+_scheduler: BackupScheduler | None = None
+_scheduler_lock = threading.Lock()
+
+
+def get_scheduler() -> BackupScheduler:
+    """Akses singleton scheduler."""
+    global _scheduler
+    if _scheduler is None:
+        with _scheduler_lock:
+            if _scheduler is None:
+                _scheduler = BackupScheduler()
+    return _scheduler
+
+
+def reset_scheduler_for_tests() -> None:
+    """Reset singleton (HANYA untuk tests)."""
+    global _scheduler
+    with _scheduler_lock:
+        if _scheduler is not None:
+            _scheduler.stop(timeout=0.1)
+        _scheduler = None

--- a/src/perpustakaan/services/backup_service.py
+++ b/src/perpustakaan/services/backup_service.py
@@ -1,6 +1,18 @@
-"""Backup & Reset database."""
+"""Backup & Reset database.
+
+Selain backup manual ada juga *backup terjadwal* yang dipicu oleh
+:mod:`perpustakaan.services.backup_scheduler`. Modul ini menyediakan
+primitif yang dipakai keduanya:
+
+- :func:`backup_db`: copy file SQLite ke folder tujuan dengan timestamp.
+- :func:`list_backups`: daftar file backup dalam suatu folder, terbaru duluan.
+- :func:`prune_backups`: pertahankan N file terbaru, hapus sisanya.
+- :func:`run_scheduled_backup`: orkestrasi backup terjadwal — backup +
+  prune + tulis status ke ``settings`` + audit log.
+"""
 from __future__ import annotations
 
+import logging
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -8,14 +20,146 @@ from pathlib import Path
 from perpustakaan.config import BACKUPS_DIR, DB_PATH
 from perpustakaan.db.connection import Database, get_db, transaction
 
+_log = logging.getLogger("perpustakaan.backup")
 
-def backup_db(target_dir: Path | None = None) -> Path:
-    target_dir = target_dir or BACKUPS_DIR
-    target_dir.mkdir(parents=True, exist_ok=True)
+_BACKUP_GLOB = "perpustakaan_*.db"
+
+
+def resolve_backup_folder(folder: str | Path | None = None) -> Path:
+    """Resolve folder backup; kalau ``folder`` kosong/None pakai ``BACKUPS_DIR``."""
+    if folder is None or (isinstance(folder, str) and not folder.strip()):
+        return BACKUPS_DIR
+    return Path(folder).expanduser()
+
+
+def backup_db(target_dir: Path | str | None = None, db_path: Path | None = None) -> Path:
+    """Backup file SQLite ke ``target_dir`` (default ``BACKUPS_DIR``).
+
+    Nama file mengikuti pola ``perpustakaan_YYYYMMDD_HHMMSS.db`` sehingga
+    :func:`list_backups` & :func:`prune_backups` bisa mengenalinya.
+    """
+    target = resolve_backup_folder(target_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    src = Path(db_path) if db_path else DB_PATH
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    out = target_dir / f"perpustakaan_{ts}.db"
-    shutil.copy2(DB_PATH, out)
+    out = target / f"perpustakaan_{ts}.db"
+    shutil.copy2(src, out)
     return out
+
+
+def list_backups(folder: str | Path | None = None) -> list[dict]:
+    """Daftar file backup di ``folder`` (terbaru duluan).
+
+    Tiap entri berisi ``path`` (Path), ``name``, ``size_bytes``, ``mtime``
+    (datetime), dan ``mtime_str`` (untuk display).
+    """
+    folder = resolve_backup_folder(folder)
+    if not folder.exists():
+        return []
+    rows: list[dict] = []
+    for p in folder.glob(_BACKUP_GLOB):
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        if not p.is_file():
+            continue
+        mtime = datetime.fromtimestamp(st.st_mtime)
+        rows.append(
+            {
+                "path": p,
+                "name": p.name,
+                "size_bytes": st.st_size,
+                "mtime": mtime,
+                "mtime_str": mtime.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
+    rows.sort(key=lambda r: r["mtime"], reverse=True)
+    return rows
+
+
+def prune_backups(folder: str | Path | None = None, *, keep: int = 7) -> list[Path]:
+    """Pertahankan ``keep`` backup terbaru, hapus sisanya.
+
+    Mengembalikan list ``Path`` yang dihapus. ``keep <= 0`` artinya
+    tidak ada retention (tidak ada file yang dihapus).
+    """
+    if keep <= 0:
+        return []
+    rows = list_backups(folder)
+    deleted: list[Path] = []
+    for row in rows[keep:]:
+        try:
+            row["path"].unlink()
+            deleted.append(row["path"])
+        except OSError as exc:
+            _log.warning("Gagal hapus backup lama %s: %s", row["path"], exc)
+    return deleted
+
+
+def run_scheduled_backup(
+    *,
+    folder: str | Path | None = None,
+    keep: int = 7,
+    user_id: int | None = None,
+    trigger: str = "scheduled",
+) -> dict:
+    """Jalankan satu siklus backup + prune + tulis status.
+
+    Args:
+        folder: folder tujuan; ``None`` = pakai ``BACKUPS_DIR``.
+        keep: jumlah backup yang dipertahankan.
+        user_id: user yang mentrigger (untuk audit log).
+        trigger: ``"scheduled"`` (otomatis) atau ``"manual"`` (tombol UI).
+
+    Returns:
+        Dict ``{"status": "success"|"failed", "path": str, "error": str,
+        "deleted": int, "at": iso_timestamp}``.
+    """
+    from perpustakaan.models import audit_log as audit_log_repo
+    from perpustakaan.models import settings as settings_repo
+
+    now_iso = datetime.now().isoformat(timespec="seconds")
+    result: dict = {
+        "status": "success",
+        "path": "",
+        "error": "",
+        "deleted": 0,
+        "at": now_iso,
+        "trigger": trigger,
+    }
+    try:
+        out_path = backup_db(folder)
+        deleted = prune_backups(folder, keep=keep)
+        result["path"] = str(out_path)
+        result["deleted"] = len(deleted)
+    except Exception as exc:  # noqa: BLE001
+        _log.exception("Backup terjadwal gagal")
+        result["status"] = "failed"
+        result["error"] = f"{type(exc).__name__}: {exc}"
+
+    try:
+        settings_repo.set_many(
+            {
+                "backup.last_run_at": result["at"],
+                "backup.last_run_status": result["status"],
+                "backup.last_run_path": result["path"],
+                "backup.last_run_error": result["error"],
+            }
+        )
+    except Exception:  # noqa: BLE001
+        _log.warning("Gagal simpan status backup terjadwal", exc_info=True)
+
+    audit_log_repo.record(
+        aksi=("backup_ok" if result["status"] == "success" else "backup_failed"),
+        entitas="backup",
+        detail=(
+            f"trigger={trigger} path={Path(result['path']).name if result['path'] else '-'} "
+            f"deleted={result['deleted']} error={result['error'] or '-'}"
+        ),
+        user_id=user_id,
+    )
+    return result
 
 
 def reset_transaksi(*, keep_outstanding: bool = True, db: Database | None = None) -> None:

--- a/tests/test_backup_terjadwal.py
+++ b/tests/test_backup_terjadwal.py
@@ -1,0 +1,351 @@
+"""Test backup terjadwal: backup_service + backup_scheduler."""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def _seed_backup_files(folder: Path, count: int, *, base_time: float | None = None) -> list[Path]:
+    """Buat ``count`` file backup palsu dengan mtime yang dijamin terurut."""
+    folder.mkdir(parents=True, exist_ok=True)
+    base = base_time or time.time()
+    paths: list[Path] = []
+    for i in range(count):
+        ts = datetime.fromtimestamp(base - i * 3600).strftime("%Y%m%d_%H%M%S")
+        # Tambah suffix supaya nama unik walau timestamp sama.
+        p = folder / f"perpustakaan_{ts}_{i}.db"
+        p.write_bytes(f"db-{i}".encode())
+        # Set mtime eksplisit supaya urutan terbaru→terlama jelas.
+        os_mtime = base - i * 3600
+        import os as _os
+        _os.utime(p, (os_mtime, os_mtime))
+        paths.append(p)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# backup_service primitives
+# ---------------------------------------------------------------------------
+class TestBackupService:
+    def test_backup_db_creates_copy(self, fresh_db, tmp_path):
+        from perpustakaan.services import backup_service
+
+        target = tmp_path / "backups"
+        out = backup_service.backup_db(target)
+        assert out.exists()
+        assert out.parent == target
+        assert out.name.startswith("perpustakaan_") and out.suffix == ".db"
+
+    def test_backup_db_default_folder(self, fresh_db):
+        from perpustakaan.config import BACKUPS_DIR
+        from perpustakaan.services import backup_service
+
+        out = backup_service.backup_db()
+        assert out.parent == BACKUPS_DIR
+        out.unlink(missing_ok=True)
+
+    def test_resolve_backup_folder_blank(self, fresh_db):
+        from perpustakaan.config import BACKUPS_DIR
+        from perpustakaan.services import backup_service
+
+        assert backup_service.resolve_backup_folder(None) == BACKUPS_DIR
+        assert backup_service.resolve_backup_folder("") == BACKUPS_DIR
+        assert backup_service.resolve_backup_folder("   ") == BACKUPS_DIR
+
+    def test_list_backups_sorted_newest_first(self, fresh_db, tmp_path):
+        from perpustakaan.services import backup_service
+
+        folder = tmp_path / "bk"
+        _seed_backup_files(folder, 5)
+        rows = backup_service.list_backups(folder)
+        assert len(rows) == 5
+        # Mtime descending.
+        for i in range(len(rows) - 1):
+            assert rows[i]["mtime"] >= rows[i + 1]["mtime"]
+
+    def test_list_backups_ignores_non_matching(self, fresh_db, tmp_path):
+        from perpustakaan.services import backup_service
+
+        folder = tmp_path / "bk"
+        _seed_backup_files(folder, 2)
+        (folder / "random.txt").write_text("ignore me")
+        (folder / "perpustakaan_invalid.db").write_text("x")  # masih cocok glob
+        rows = backup_service.list_backups(folder)
+        names = [r["name"] for r in rows]
+        assert all(n.endswith(".db") for n in names)
+        assert "random.txt" not in names
+
+    def test_list_backups_missing_folder(self, fresh_db, tmp_path):
+        from perpustakaan.services import backup_service
+
+        rows = backup_service.list_backups(tmp_path / "does-not-exist")
+        assert rows == []
+
+    def test_prune_keeps_latest_n(self, fresh_db, tmp_path):
+        from perpustakaan.services import backup_service
+
+        folder = tmp_path / "bk"
+        _seed_backup_files(folder, 10)
+        deleted = backup_service.prune_backups(folder, keep=3)
+        assert len(deleted) == 7
+        remaining = backup_service.list_backups(folder)
+        assert len(remaining) == 3
+
+    def test_prune_keep_zero_or_negative_no_op(self, fresh_db, tmp_path):
+        from perpustakaan.services import backup_service
+
+        folder = tmp_path / "bk"
+        _seed_backup_files(folder, 5)
+        assert backup_service.prune_backups(folder, keep=0) == []
+        assert backup_service.prune_backups(folder, keep=-1) == []
+        assert len(backup_service.list_backups(folder)) == 5
+
+    def test_run_scheduled_backup_writes_status_and_audit(self, fresh_db, tmp_path):
+        from perpustakaan.models import audit_log as audit_log_repo
+        from perpustakaan.models import settings as settings_repo
+        from perpustakaan.services import backup_service
+
+        folder = tmp_path / "bk"
+        result = backup_service.run_scheduled_backup(
+            folder=folder, keep=5, trigger="manual"
+        )
+        assert result["status"] == "success"
+        assert result["path"]
+        assert Path(result["path"]).exists()
+        assert settings_repo.get_value("backup.last_run_at") == result["at"]
+        assert settings_repo.get_value("backup.last_run_status") == "success"
+
+        # Audit log harus tercatat.
+        rows = audit_log_repo.list_all(search="backup", limit=20)
+        assert any(r["aksi"] == "backup_ok" for r in rows)
+
+    def test_run_scheduled_backup_failure_marked(self, fresh_db, monkeypatch, tmp_path):
+        from perpustakaan.models import settings as settings_repo
+        from perpustakaan.services import backup_service
+
+        def boom(*_a, **_kw):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(backup_service, "backup_db", boom)
+        result = backup_service.run_scheduled_backup(
+            folder=tmp_path / "bk", trigger="scheduled"
+        )
+        assert result["status"] == "failed"
+        assert "disk full" in result["error"]
+        assert settings_repo.get_value("backup.last_run_status") == "failed"
+
+
+# ---------------------------------------------------------------------------
+# backup_scheduler logic
+# ---------------------------------------------------------------------------
+class TestBackupSchedulerCompute:
+    def test_off_returns_none(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        cfg = bs.BackupConfig(schedule="off")
+        assert bs.compute_next_run(cfg) is None
+
+    def test_daily_in_future_today(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        now = datetime(2026, 1, 1, 8, 0, 0)
+        cfg = bs.BackupConfig(schedule="daily", hour=20, minute=30)
+        nxt = bs.compute_next_run(cfg, now=now)
+        assert nxt == datetime(2026, 1, 1, 20, 30, 0)
+
+    def test_daily_already_passed_means_tomorrow(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        now = datetime(2026, 1, 1, 23, 0, 0)
+        cfg = bs.BackupConfig(schedule="daily", hour=2, minute=0)
+        nxt = bs.compute_next_run(cfg, now=now)
+        assert nxt == datetime(2026, 1, 2, 2, 0, 0)
+
+    def test_weekly_picks_correct_weekday(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        # 2026-01-01 = Kamis (weekday=3)
+        now = datetime(2026, 1, 1, 8, 0, 0)
+        # weekday=0 (Senin), jam 02:00 -> Senin berikutnya 2026-01-05.
+        cfg = bs.BackupConfig(schedule="weekly", hour=2, minute=0, weekday=0)
+        nxt = bs.compute_next_run(cfg, now=now)
+        assert nxt == datetime(2026, 1, 5, 2, 0, 0)
+
+    def test_weekly_same_weekday_already_passed_means_next_week(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        # Kamis 23:00, jadwal Kamis 02:00 -> harusnya Kamis depan.
+        now = datetime(2026, 1, 1, 23, 0, 0)
+        cfg = bs.BackupConfig(schedule="weekly", hour=2, minute=0, weekday=3)
+        nxt = bs.compute_next_run(cfg, now=now)
+        assert nxt == datetime(2026, 1, 8, 2, 0, 0)
+
+    def test_should_catchup_no_last_run(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        cfg = bs.BackupConfig(schedule="daily")
+        assert bs.should_catchup(cfg) is False
+
+    def test_should_catchup_recent_run(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        now = datetime(2026, 1, 2, 9, 0, 0)
+        cfg = bs.BackupConfig(
+            schedule="daily",
+            last_run_at=(now - timedelta(hours=12)).isoformat(),
+        )
+        assert bs.should_catchup(cfg, now=now) is False
+
+    def test_should_catchup_overdue_daily(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        now = datetime(2026, 1, 5, 9, 0, 0)
+        cfg = bs.BackupConfig(
+            schedule="daily",
+            last_run_at=(now - timedelta(days=2)).isoformat(),
+        )
+        assert bs.should_catchup(cfg, now=now) is True
+
+    def test_should_catchup_overdue_weekly(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        now = datetime(2026, 1, 20, 9, 0, 0)
+        cfg = bs.BackupConfig(
+            schedule="weekly",
+            last_run_at=(now - timedelta(days=10)).isoformat(),
+        )
+        assert bs.should_catchup(cfg, now=now) is True
+
+    def test_should_catchup_off_returns_false(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        now = datetime(2026, 1, 5, 9, 0, 0)
+        cfg = bs.BackupConfig(
+            schedule="off",
+            last_run_at=(now - timedelta(days=10)).isoformat(),
+        )
+        assert bs.should_catchup(cfg, now=now) is False
+
+
+class TestBackupSchedulerConfig:
+    def test_from_settings_defaults_to_off(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        cfg = bs.BackupConfig.from_settings()
+        assert cfg.schedule == "off"
+        assert cfg.hour == 2
+        assert cfg.retention == 7
+
+    def test_from_settings_round_trip(self, fresh_db):
+        from perpustakaan.models import settings as settings_repo
+        from perpustakaan.services import backup_scheduler as bs
+
+        settings_repo.set_many(
+            {
+                "backup.schedule": "weekly",
+                "backup.time": "23:45",
+                "backup.weekday": "5",
+                "backup.folder": "/tmp/foo",
+                "backup.retention": "12",
+            }
+        )
+        cfg = bs.BackupConfig.from_settings()
+        assert cfg.schedule == "weekly"
+        assert (cfg.hour, cfg.minute) == (23, 45)
+        assert cfg.weekday == 5
+        assert cfg.folder == "/tmp/foo"
+        assert cfg.retention == 12
+
+    def test_invalid_time_falls_back_to_default(self, fresh_db):
+        from perpustakaan.models import settings as settings_repo
+        from perpustakaan.services import backup_scheduler as bs
+
+        settings_repo.set_value("backup.time", "garbage")
+        cfg = bs.BackupConfig.from_settings()
+        assert (cfg.hour, cfg.minute) == (2, 0)
+
+    def test_invalid_schedule_falls_back_to_off(self, fresh_db):
+        from perpustakaan.models import settings as settings_repo
+        from perpustakaan.services import backup_scheduler as bs
+
+        settings_repo.set_value("backup.schedule", "monthly")
+        cfg = bs.BackupConfig.from_settings()
+        assert cfg.schedule == "off"
+
+
+class TestBackupSchedulerLifecycle:
+    def test_singleton_returns_same_instance(self, fresh_db):
+        from perpustakaan.services import backup_scheduler as bs
+
+        bs.reset_scheduler_for_tests()
+        try:
+            a = bs.get_scheduler()
+            b = bs.get_scheduler()
+            assert a is b
+        finally:
+            bs.reset_scheduler_for_tests()
+
+    def test_trigger_now_runs_backup(self, fresh_db, tmp_path):
+        from perpustakaan.models import settings as settings_repo
+        from perpustakaan.services import backup_scheduler as bs
+
+        bs.reset_scheduler_for_tests()
+        try:
+            settings_repo.set_many(
+                {"backup.folder": str(tmp_path / "bk"), "backup.retention": "3"}
+            )
+            sched = bs.get_scheduler()
+            result = sched.trigger_now()
+            assert result["status"] == "success"
+            assert Path(result["path"]).exists()
+            assert sched.last_result is not None
+        finally:
+            bs.reset_scheduler_for_tests()
+
+    def test_callback_called_on_trigger(self, fresh_db, tmp_path):
+        from perpustakaan.models import settings as settings_repo
+        from perpustakaan.services import backup_scheduler as bs
+
+        bs.reset_scheduler_for_tests()
+        try:
+            settings_repo.set_value("backup.folder", str(tmp_path / "bk"))
+            received: list[dict] = []
+            sched = bs.get_scheduler()
+            sched.set_callback(received.append)
+            sched.trigger_now()
+            assert len(received) == 1
+            assert received[0]["status"] == "success"
+        finally:
+            bs.reset_scheduler_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Audit log helper
+# ---------------------------------------------------------------------------
+class TestAuditLogRecord:
+    def test_record_inserts_row(self, fresh_db):
+        from perpustakaan.models import audit_log as audit_log_repo
+
+        rid = audit_log_repo.record(
+            aksi="backup_ok", entitas="backup", detail="trigger=manual"
+        )
+        assert rid > 0
+        rows = audit_log_repo.list_all(search="backup_ok", limit=10)
+        assert any(r["id"] == rid for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Tutorial flag (settings-based)
+# ---------------------------------------------------------------------------
+class TestTutorialFlag:
+    def test_default_empty(self, fresh_db):
+        from perpustakaan.models import settings as settings_repo
+
+        assert (settings_repo.get_value("tutorial.completed") or "") == ""
+
+    def test_mark_completed(self, fresh_db):
+        from perpustakaan.models import settings as settings_repo
+
+        settings_repo.set_value("tutorial.completed", "1")
+        assert settings_repo.get_value("tutorial.completed") == "1"


### PR DESCRIPTION
## Summary

Tiga fitur baru sekaligus untuk **v0.4.0** (digabung jadi 1 PR per request user):

### 1. Backup Terjadwal (roadmap Jalur D)
Auto-backup database SQLite secara harian / mingguan ke folder lokal dengan retensi otomatis.
- `services/backup_service.py`: tambah `list_backups()`, `prune_backups()`, `run_scheduled_backup()` (orkestrasi backup + prune + tulis status + audit log).
- `services/backup_scheduler.py` **(baru)**: daemon thread singleton yang loop nunggu deadline lewat `threading.Event` (bisa stop / reload kapan saja). Catch-up saat startup kalau jadwal terlewat (mis. PC mati semalam). Tanpa dependency tambahan supaya bundle PyInstaller tetap ramping.
- `models/audit_log.record()` **(helper baru)**: log `backup_ok` / `backup_failed` dengan trigger (`scheduled` / `manual` / `catchup`) + jumlah file lama yang ter-prune.
- Settings → tab **Backup Terjadwal** **(baru)**: frekuensi (Off/Harian/Mingguan), jam (HH:MM 24-jam), hari (saat weekly), folder tujuan (kosong = default `BACKUPS_DIR`), retensi, tombol **Backup Sekarang** + **Buka Folder** + **Simpan Pengaturan**, status backup terakhir + perkiraan backup berikutnya, list file backup tersimpan.
- Toast otomatis muncul saat backup terjadwal selesai (sukses → hijau, gagal → merah). Marshalling ke main thread via `Tk.after`.

### 2. Toggle Tema Global (Sistem / Terang / Gelap)
- `CTkSegmentedButton` mengambang di **pojok kanan-atas content area**, **selalu visible** di menu manapun (di-`.lift()` setiap kali view di-raise).
- Tiga pilihan: **Sistem** (ikut OS), **Terang**, **Gelap**. Persist ke `ui.theme` settings.
- Toast feedback "Tema diterapkan" tiap ganti.

### 3. Tutorial / Guided Tour Interaktif
- `gui/tour.py` **(baru)**: `TourManager` + `TourStep` dataclass + `TourPopup` (CTkToplevel borderless overlay yang nempel di widget target).
- 10 step: welcome → Dashboard → Anggota → Buku → Peminjaman → Pengembalian → Laporan → Setting → Toggle Tema → closing. Tiap step otomatis pindah ke menu yang relevan supaya widget target visible.
- Tombol **Lewati** / **Sebelumnya** / **Berikutnya** / **Selesai**, plus indikator step counter ("Langkah X dari N").
- Auto-launch di first-run via flag `tutorial.completed` di tabel settings. Sekali Skip atau Selesai → flag di-set, tidak muncul lagi otomatis.
- Tombol **Mulai Ulang Tutorial** di Settings → tab Bahasa & Tema untuk replay kapan saja.

### Bilingual i18n
Semua string baru ada di **Indonesia + English** (`backup.*`, `theme.*`, `tour.*` di `_STRINGS`).

### Versi & Distribusi
- `pyproject.toml` 0.3.1 → **0.4.0**
- `src/perpustakaan/__init__.py` 0.3.1 → **0.4.0**
- `src/perpustakaan/config.py` `APP_VERSION` 0.3.0 → **0.4.0** (sebelumnya inconsistent)
- `installer/installer.iss` MyAppVersion 0.3.1 → **0.4.0**

### Tests
- `tests/test_backup_terjadwal.py` **(baru)**: 30 test case mencakup `backup_service` primitif (backup_db, list_backups sorted, prune retains N, run_scheduled_backup sukses & gagal, settings persist, audit log entry), `backup_scheduler` (compute_next_run untuk daily / weekly / off, should_catchup overdue / fresh / off, BackupConfig.from_settings round-trip & fallback parsing, scheduler singleton, trigger_now sync, callback dipanggil), audit_log.record helper, dan tutorial flag.
- Total suite: **47 test pass**, ruff bersih, app `--no-gui` start dengan `Perpustakaan Offline v0.4.0`.

## Review & Testing Checklist for Human

> Risk level: **yellow** — fitur baru cukup luas (3 fitur sekaligus), termasuk daemon thread + window-level overlay yang berinteraksi dengan widget lifecycle.

- [ ] **Tutorial first-run** — hapus `tutorial.completed` di DB (atau pakai user/data dir baru), buka app, login. Tour seharusnya muncul ~0.8 detik setelah login. Test tombol **Lewati** (close + tidak muncul lagi), **Sebelumnya**, **Berikutnya** (auto-pindah menu sesuai step), **Selesai**. Verify popup nempel ke widget yang dimaksud.
- [ ] **Theme toggle persistence** — klik Sistem/Terang/Gelap di pojok kanan-atas, restart app, theme harus tetap. Coba di setiap menu — toggle harus tetap visible & di atas konten.
- [ ] **Backup Terjadwal end-to-end**: set frekuensi Harian + jam 5 menit kemudian + retensi 3, tunggu jadwal lewat → file backup baru, toast hijau, audit log `backup_ok` trigger=scheduled. Klik **Backup Sekarang** > retensi → file lama auto-prune. Set Mingguan + besok → label "Backup berikutnya" benar. Test **catch-up**: edit `backup.last_run_at` ke 3 hari lalu, restart app → backup langsung jalan saat startup (audit `trigger=catchup`).
- [ ] **Smoke test GUI** — pastikan CI smoke test (Xvfb) tetap hijau setelah penambahan tab + theme toggle.
- [ ] **Build .exe Windows** — cek artifact PyInstaller; pastikan `services/backup_scheduler.py` + `gui/tour.py` ke-include. Jalankan `.exe` dan verify ketiga fitur muncul.

### Notes
- Scheduler hanya jalan saat aplikasi terbuka. Catch-up logic mitigasi PC mati semalam.
- Theme toggle pakai `place()` overlay — kalau ada view future yang juga pakai `place()` di pojok kanan-atas, bisa overlap.
- Tour pakai `overrideredirect(True)` — di beberapa WM Linux bisa aneh, di Windows pasti aman.
- Roadmap "Backup terjadwal" di README.md di-mark `[x]` (selesai di v0.4.0).