### PR TITLE
docs(migration-v2): bootstrap migration plan

### DIFF
--- a/docs/migration-v2/ARCHITECTURE.md
+++ b/docs/migration-v2/ARCHITECTURE.md
@@ -1,0 +1,417 @@
+# Architecture — Migration v2
+
+> Arsitektur target Perpustakaan Offline v2: monorepo Tauri 2.0 + React 18 +
+> Rust backend + SQLite (reuse schema v1).
+>
+> Dokumen ini blueprint untuk Devin 2 dst. Diagram pakai ASCII supaya bisa
+> diff di git.
+
+## 1. Tinjauan tinggi
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                       Perpustakaan Offline v2                       │
+│                                                                    │
+│   ┌─────────────────────────────┐    ┌──────────────────────────┐  │
+│   │   Frontend (WebView)        │    │   Native Layer (Rust)    │  │
+│   │   apps/desktop/src/         │    │   apps/desktop/src-tauri/│  │
+│   │                             │    │                          │  │
+│   │   React 18 + TS             │    │   Tauri 2.0 runtime      │  │
+│   │   Tailwind 3 + shadcn/ui    │    │   tauri-plugin-sql       │  │
+│   │   Zustand (state)           │ ◄──►   tauri-plugin-fs        │  │
+│   │   TanStack Router           │IPC │   tauri-plugin-dialog    │  │
+│   │   recharts (charts)         │    │   tauri-plugin-printer   │  │
+│   │   pdf-lib (PDF gen)         │    │   tauri-plugin-stronghold│  │
+│   │   react-i18next             │    │                          │  │
+│   │                             │    │   Custom commands:       │  │
+│   │   Vite dev server (dev)     │    │   - auth.* (bcrypt+AES)  │  │
+│   │                             │    │   - db.* (CRUD)          │  │
+│   └─────────────────────────────┘    │   - kta.* (PDF/print)    │  │
+│                                      │   - report.* (export)    │  │
+│                                      │   - identity.* (events)  │  │
+│                                      └──────────────────────────┘  │
+│                                              │                      │
+│                                              ▼                      │
+│                              ┌─────────────────────────────────┐    │
+│                              │  SQLite DB                      │    │
+│                              │  ~/AppData/PerpustakaanOffline/ │    │
+│                              │     perpustakaan-v2.db          │    │
+│                              │  (schema reuse dari v1 + add    │    │
+│                              │  tabel master_data baru)        │    │
+│                              └─────────────────────────────────┘    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## 2. File structure (monorepo)
+
+```
+perpustakaan-offline/
+├── apps/
+│   ├── desktop/                # Tauri desktop app (utama)
+│   │   ├── src/                # Frontend React + TS
+│   │   │   ├── main.tsx
+│   │   │   ├── App.tsx
+│   │   │   ├── components/
+│   │   │   │   ├── ui/         # shadcn primitives (copy-paste)
+│   │   │   │   ├── layout/     # Sidebar, Header, AppShell
+│   │   │   │   └── shared/     # DataTable, EmptyState, ...
+│   │   │   ├── features/
+│   │   │   │   ├── auth/
+│   │   │   │   ├── dashboard/
+│   │   │   │   ├── anggota/
+│   │   │   │   ├── buku/
+│   │   │   │   ├── peminjaman/
+│   │   │   │   ├── pengembalian/
+│   │   │   │   ├── kunjungan/
+│   │   │   │   ├── laporan/
+│   │   │   │   ├── kta/
+│   │   │   │   └── settings/
+│   │   │   ├── hooks/
+│   │   │   ├── lib/            # utils (cn, format, dll.)
+│   │   │   ├── stores/         # Zustand stores
+│   │   │   ├── routes/         # TanStack Router file-based
+│   │   │   ├── i18n/
+│   │   │   │   ├── index.ts
+│   │   │   │   ├── id/
+│   │   │   │   └── en/
+│   │   │   └── types/          # TS types (shared dengan packages/shared)
+│   │   ├── src-tauri/
+│   │   │   ├── src/
+│   │   │   │   ├── main.rs
+│   │   │   │   ├── commands/   # Tauri commands per domain
+│   │   │   │   │   ├── auth.rs
+│   │   │   │   │   ├── anggota.rs
+│   │   │   │   │   ├── buku.rs
+│   │   │   │   │   ├── peminjaman.rs
+│   │   │   │   │   ├── kunjungan.rs
+│   │   │   │   │   ├── laporan.rs
+│   │   │   │   │   ├── kta.rs
+│   │   │   │   │   └── identity.rs
+│   │   │   │   └── db/
+│   │   │   │       ├── mod.rs
+│   │   │   │       ├── schema.sql       # COPY dari v1 + extend
+│   │   │   │       └── migrations/
+│   │   │   ├── icons/          # 32/128/128@2x/icon.ico/icon.icns
+│   │   │   ├── resources/      # bundled: fonts, manual HTML, seed data
+│   │   │   ├── installer/
+│   │   │   │   ├── inno-setup.iss
+│   │   │   │   └── assets/     # wizard images (#3)
+│   │   │   ├── Cargo.toml
+│   │   │   ├── tauri.conf.json
+│   │   │   └── build.rs
+│   │   ├── public/
+│   │   │   └── illustrations/  # SVG / PNG 1024px+
+│   │   ├── tests/
+│   │   │   └── e2e/            # Playwright
+│   │   ├── package.json
+│   │   ├── tsconfig.json
+│   │   ├── tailwind.config.ts
+│   │   ├── postcss.config.cjs
+│   │   ├── vite.config.ts
+│   │   └── vitest.config.ts
+│   └── web/                    # (FUTURE) browser-only demo, optional
+│
+├── packages/
+│   └── shared/                 # Tipe TS dipakai bersama (DTO IPC)
+│       ├── src/
+│       │   ├── types/
+│       │   │   ├── anggota.ts
+│       │   │   ├── buku.ts
+│       │   │   └── ...
+│       │   └── index.ts
+│       └── package.json
+│
+├── docs/
+│   ├── migration-v2/           # planning + state (file ini, dll.)
+│   ├── manual.md               # legacy v1, akan di-port di Devin 11
+│   └── screenshots/            # legacy v1 screenshots (referensi)
+│
+├── scripts/
+│   ├── migrate-v1-to-v2.ts     # Devin 12: convert .db v1 → v2
+│   └── dev.sh
+│
+├── pnpm-workspace.yaml
+├── package.json                # root workspace
+├── .github/
+│   └── workflows/
+│       ├── ci.yml              # legacy Python CI (akan jadi disable di Devin 12)
+│       └── ci-v2.yml           # baru: pnpm lint/test/typecheck + Tauri build
+└── .gitignore
+```
+
+> v1 source (`src/perpustakaan/`, `tests/`, `build.spec`, `installer/`) **tidak**
+> dihapus selama migrasi (dipertahankan di branch `main`) sampai Devin 12
+> melakukan release v1.0.0 dan sweep cleanup.
+
+## 3. IPC layer (Tauri commands + events)
+
+### Naming convention
+
+- Command: `<domain>:<action>` → di Rust pakai `#[tauri::command]`.
+- Event: `<domain>:<event>` → di Rust pakai `app.emit_all(...)`.
+
+### Contoh command (Rust → TS)
+
+```rust
+// apps/desktop/src-tauri/src/commands/anggota.rs
+#[tauri::command]
+pub async fn anggota_list(
+    state: tauri::State<'_, DbPool>,
+    query: Option<String>,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<Anggota>, String> { ... }
+```
+
+```ts
+// apps/desktop/src/features/anggota/api.ts
+import { invoke } from '@tauri-apps/api/core';
+import type { Anggota } from '@perpustakaan/shared/types';
+
+export async function anggotaList(
+  query: string | null,
+  limit: number,
+  offset: number,
+): Promise<Anggota[]> {
+  return invoke('anggota_list', { query, limit, offset });
+}
+```
+
+### Event yang dipakai
+
+| Event | Emitter | Listener | Payload |
+|---|---|---|---|
+| `identity:changed` | Settings save | Sidebar/Header/Dashboard/KTA | `{ nama, logo_path, alamat, ... }` |
+| `db:migrated` | App startup | Splash screen | `{ from: int, to: int }` |
+| `auth:logout` | Logout button | App root | `{}` |
+| `print:complete` | Printer plugin | Toast | `{ status: 'ok' \| 'error' }` |
+
+## 4. DB layer
+
+### Reuse schema v1
+
+File `src/perpustakaan/db/schema.sql` (15 tabel) di-copy ke
+`apps/desktop/src-tauri/src/db/schema.sql`. Tabel:
+
+- `schema_version`, `settings`, `users`
+- `ddc`, `kelas`, `penerbit`
+- `anggota`, `buku`, `eksemplar`
+- `peminjaman`, `peminjaman_item`
+- `kunjungan`, `kas`
+- `permissions`, `user_permissions`, `audit_log`
+
+### Tabel baru di v2
+
+Untuk revisi #17 (master data lengkap), tambah migration:
+
+```sql
+-- migrations/002_master_data.sql
+CREATE TABLE IF NOT EXISTS kategori (
+    id INTEGER PRIMARY KEY,
+    nama TEXT UNIQUE NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS bahasa (
+    kode TEXT PRIMARY KEY,        -- ISO 639-1 (id, en, ar, jw, ...)
+    nama TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS jurusan (
+    id INTEGER PRIMARY KEY,
+    nama TEXT UNIQUE NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS agama (
+    id INTEGER PRIMARY KEY,
+    nama TEXT UNIQUE NOT NULL
+);
+
+-- Tabel untuk template KTA (revisi #14)
+CREATE TABLE IF NOT EXISTS kta_templates (
+    id INTEGER PRIMARY KEY,
+    nama TEXT NOT NULL,
+    layout_json TEXT NOT NULL,    -- JSON struktur field positions
+    is_default INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Tabel untuk remember-me token (revisi #10)
+CREATE TABLE IF NOT EXISTS auth_tokens (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+### Migration runner
+
+Pakai `tauri-plugin-sql` migration loader:
+
+```rust
+tauri::Builder::default()
+    .plugin(tauri_plugin_sql::Builder::default()
+        .add_migrations("sqlite:perpustakaan-v2.db", vec![
+            Migration { version: 1, description: "init", sql: include_str!("db/schema.sql"), kind: MigrationKind::Up },
+            Migration { version: 2, description: "master_data", sql: include_str!("db/migrations/002_master_data.sql"), kind: MigrationKind::Up },
+        ])
+        .build())
+    .run(...);
+```
+
+## 5. Build pipeline
+
+### Dev
+
+```bash
+pnpm install                       # root install (workspace-aware)
+pnpm --filter desktop tauri dev    # Vite dev + Tauri webview
+```
+
+### Production build
+
+```bash
+pnpm --filter desktop tauri build  # bundle MSI / .exe / .deb sesuai OS host
+```
+
+Output:
+
+- Windows: `apps/desktop/src-tauri/target/release/bundle/msi/*.msi`
+  + `apps/desktop/src-tauri/target/release/bundle/nsis/*.exe`
+- Linux: `target/release/bundle/{deb,appimage}/`
+- macOS: `target/release/bundle/{dmg,macos}/`
+
+### CI (GitHub Actions, mulai Devin 2)
+
+Workflow `.github/workflows/ci-v2.yml`:
+
+```yaml
+name: CI v2
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter desktop lint
+      - run: pnpm --filter desktop typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter desktop test
+
+  build-windows:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+    needs: [lint-typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - uses: dtolnay/rust-toolchain@stable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter desktop tauri build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: apps/desktop/src-tauri/target/release/bundle/msi/*.msi
+```
+
+### CI legacy
+
+`ci.yml` (Python lint/test) **tetap aktif** sampai Devin 12 melakukan
+release v1.0.0, lalu di-switch ke `if: false` (atau dihapus). Selama
+migrasi, Devin 1–11 hanya menambah file baru di `apps/`, `packages/`, `docs/`,
+sehingga tidak break Python CI.
+
+## 6. Konfigurasi Tauri penting
+
+`apps/desktop/src-tauri/tauri.conf.json` (highlight):
+
+```json
+{
+  "productName": "PerpustakaanOffline",
+  "version": "0.0.0",
+  "identifier": "id.alviarts.perpustakaan",
+  "app": {
+    "windows": [
+      {
+        "title": "Perpustakaan Offline",
+        "width": 1280,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "resizable": true,
+        "fullscreen": false,
+        "decorations": true
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self'; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline';"
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": ["msi", "nsis"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "windows": {
+      "wix": { "language": "en-US" },
+      "nsis": { "languages": ["English"] }
+    }
+  }
+}
+```
+
+## 7. Ringkasan tanggung jawab tiap layer
+
+| Layer | Tanggung jawab |
+|---|---|
+| Frontend React | UI, animasi, form validation, state ephemeral, charts, PDF gen (pdf-lib) |
+| Zustand store | State global lintas page (theme, sidebar, auth, identity, i18n) |
+| TanStack Router | Routing + search params + data loaders |
+| Tauri commands (Rust) | Business logic kritis (auth, peminjaman validation), DB CRUD, file I/O |
+| Tauri events (Rust) | Push notifikasi ke frontend (identity changed, print complete) |
+| sqlx + SQLite | Persistent storage (offline-first) |
+| Stronghold/keyring | Token "Ingat Saya" terenkripsi |
+| Inno Setup / WiX | Windows installer (MSI atau .exe wizard) |
+
+## 8. Constraint penting
+
+- **Offline-first**: tidak boleh ada API call ke external server (kecuali
+  Google Sheets sync, opt-in di Settings).
+- **Single-tenant**: 1 sekolah = 1 instalasi DB.
+- **Windows is primary target**: tidak ada gating fitur untuk Linux/macOS,
+  tapi prioritas QA Windows.
+- **Backward compat**: data v1 harus bisa di-migrate (Devin 12 script).

--- a/docs/migration-v2/ASSETS_REUSE.md
+++ b/docs/migration-v2/ASSETS_REUSE.md
@@ -1,0 +1,295 @@
+# Assets & Code Reuse — Migration v2
+
+> Decision matrix: bagian v1 mana yang **REUSE** (copy/port), **BUANG** (drop),
+> **PORT** (translasi konsep), dan **MIGRATE** (transform via script).
+>
+> Pakai sebagai checklist saat Devin 2 mulai scaffolding.
+
+## 1. REUSE — copy langsung / minor adapt
+
+### 1.1 SQLite schema
+
+| File v1 | File v2 |
+|---|---|
+| `src/perpustakaan/db/schema.sql` | `apps/desktop/src-tauri/src/db/schema.sql` |
+
+- Copy 1:1 (15 tabel inti).
+- Tambah migration v2 untuk tabel baru (lihat ARCHITECTURE.md §4): `kategori`,
+  `bahasa`, `jurusan`, `agama`, `kta_templates`, `auth_tokens`.
+- Pertahankan PRAGMA: `foreign_keys = ON`, `journal_mode = WAL`.
+- Index, trigger, default values: copy semua.
+
+### 1.2 Business logic patterns
+
+Logic CRUD + validasi v1 (`src/perpustakaan/services/*.py`,
+`src/perpustakaan/models/*.py`) **tidak di-port file-by-file**, tapi pattern-nya
+di-port:
+
+| File v1 | Pattern → v2 lokasi |
+|---|---|
+| `services/auth.py` | bcrypt verify + session → `src-tauri/src/commands/auth.rs` |
+| `services/permissions.py` + `permissions_registry.py` | RBAC matrix → `src-tauri/src/commands/permissions.rs` + `src/stores/authStore.ts` |
+| `services/barcode_service.py` | barcode QR/Code39 → `src/lib/barcode.ts` (frontend) |
+| `services/pdf_service.py` | PDF KTA + nota + laporan → `src/lib/pdf/*.ts` (pdf-lib) |
+| `services/excel_service.py` | import/export Excel → `src/lib/excel.ts` (`xlsx` lib) |
+| `services/sheets_service.py` | Google Sheets sync → `src/features/settings/sync/sheets.ts` |
+| `services/report_service.py` | aggregate query laporan → `src-tauri/src/commands/laporan.rs` |
+| `services/backup_service.py` + `backup_scheduler.py` | DB backup + jadwal → `src-tauri/src/commands/backup.rs` + Tauri scheduler |
+| `models/anggota.py` ... `models/audit_log.py` | CRUD per domain → `src-tauri/src/commands/<domain>.rs` |
+
+> Devin pengerja sesi yang relevan WAJIB baca file v1 yang dimaksud sebagai
+> source of truth untuk: kolom yang dipakai, validasi business, edge cases.
+
+### 1.3 i18n strings
+
+| File v1 | File v2 |
+|---|---|
+| `src/perpustakaan/i18n.py` | `apps/desktop/src/i18n/{id,en}/*.json` |
+
+- Extract semua string ID/EN dari `i18n.py` → JSON.
+- Pecah per-namespace: `common.json`, `auth.json`, `dashboard.json`, dll.
+- Sweep audit wording (revisi #25) di Devin 11.
+
+### 1.4 Test fixtures + seed
+
+| File v1 | File v2 |
+|---|---|
+| `tests/conftest.py` | `apps/desktop/tests/fixtures/db.ts` |
+| `src/perpustakaan/db/seed.py` (demo data) | `scripts/seed-demo.ts` |
+| `assets/ddc-source.txt` | `apps/desktop/src-tauri/resources/seed/ddc.txt` |
+
+- Demo data 5 anggota + 10 buku + 2 peminjaman: port jadi seed script TS.
+- Pakai sama key/values supaya QA visual konsisten dengan v1.
+
+### 1.5 Permissions catalog
+
+`services/permissions_registry.py` → port jadi TS const di
+`apps/desktop/src/lib/permissions.ts` (single source of truth, share via
+`packages/shared`).
+
+### 1.6 Manual book content
+
+| File v1 | File v2 |
+|---|---|
+| `docs/manual.md` (Markdown plain) | `docs/migration-v2/manual/*.md` (multi-page) → bundle `apps/desktop/src-tauri/resources/manual/index.html` |
+
+- Source markdown di-split per chapter, lalu di-build jadi static HTML
+  (mdBook / VitePress / Docusaurus minimal).
+- Devin 11 yang generate.
+
+---
+
+## 2. BUANG — tidak di-port
+
+### 2.1 customtkinter UI layer
+
+| Path v1 | Status |
+|---|---|
+| `src/perpustakaan/gui/` | DROP semua (`__init__.py`, `app.py` parts, `login.py`, `main_window.py`, `views/*.py`, `widgets.py`, `password_dialogs.py`, `help_dialog.py`, `tour.py`) |
+| `src/perpustakaan/gui/animations.py` + `animation_player.py` | DROP (PIL procedural animation tidak relevan di webview) |
+| `src/perpustakaan/gui/illustrations.py` | DROP (procedural PIL drawing → ganti SVG/PNG) |
+| `src/perpustakaan/gui/effects.py` | DROP (CT-specific effects) |
+| `src/perpustakaan/gui/icons.py`, `phosphor.py` | DROP source Python, port ke TS (lihat §3) |
+| `src/perpustakaan/gui/design_tokens.py` | DROP (replace dengan Tailwind config) |
+
+### 2.2 Asset procedural
+
+| Path v1 | Status |
+|---|---|
+| `assets/animations/` | DROP (frame-based PIL animation) |
+| `assets/illustrations/` | DROP (procedural PNG) |
+
+Replace dengan asset baru (revisi #6) di `apps/desktop/public/illustrations/`.
+
+### 2.3 Build pipeline lama
+
+| Path v1 | Status |
+|---|---|
+| `build.spec` (PyInstaller) | DROP (Devin 12) |
+| `build.bat` | DROP (Devin 12) |
+| `installer/installer.iss` | REPLACE (Devin 12 bikin baru di `apps/desktop/src-tauri/installer/inno-setup.iss`) |
+
+> CATATAN: file ini tetap ada selama migrasi (Devin 2–11) supaya v1 masih bisa
+> di-build kalau ada bug critical yang harus di-patch. Devin 12 akan hapus
+> setelah release v1.0.0 v2 stable.
+
+### 2.4 Test customtkinter
+
+| Path v1 | Status |
+|---|---|
+| `tests/test_smoke_gui.py` | DROP (CT smoke test, replace Playwright) |
+| `tests/test_widgets_visual.py` | DROP |
+| `tests/test_animation_player.py`, `test_animations_v4.py`, `test_effects.py` | DROP |
+| `tests/test_design_tokens.py` | DROP |
+| `tests/test_help_dialog.py`, `test_tour_contextual.py` | DROP |
+| `tests/test_phosphor.py`, `test_icons.py`, `test_fonts.py` | DROP (Python-side, replace dengan Vitest) |
+
+Tests yang tetap relevan (logic, bukan GUI) → port ke Vitest:
+`test_auth.py`, `test_anggota_buku.py`, `test_peminjaman.py`,
+`test_password_security.py`, `test_permissions.py`, `test_backup_terjadwal.py`,
+`test_seed.py`.
+
+### 2.5 Misc
+
+- Smoke test screenshots (`docs/smoke-test/*.png`) — DROP (akan diganti
+  Playwright screenshots).
+- `scripts/` Python (`init_db.py`, dll.) — DROP, replace dengan TS scripts.
+
+---
+
+## 3. PORT — translasi konsep / library
+
+### 3.1 Phosphor icons
+
+| v1 | v2 |
+|---|---|
+| `gui/phosphor.py` (custom mapping) | `@phosphor-icons/react` |
+
+- Daftar icon yang dipakai v1 → cari counterpart React-nya:
+  - `gui/phosphor.py` define alias seperti `house`, `users`, `book`,
+    `gear`, `chart-line`, etc.
+  - Di v2 import langsung: `import { House, Users, Book, Gear, ChartLine } from '@phosphor-icons/react'`.
+- Devin 2 generate file index `apps/desktop/src/lib/icons.ts` yang re-export
+  yang dipakai untuk konsistensi tree-shaking.
+
+### 3.2 Theme tokens
+
+| v1 (`design_tokens.py`) | v2 |
+|---|---|
+| color palette dict | `apps/desktop/tailwind.config.ts` `theme.extend.colors` |
+| spacing scale | Tailwind default + custom |
+| typography | Tailwind `fontFamily` + `fontSize` |
+
+Reuse warna kunci v1 (primary brand color, dll.) — copy hex-nya.
+
+### 3.3 Animation patterns
+
+| v1 (`gui/animations.py`) | v2 |
+|---|---|
+| Tween fade/slide procedural | Framer Motion `<motion.div initial animate exit>` |
+| Bounce / spring | Framer Motion `transition={{ type: 'spring' }}` |
+
+### 3.4 Form validation
+
+| v1 (Tk validation manual) | v2 |
+|---|---|
+| `entry.config(validate='key')` | `react-hook-form` + `zod` schema |
+| password rules custom | `zod.string().min(8).regex(...)` + reuse rule list dari `password_dialogs.py` |
+
+### 3.5 Tour / onboarding
+
+| v1 (`tour.py`) | v2 |
+|---|---|
+| custom highlight overlay | `driver.js` atau `react-joyride` (optional, Devin 11) |
+
+### 3.6 Help dialog
+
+| v1 (`help_dialog.py` + `help_content.py`) | v2 |
+|---|---|
+| modal customtkinter | shadcn `Sheet` / `Dialog` + Markdown render (revisi #4 manual HTML) |
+
+### 3.7 Fonts
+
+| v1 (`assets/fonts/*`) | v2 |
+|---|---|
+| TTF bundled di PyInstaller | TTF/WOFF2 bundle di `apps/desktop/public/fonts/` + `@font-face` di `index.css` |
+
+---
+
+## 4. MIGRATE — transform via script
+
+### 4.1 Database v1 → v2
+
+Devin 12 bikin script `scripts/migrate-v1-to-v2.ts`:
+
+- Input: path ke `.db` v1 (default `%APPDATA%/PerpustakaanOffline/perpustakaan.db`).
+- Output: `.db` v2 (default `%APPDATA%/PerpustakaanOffline/perpustakaan-v2.db`).
+- Flow:
+  1. Buka DB v1 read-only.
+  2. Buat DB v2 fresh dengan schema baru (apply semua migrations).
+  3. Copy row per tabel (skip `schema_version`, applied otomatis).
+  4. Untuk tabel baru di v2 (kategori/bahasa/jurusan/agama/kta_templates):
+     seed default values + (jika ada) extract dari v1 settings JSON.
+  5. Validasi: count row tiap tabel match.
+  6. Backup `.db` v1 → `<filename>.v1-backup-<timestamp>.db`.
+  7. Print summary report (count per tabel, error list).
+- UI: tombol "Migrasi DB v1" di Settings → Backup tab (Devin 11) atau
+  one-shot dialog di first launch v2 (Devin 12).
+
+### 4.2 Settings JSON schema
+
+v1 `settings` table key/value, v2 tetap key/value (reuse), tapi nambah key
+baru:
+
+```
+kta_template_default_id    -> int (id row di kta_templates)
+sidebar_collapsed          -> bool (tapi yang otoritatif tetap localStorage)
+theme                       -> 'light' | 'dark' | 'system'
+language                    -> 'id' | 'en'
+remember_me_enabled         -> bool
+backup_schedule_cron        -> string (e.g. '0 2 * * *' = 2am daily)
+```
+
+Migration script add default values untuk key baru.
+
+### 4.3 User passwords
+
+Hash bcrypt v1 langsung di-reuse v2 (algoritma sama). Tidak perlu user reset
+password.
+
+### 4.4 Asset copy
+
+KTA template lama (`settings.kta_layout_json` di v1) di-import ke `kta_templates`
+(satu template default = layout v1) supaya KTA tidak hilang.
+
+---
+
+## 5. Quick reference table
+
+| v1 path | Action | v2 path |
+|---|---|---|
+| `src/perpustakaan/db/schema.sql` | REUSE | `apps/desktop/src-tauri/src/db/schema.sql` |
+| `src/perpustakaan/db/seed.py` | PORT | `scripts/seed-demo.ts` |
+| `src/perpustakaan/i18n.py` | REUSE strings | `apps/desktop/src/i18n/{id,en}/*.json` |
+| `src/perpustakaan/services/auth.py` | PORT logic | `apps/desktop/src-tauri/src/commands/auth.rs` |
+| `src/perpustakaan/services/permissions*.py` | PORT | `apps/desktop/src-tauri/src/commands/permissions.rs` + TS const |
+| `src/perpustakaan/services/pdf_service.py` | PORT | `apps/desktop/src/lib/pdf/*.ts` |
+| `src/perpustakaan/services/barcode_service.py` | PORT | `apps/desktop/src/lib/barcode.ts` |
+| `src/perpustakaan/services/excel_service.py` | PORT | `apps/desktop/src/lib/excel.ts` |
+| `src/perpustakaan/services/sheets_service.py` | PORT | `apps/desktop/src/features/settings/sync/sheets.ts` |
+| `src/perpustakaan/services/report_service.py` | PORT | `apps/desktop/src-tauri/src/commands/laporan.rs` |
+| `src/perpustakaan/services/backup*.py` | PORT | `apps/desktop/src-tauri/src/commands/backup.rs` |
+| `src/perpustakaan/models/*.py` | PORT (reference) | `apps/desktop/src-tauri/src/commands/*.rs` |
+| `src/perpustakaan/gui/` | DROP | `apps/desktop/src/features/*` (rewrite) |
+| `src/perpustakaan/gui/icons.py`, `phosphor.py` | PORT | `apps/desktop/src/lib/icons.ts` (re-export `@phosphor-icons/react`) |
+| `src/perpustakaan/gui/design_tokens.py` | PORT | `apps/desktop/tailwind.config.ts` |
+| `src/perpustakaan/gui/illustrations.py` | DROP | `apps/desktop/public/illustrations/*.svg` (asset baru #6) |
+| `src/perpustakaan/gui/animations.py` | DROP | Framer Motion / Tailwind animate-in |
+| `src/perpustakaan/gui/help_dialog.py` + `help_content.py` | DROP | Manual HTML #4 |
+| `assets/ddc-source.txt` | REUSE | `apps/desktop/src-tauri/resources/seed/ddc.txt` |
+| `assets/animations/`, `assets/illustrations/` | DROP | (lihat §6 ASSETS_REUSE) |
+| `assets/fonts/*` | REUSE | `apps/desktop/public/fonts/` |
+| `assets/icons/` | REVIEW | Pertahankan yang non-procedural; rest replace |
+| `tests/test_auth.py`, `test_anggota_buku.py`, `test_peminjaman.py` | PORT logic | `apps/desktop/tests/unit/*.test.ts` |
+| `tests/test_smoke_gui.py` | DROP | `apps/desktop/tests/e2e/smoke.spec.ts` (Playwright) |
+| `build.spec`, `build.bat`, `installer/installer.iss` | DROP (Devin 12) | `apps/desktop/src-tauri/tauri.conf.json` + Tauri MSI/NSIS |
+| `docs/manual.md` | PORT | `docs/migration-v2/manual/*.md` → HTML bundled |
+| `docs/screenshots/` | KEEP (referensi) | (read-only, baseline visual) |
+
+---
+
+## 6. Catatan untuk Devin 12 (release v1.0.0)
+
+Setelah v2 stable + tested:
+
+1. Move `src/perpustakaan/` → `legacy/v1/perpustakaan/` (atau tag git +
+   delete dari main).
+2. Move `tests/` (file yang di-DROP) ke `legacy/v1/tests/`.
+3. Hapus `build.spec`, `build.bat`, `installer/`.
+4. Disable workflow `ci.yml` (rename ke `ci-v1.yml.disabled` atau hapus).
+5. Update `README.md` jadi panduan v2.
+6. Tag `v1.0.0` (release pertama v2 stable).
+7. Hapus `.venv`, `requirements.txt`, `pyproject.toml` Python (atau pertahankan
+   sebagai stub kalau ada utilitas mig CLI).
+
+Cleanup ini di-handle by Devin 12, bukan Devin 1–11.

--- a/docs/migration-v2/INSTRUCTION_TEMPLATE.md
+++ b/docs/migration-v2/INSTRUCTION_TEMPLATE.md
@@ -1,0 +1,132 @@
+# Devin Migration v2 — Universal Prompt Template
+
+> Copy-paste prompt di bawah ini saat memulai sesi Devin baru untuk
+> migrasi `perpustakaan-offline`. Devin akan otomatis menentukan dirinya sesi
+> ke-berapa berdasarkan state `docs/migration-v2/PROGRESS.md`.
+>
+> Prompt ini sengaja sama persis dengan yang dipakai untuk Devin 1, sehingga
+> semua sesi konsisten.
+
+---
+
+```
+Repo: alviarts/perpustakaan-offline
+Branch utama: main
+Bahasa komunikasi: Indonesia. Bahasa commit/PR: English (conventional commits).
+
+Saya migrasi full rewrite Perpustakaan Offline dari Python+customtkinter ke modern stack (Tauri 2.0 + React 18 + TypeScript + Tailwind 3 + shadcn/ui + Zustand + Vite + pnpm + Vitest + Playwright). Total 12 sesi Devin sequential. Sesi yang kamu kerjakan ditentukan otomatis berdasarkan state repo.
+
+== PROTOKOL ==
+
+STEP 1 — Sync state
+1. `git clone https://github.com/alviarts/perpustakaan-offline.git` (atau pull kalau sudah ada)
+2. `cd perpustakaan-offline && git checkout main && git pull origin main`
+3. Cek `docs/migration-v2/PROGRESS.md`:
+   - Tidak ada → kamu Devin 1, lanjut STEP 2A.
+   - Ada → kamu Devin 2-12, lanjut STEP 2B.
+
+Folder `docs/migration-v2/references/` berisi 36 screenshot dengan INDEX.md. Pelajari image yang relevan sebelum ngerjakan revisi.
+
+STEP 2A — Devin 1 (bootstrap, NO KODE, dokumen saja)
+Bikin 7 set file di `docs/migration-v2/`:
+
+1. `REVISION_BACKLOG.md` — 26 revisi dengan struktur: ID, judul, kategori (UI/UX/Bug/Asset/Logic), scope detail (file v1, lokasi v2), dependency, prioritas P0/P1/P2, link ke `references/revision-NN-*.png`, definition of done.
+
+2. `STACK_DECISION.md` — analisis Tauri 2.0 vs Electron + rekomendasi (default Tauri 2.0). Sub-decision: DB strategy (better-sqlite3 vs sqlx vs Python sidecar), state mgmt (Zustand vs Redux Toolkit), routing (TanStack Router vs React Router).
+
+3. `ARCHITECTURE.md` — diagram arsitektur v2: Frontend (React+TS+Tailwind+shadcn+Zustand), IPC (Tauri command/event), Backend (Rust + Tauri plugins sqlite/fs/dialog/printer), DB layer reuse schema v1, file structure (`apps/desktop/`, `apps/web/`, `packages/shared/`), build pipeline (Vite + Tauri CLI + GitHub Actions).
+
+4. `ASSETS_REUSE.md` — REUSE: SQLite schema (`src/perpustakaan/db.py`), business logic patterns (`services/*.py`), i18n strings → JSON, test fixtures, seed data DDC/ISO 639. BUANG: customtkinter UI (`gui/`), procedural illustrations/animations, build.spec, installer.iss. PORT: phosphor icons → `@phosphor-icons/react`. MIGRATE: Devin 12 bikin script .db v1 → v2.
+
+5. `PROGRESS.md` — YAML/markdown table machine-parseable, 12 sesi:
+   - id, title, status (PENDING/IN_PROGRESS/COMPLETED), pr (URL atau PENDING), completed_at, dependencies (list of session ids).
+   - Sesi 1 = COMPLETED setelah PR ini merge.
+
+6. `sessions/SESSION_01.md` ... `SESSION_12.md` — per file: Goal, Scope, Revisi tercover, Dependency, Tasks breakdown, Deliverables (file/test/UI), Definition of done. Breakdown:
+   - 01: Bootstrap migration plan (no kode)
+   - 02: Scaffolding Tauri+React+TS+Tailwind+shadcn project + setup CI/CD baru + reuse SQLite schema + login screen + theme system + i18n. Covers #5, #8, #10, #25 partial.
+   - 03: Layout shell (sidebar collapsible + header + window responsive + identitas sync foundation). Covers #7, #11, #13, #22.
+   - 04: Data Anggota CRUD + autocomplete + live search + dropdown styled. Covers #15, #17 (anggota), #19, #20 (anggota).
+   - 05: Data Buku CRUD + Master Data komplit (DDC/Kategori/Bahasa/Jurusan/Kelas/Agama). Covers #16, #17 full.
+   - 06: Peminjaman + Pengembalian (date picker, panel info, validasi, print nota). Covers #12, #21.
+   - 07: Kunjungan redesign (transparent illustrations, quick stats, filter date range). Covers #18.
+   - 08: Dashboard modern dengan charts (3 hero card + donut + bar + featured row). Covers #9.
+   - 09: Laporan komplit (Grafik/Top Peminjam/Top Buku/Kas/Backup). Covers #23.
+   - 10: KTA system komplit (template editor + barcode + auto-fill + print). Covers #14.
+   - 11: Settings comprehensive 12 kategori + manual book HTML + audit wording final. Covers #4, #24, #25 full.
+   - 12: Installer Tauri MSI (logo, license, no language picker, scrollbar polish, asset bundle) + release v1.0.0. Covers #1, #2, #3, #6, #26.
+
+7. `INSTRUCTION_TEMPLATE.md` — copy-paste prompt universal yang lagi kamu baca ini.
+
+Lalu:
+- Branch: `devin/<unix-timestamp>-migration-v2-bootstrap`
+- Commit: `docs(migration-v2): bootstrap migration plan + 12 session breakdown`
+- Push, bikin PR title `docs(migration-v2): bootstrap migration plan` body berisi ringkasan + link tiap file + footer "Devin session 1/12".
+- Tunggu CI pass.
+- Final message ke user: link PR + minta merge supaya Devin 2 bisa lanjut.
+
+STEP 2B — Devin 2-12 (eksekusi sesi berikutnya)
+1. Baca `docs/migration-v2/PROGRESS.md`. Cari sesi pertama dengan status PENDING.
+2. Baca `docs/migration-v2/sessions/SESSION_NN.md`.
+3. Verifikasi dependency semua COMPLETED. Kalau belum, STOP, kasih tau user.
+4. Branch: `devin/<unix-timestamp>-session-NN-<short-name>`.
+5. Eksekusi tasks sampai semua deliverables tercapai.
+6. Pastikan tests pass + lint/typecheck pass.
+7. Update `PROGRESS.md`: sesi NN PENDING → COMPLETED dengan tanggal + PR placeholder.
+8. Commit: `feat(session-NN): <judul singkat>`.
+9. Push, bikin PR title `feat(session-NN): <judul>` body berisi: Goal sesi, Revisi tercover, Deliverables checklist, Tests added, Screenshot/recording untuk UI, footer "Devin session NN/12".
+10. Tunggu CI pass via `git_pr` action pr_checks wait_mode=all.
+11. CI fail → fix max 3 attempt, masih fail eskalasi ke user.
+12. Final message ke user: link PR + minta merge.
+
+== ATURAN GLOBAL ==
+- JANGAN merge PR sendiri (review gate user).
+- JANGAN modify file di sesi lain (fokus scope sesi sekarang).
+- JANGAN skip update PROGRESS.md.
+- JANGAN force push ke main atau bypass branch protection.
+- WAJIB pull main dulu sebelum mulai.
+- WAJIB push branch + bikin PR sebelum stop.
+- WAJIB tunggu CI pass sebelum minta merge.
+- Pakai `git_pr` tool untuk PR (bukan gh CLI).
+
+== 26 REVISI (ringkasan, detail di REVISION_BACKLOG.md Devin 1) ==
+1. Logo installer + .exe icon (Start Menu/Search/Taskbar)
+2. Hapus Select Setup Language di installer
+3. License custom kredit "alvi arts / vwrks" + replace CD/box wizard graphic dengan logo Nusantara
+4. Manual book HTML responsif gantikan README.md
+5. Redesign login modern minimal (2-kolom, gradient, smooth animation)
+6. Asset quality high-res dari unDraw/Storyset/DrawKit (1024px+ PNG, no procedural)
+7. Sidebar collapsible (chevron toggle, persist state, Ctrl+B, tooltip on-hover, auto-collapse <1024px)
+8. Theme switcher dropdown (icon button + popover 3 row, fade-in)
+9. Redesign dashboard modern (3 hero card + donut + bar + featured row, replace Treeview)
+10. "Ingat Saya" auto-login (token bcrypt + AES, expire 30 hari)
+11. Sync identitas perpustakaan ke sidebar/header/dashboard hero/KTA/laporan/login/manual/About
+12. Date picker calendar popup (locale ID, range tahun configurable, "Hari Ini")
+13. Fix glitch fullscreen + responsive + animated resize (breakpoint 768/1280)
+14. Sistem KTA komplit (fix font path, template editor visual, auto-fill, barcode QR untuk peminjaman cepat)
+15. Live search instant debounced 200ms apply ke semua list view
+16. Fix layout Data Buku (master/detail, fix bounce_book empty state)
+17. Dropdown master data DDC/Kategori/Bahasa/Jurusan/Kelas/Agama dengan CRUD di Settings, seed online (Dewey, ISO 639)
+18. Fix Kunjungan animasi bg transparent + quick stat card + filter date range
+19. Style dropdown match width (popup full = trigger, animasi, keyboard nav)
+20. Autocomplete anggota & buku (2-line item, fuzzy match, smart suggest)
+21. Redesign Peminjaman komplit (autocomplete, date range, panel info anggota+buku, validasi, print nota, quick stats)
+22. Window resize fleksibel + tombol/menu tidak hidden saat windowed (resizable + minsize 800×600)
+23. Redesign Laporan (sidebar nav + filter + Grafik/Top Peminjam/Top Buku/Kas/Backup dengan charts)
+24. Settings 12 kategori mirip Google (search bar, tooltip, reset to default)
+25. Audit wording (rename Transaksi → Aturan Peminjaman, sweep semua label/dialog/error/i18n)
+26. Mouse wheel scroll global + smooth scroll + scrollbar fade auto-hide
+
+Mulai eksekusi STEP 1 sekarang. Tentukan Devin keberapa kamu, lanjut STEP 2A atau 2B.
+```
+
+---
+
+## Catatan pakai
+
+- Prompt di atas **idempotent**: aman dijalankan berulang. Devin akan otomatis
+  pilih sesi sesuai state `PROGRESS.md`.
+- Kalau mau force sesi tertentu (misal mau redo), bilang ke Devin: _"Skip
+  state check, langsung kerjakan SESSION_05"_.
+- Untuk sesi Devin 1 (bootstrap), prompt sama saja — Devin akan tahu kalau
+  `docs/migration-v2/PROGRESS.md` belum ada.

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -21,7 +21,7 @@ project: perpustakaan-offline
 migration: v1 (python+customtkinter) -> v2 (tauri 2.0 + react 18 + ts + tailwind 3 + shadcn + zustand)
 total_sessions: 12
 schema_version: 1
-last_updated: 2025-05-03
+last_updated: 2026-05-03
 ```
 
 ## Sessions
@@ -31,7 +31,7 @@ sessions:
   - id: 1
     title: Bootstrap migration plan (no kode, dokumen saja)
     status: IN_PROGRESS
-    pr: PENDING
+    pr: https://github.com/alviarts/perpustakaan-offline/pull/35
     completed_at: null
     dependencies: []
 
@@ -117,7 +117,7 @@ sessions:
 
 | # | Session | Status | PR | Completed | Deps |
 |---|---|---|---|---|---|
-| 1 | Bootstrap migration plan | IN_PROGRESS | PENDING | — | — |
+| 1 | Bootstrap migration plan | IN_PROGRESS | [#35](https://github.com/alviarts/perpustakaan-offline/pull/35) | — | — |
 | 2 | Scaffolding + login + theme + i18n | PENDING | PENDING | — | 1 |
 | 3 | Layout shell (sidebar + header + responsive) | PENDING | PENDING | — | 2 |
 | 4 | Data Anggota CRUD + search/autocomplete | PENDING | PENDING | — | 3 |

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -1,0 +1,151 @@
+# Migration v2 — Progress Tracker
+
+> **Source of truth** untuk state migrasi `Perpustakaan Offline` dari Python +
+> customtkinter (v1) ke Tauri 2.0 + React 18 + TypeScript + Tailwind 3 +
+> shadcn/ui + Zustand + Vite + pnpm + Vitest + Playwright (v2).
+>
+> **Total 12 sesi Devin sequential.** Setiap sesi = 1 PR.
+> File ini di-update oleh setiap Devin di akhir sesinya. Devin berikutnya membaca
+> file ini untuk menentukan sesi mana yang harus dikerjakan (sesi pertama dengan
+> status `PENDING` dan semua dependency `COMPLETED`).
+>
+> Format: machine-parseable (YAML front-matter + tabel Markdown).
+> Jangan ubah field `id` / `dependencies` tanpa diskusi — itu memutus rantai sesi.
+
+---
+
+## Meta
+
+```yaml
+project: perpustakaan-offline
+migration: v1 (python+customtkinter) -> v2 (tauri 2.0 + react 18 + ts + tailwind 3 + shadcn + zustand)
+total_sessions: 12
+schema_version: 1
+last_updated: 2025-05-03
+```
+
+## Sessions
+
+```yaml
+sessions:
+  - id: 1
+    title: Bootstrap migration plan (no kode, dokumen saja)
+    status: IN_PROGRESS
+    pr: PENDING
+    completed_at: null
+    dependencies: []
+
+  - id: 2
+    title: Scaffolding Tauri+React+TS+Tailwind+shadcn + CI/CD baru + reuse SQLite schema + login + theme + i18n
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [1]
+
+  - id: 3
+    title: Layout shell (sidebar collapsible + header + window responsive + identitas sync foundation)
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [2]
+
+  - id: 4
+    title: Data Anggota CRUD + autocomplete + live search + dropdown styled
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [3]
+
+  - id: 5
+    title: Data Buku CRUD + Master Data komplit (DDC/Kategori/Bahasa/Jurusan/Kelas/Agama)
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [4]
+
+  - id: 6
+    title: Peminjaman + Pengembalian (date picker, panel info, validasi, print nota)
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [4, 5]
+
+  - id: 7
+    title: Kunjungan redesign (transparent illustrations, quick stats, filter date range)
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [3, 4]
+
+  - id: 8
+    title: Dashboard modern dengan charts (3 hero card + donut + bar + featured row)
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [4, 5, 6]
+
+  - id: 9
+    title: Laporan komplit (Grafik / Top Peminjam / Top Buku / Kas / Backup)
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [6, 7, 8]
+
+  - id: 10
+    title: KTA system komplit (template editor + barcode + auto-fill + print)
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [4, 5]
+
+  - id: 11
+    title: Settings comprehensive 12 kategori + manual book HTML + audit wording final
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [3, 5, 10]
+
+  - id: 12
+    title: Installer Tauri MSI (logo, license, no language picker, scrollbar polish, asset bundle) + release v1.0.0
+    status: PENDING
+    pr: PENDING
+    completed_at: null
+    dependencies: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+```
+
+## Quick view (human)
+
+| # | Session | Status | PR | Completed | Deps |
+|---|---|---|---|---|---|
+| 1 | Bootstrap migration plan | IN_PROGRESS | PENDING | — | — |
+| 2 | Scaffolding + login + theme + i18n | PENDING | PENDING | — | 1 |
+| 3 | Layout shell (sidebar + header + responsive) | PENDING | PENDING | — | 2 |
+| 4 | Data Anggota CRUD + search/autocomplete | PENDING | PENDING | — | 3 |
+| 5 | Data Buku CRUD + Master Data | PENDING | PENDING | — | 4 |
+| 6 | Peminjaman + Pengembalian | PENDING | PENDING | — | 4, 5 |
+| 7 | Kunjungan redesign | PENDING | PENDING | — | 3, 4 |
+| 8 | Dashboard modern + charts | PENDING | PENDING | — | 4, 5, 6 |
+| 9 | Laporan komplit | PENDING | PENDING | — | 6, 7, 8 |
+| 10 | KTA system | PENDING | PENDING | — | 4, 5 |
+| 11 | Settings 12 kategori + manual + audit wording | PENDING | PENDING | — | 3, 5, 10 |
+| 12 | Installer MSI + release v1.0.0 | PENDING | PENDING | — | 2..11 |
+
+## Update protocol
+
+Setiap Devin di akhir sesinya WAJIB:
+
+1. Update field `status` sesi yang dikerjakan dari `PENDING` → `COMPLETED`.
+2. Set `pr` ke URL PR yang dibuat.
+3. Set `completed_at` ke tanggal ISO (`YYYY-MM-DD`).
+4. JANGAN ubah `id`, `dependencies`, atau urutan sesi.
+5. Update juga tabel "Quick view" supaya konsisten.
+
+Kalau sesi blocked (misal dependency belum COMPLETED), STOP dan kasih tau user.
+JANGAN bypass dependency.
+
+## Status legend
+
+- `PENDING` — belum dikerjakan, menunggu giliran.
+- `IN_PROGRESS` — Devin sedang ngerjakan (PR belum merge).
+- `COMPLETED` — PR sudah merge ke `main`.
+- `BLOCKED` — ada masalah, butuh keputusan user (jelaskan di PR / chat).

--- a/docs/migration-v2/REVISION_BACKLOG.md
+++ b/docs/migration-v2/REVISION_BACKLOG.md
@@ -1,0 +1,826 @@
+# Revision Backlog — Migration v2
+
+> 26 revisi yang harus dikerjakan selama migrasi v1 → v2. Tiap revisi punya:
+> **ID**, **Judul**, **Kategori**, **Scope detail** (file v1 → lokasi v2),
+> **Dependency** ke revisi lain, **Prioritas** (P0/P1/P2),
+> **Reference image** (di `docs/migration-v2/references/`), dan
+> **Definition of Done**.
+>
+> Mapping revisi → sesi ada di kolom **Sesi**. Detail per-sesi di
+> `docs/migration-v2/sessions/SESSION_NN.md`.
+
+## Legenda
+
+- **Kategori**: `UI` (visual), `UX` (alur), `Bug`, `Asset`, `Logic`.
+- **Prioritas**:
+  - `P0` — blocker rilis v2 (fitur inti tidak jalan tanpa ini).
+  - `P1` — penting, harus masuk v1.0.0 tapi punya workaround sementara.
+  - `P2` — nice-to-have, boleh slip ke v1.1 kalau time-box ketat.
+- **Reference image**: filename pattern `revision-NN-<short>.png` (misal
+  `revision-05-login.png`). Ditaruh di `docs/migration-v2/references/`.
+  Jika belum ada (Devin 1 belum drop), pakai screenshot v1 di
+  `docs/screenshots/` sebagai baseline visual.
+
+---
+
+## Revisi #1 — Logo installer + `.exe` icon
+
+| Field | Value |
+|---|---|
+| **Kategori** | Asset |
+| **Prioritas** | P1 |
+| **Sesi** | 12 |
+| **Dependency** | — |
+| **Reference** | `references/revision-01-installer-logo.png` |
+
+**Scope v1 → v2**
+
+- v1: `installer/installer.iss` (Inno Setup) + `build.spec` PyInstaller (icon
+  Windows lewat `--icon`).
+- v2: `apps/desktop/src-tauri/tauri.conf.json` field `bundle.icon`
+  (multiple sizes: `32x32.png`, `128x128.png`, `128x128@2x.png`, `icon.icns`,
+  `icon.ico`). Inno Setup config v2 di
+  `apps/desktop/src-tauri/installer/inno-setup.iss` (atau pakai Tauri MSI native).
+
+**Definition of Done**
+
+- [ ] Logo `.ico` muncul di Start Menu, Windows Search, Taskbar pinned, Alt-Tab.
+- [ ] Logo `.png` muncul di window title-bar (Tauri default).
+- [ ] Installer `.exe` punya icon yang sama (bukan default Inno Setup ribbon).
+- [ ] Source asset (SVG / 1024×1024 PNG) di-commit ke
+      `apps/desktop/src-tauri/icons/source/`.
+
+---
+
+## Revisi #2 — Hapus "Select Setup Language" di installer
+
+| Field | Value |
+|---|---|
+| **Kategori** | UX |
+| **Prioritas** | P2 |
+| **Sesi** | 12 |
+| **Dependency** | — |
+| **Reference** | `references/revision-02-no-language-picker.png` |
+
+**Scope v1 → v2**
+
+- v1: Inno Setup default include semua bahasa di `[Languages]` → muncul popup
+  "Select Setup Language" sebelum wizard.
+- v2: Konfigurasi installer Tauri (Inno Setup template via Tauri) hanya
+  include 1 bahasa default (Indonesian atau English—pilih satu di Devin 11
+  audit wording). Set `ShowLanguageDialog=no` di section `[Setup]`.
+
+**Definition of Done**
+
+- [ ] Jalankan installer fresh di Windows 10/11 → popup language tidak muncul.
+- [ ] Wizard langsung ke welcome screen.
+
+---
+
+## Revisi #3 — License page custom + replace CD/box wizard graphic
+
+| Field | Value |
+|---|---|
+| **Kategori** | Asset / UX |
+| **Prioritas** | P2 |
+| **Sesi** | 12 |
+| **Dependency** | #1 (logo source) |
+| **Reference** | `references/revision-03-license-and-wizard.png` |
+
+**Scope v1 → v2**
+
+- v1: License default Inno Setup (`LicenseFile=` kosong / generic), wizard
+  graphic = box CD generic.
+- v2:
+  - License markdown disusun di `docs/legal/LICENSE-installer.txt` dengan
+    kredit "alvi arts / vwrks" + lisensi MIT/GPL-3.0 (samakan dengan
+    `LICENSE` repo root).
+  - Wizard graphic: render logo "Nusantara" (PNG 164×314 untuk `WizardImage`
+    + 55×58 untuk `WizardSmallImage`) → simpan di
+    `apps/desktop/src-tauri/installer/assets/`.
+
+**Definition of Done**
+
+- [ ] Halaman "License Agreement" di installer menampilkan teks kredit + isi
+      LICENSE.
+- [ ] Side-banner installer tidak lagi pakai box CD generic, tapi logo
+      Nusantara.
+
+---
+
+## Revisi #4 — Manual book HTML responsif gantikan README.md
+
+| Field | Value |
+|---|---|
+| **Kategori** | UX / UI |
+| **Prioritas** | P1 |
+| **Sesi** | 11 |
+| **Dependency** | #11 (sync identitas) |
+| **Reference** | `references/revision-04-manual-html.png` |
+
+**Scope v1 → v2**
+
+- v1: `docs/manual.md` Markdown plain, dibuka di GitHub.
+- v2: Generate `apps/desktop/src-tauri/resources/manual/index.html` dari
+  Markdown source (`docs/migration-v2/manual/*.md`) pakai
+  [`@docusaurus/...`] atau static gen sederhana (mdBook / VitePress build →
+  copy `dist/` ke resources). Buka via Tauri command `open_manual` ke browser
+  default user. Responsif (mobile/tablet preview), search bar, dark mode toggle.
+
+**Definition of Done**
+
+- [ ] Tombol "Manual" di sidebar / header membuka manual HTML di browser default.
+- [ ] Manual punya: nav sidebar, search, dark mode toggle, responsif <768px.
+- [ ] Identitas perpustakaan (nama sekolah) muncul di header manual (sync via
+      template).
+
+---
+
+## Revisi #5 — Redesign login modern minimal
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI |
+| **Prioritas** | P0 |
+| **Sesi** | 2 |
+| **Dependency** | #11 (sync identitas) |
+| **Reference** | `references/revision-05-login.png`, `docs/screenshots/01-login.png` (baseline v1) |
+
+**Scope v1 → v2**
+
+- v1: `src/perpustakaan/gui/login.py` (customtkinter form 1-kolom).
+- v2: `apps/desktop/src/features/auth/Login.tsx`:
+  - Layout 2-kolom (≥768px): kiri form, kanan illustration / gradient.
+  - <768px: collapse jadi 1-kolom (form di atas, ilustrasi di bawah / hidden).
+  - shadcn `Card` + `Form` + `Input` + `Button`.
+  - Animasi entrance (fade + slight slide-up, Framer Motion atau Tailwind
+    `animate-in`).
+  - Logo + nama perpustakaan dari Settings (revisi #11).
+  - Checkbox "Ingat Saya" (revisi #10).
+
+**Definition of Done**
+
+- [ ] Login screen render 2-kolom di desktop, 1-kolom di mobile.
+- [ ] Form submit pakai bcrypt verify (lewat Tauri command).
+- [ ] Animasi entrance halus, no flash.
+- [ ] Test Vitest (form validation) + Playwright e2e (login happy path).
+
+---
+
+## Revisi #6 — Asset quality high-res
+
+| Field | Value |
+|---|---|
+| **Kategori** | Asset |
+| **Prioritas** | P1 |
+| **Sesi** | 12 (final pass), bertahap di sesi UI |
+| **Dependency** | — |
+| **Reference** | `references/revision-06-assets-undraw.png` |
+
+**Scope v1 → v2**
+
+- v1: `assets/illustrations/*.png` (procedural / low-res), `assets/animations/`
+  (PIL animation frames).
+- v2: Sumber asset bebas pakai (royalty-free, attribution OK):
+  - [unDraw](https://undraw.co/) (SVG/PNG, customizable color)
+  - [Storyset](https://storyset.com/) (PNG/SVG, 1024px+)
+  - [DrawKit](https://drawkit.com/) (subset gratis)
+  - Letakkan di `apps/desktop/public/illustrations/`.
+  - Format SVG kalau tersedia (scalable). Kalau PNG, minimal 1024×1024.
+  - Naming: `<feature>-<state>.svg` (misal `kunjungan-empty.svg`,
+    `dashboard-hero.svg`).
+
+**Definition of Done**
+
+- [ ] Tidak ada lagi PIL procedural rendering di runtime.
+- [ ] Semua ilustrasi besar di-bundle sebagai SVG / 1024px+ PNG.
+- [ ] License/attribution tiap asset tercatat di `apps/desktop/public/illustrations/CREDITS.md`.
+
+---
+
+## Revisi #7 — Sidebar collapsible
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI / UX |
+| **Prioritas** | P0 |
+| **Sesi** | 3 |
+| **Dependency** | — |
+| **Reference** | `references/revision-07-sidebar.png` |
+
+**Scope v1 → v2**
+
+- v1: `gui/main_window.py` sidebar fixed width.
+- v2: `apps/desktop/src/components/layout/Sidebar.tsx` dengan shadcn `Sidebar`
+  (jika dipakai) atau custom:
+  - Chevron toggle di header sidebar (icon `CaretDoubleLeft` / `CaretDoubleRight`).
+  - Width: 240px expanded, 64px collapsed (icon-only).
+  - Persist state di `localStorage` (key `sidebar:collapsed`) + Zustand store.
+  - Keyboard shortcut `Ctrl+B` (Windows/Linux) / `Cmd+B` (macOS).
+  - Tooltip on-hover saat collapsed (shadcn `Tooltip`).
+  - Auto-collapse saat viewport <1024px (media query + Zustand action).
+
+**Definition of Done**
+
+- [ ] Toggle chevron expand/collapse smooth (CSS transition 200ms).
+- [ ] State persist after page reload (Zustand + localStorage).
+- [ ] `Ctrl+B` shortcut works global.
+- [ ] Tooltip muncul on-hover saat collapsed.
+- [ ] Resize window <1024px → sidebar auto-collapse.
+
+---
+
+## Revisi #8 — Theme switcher dropdown
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI |
+| **Prioritas** | P1 |
+| **Sesi** | 2 |
+| **Dependency** | — |
+| **Reference** | `references/revision-08-theme-switcher.png` |
+
+**Scope v1 → v2**
+
+- v1: `gui/main_window.py` theme manual lewat customtkinter set_appearance_mode.
+- v2: shadcn `DropdownMenu` di header:
+  - Icon button (`Sun` / `Moon` / `Monitor` dari `@phosphor-icons/react`).
+  - Popover 3 row: `Light`, `Dark`, `System`.
+  - Animasi fade-in (Radix built-in).
+  - State di Zustand `themeStore` + persist `localStorage` (key `theme`).
+  - Apply via `next-themes` atau manual: toggle `dark` class di `<html>`.
+
+**Definition of Done**
+
+- [ ] Klik icon → popover 3 opsi muncul.
+- [ ] Pilih `System` → ikut `prefers-color-scheme` OS.
+- [ ] State persist after reload.
+- [ ] Tidak ada flash light → dark saat reload (FOUC suppressed via inline
+      script di `index.html`).
+
+---
+
+## Revisi #9 — Redesign dashboard modern
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI |
+| **Prioritas** | P0 |
+| **Sesi** | 8 |
+| **Dependency** | #11, #15 |
+| **Reference** | `references/revision-09-dashboard.png`, `docs/screenshots/02-dashboard.png` |
+
+**Scope v1 → v2**
+
+- v1: `gui/views/dashboard_view.py` Treeview + counter cards.
+- v2: `apps/desktop/src/features/dashboard/Dashboard.tsx`:
+  - **Hero row** (3 cards): Total Anggota, Total Buku, Buku Dipinjam (icon +
+    angka besar + delta vs bulan lalu).
+  - **Donut chart**: distribusi DDC (`recharts` `<PieChart>`).
+  - **Bar chart**: kunjungan 7 hari terakhir (`recharts` `<BarChart>`).
+  - **Featured row**: 5 anggota top + 5 buku top (mini-card carousel atau
+    grid 2-kolom).
+  - Hapus Treeview.
+
+**Definition of Done**
+
+- [ ] Hero card responsif (3-kolom ≥1024px, 1-kolom mobile).
+- [ ] Charts pakai theme-aware color (light/dark).
+- [ ] Loading state (skeleton via shadcn `Skeleton`).
+- [ ] Empty state (illustration #6 + CTA "Tambah anggota / buku").
+
+---
+
+## Revisi #10 — "Ingat Saya" auto-login
+
+| Field | Value |
+|---|---|
+| **Kategori** | Logic |
+| **Prioritas** | P1 |
+| **Sesi** | 2 |
+| **Dependency** | #5 |
+| **Reference** | `references/revision-10-remember-me.png` |
+
+**Scope v1 → v2**
+
+- v1: tidak ada fitur ini di v1.
+- v2:
+  - Frontend: checkbox "Ingat Saya" di login form.
+  - Backend (Rust Tauri command): generate token = `bcrypt(user_id || expires_at || rand_salt)`,
+    encrypt pakai AES-256-GCM dengan key derive dari machine id (Tauri
+    `tauri-plugin-stronghold` atau `keyring-rs`).
+  - Simpan token di OS keyring (`tauri-plugin-stronghold` / `keyring-rs`),
+    bukan plain file.
+  - Expire 30 hari (`expires_at` di payload).
+  - On startup: jika token valid → skip login screen.
+
+**Definition of Done**
+
+- [ ] Centang "Ingat Saya" → restart app → langsung masuk dashboard.
+- [ ] Token kadaluwarsa setelah 30 hari → fallback ke login screen.
+- [ ] Logout → token dihapus dari keyring.
+- [ ] Test unit Rust untuk encrypt/decrypt + expire check.
+
+---
+
+## Revisi #11 — Sync identitas perpustakaan
+
+| Field | Value |
+|---|---|
+| **Kategori** | Logic / UI |
+| **Prioritas** | P0 |
+| **Sesi** | 3 (foundation), dipakai di 5/8/9/10/11 |
+| **Dependency** | — |
+| **Reference** | `references/revision-11-identity-sync.png` |
+
+**Scope v1 → v2**
+
+- v1: `models/settings.py` simpan `nama_perpustakaan`, `logo_path`,
+  `alamat`, `kepala_perpustakaan`. Tapi tidak konsisten muncul di semua view.
+- v2:
+  - Zustand store `identityStore` subscribe ke Tauri event `identity:changed`.
+  - Komponen wajib re-render saat identity berubah:
+    - Sidebar header (logo + nama)
+    - App header
+    - Dashboard hero card
+    - KTA template (logo + nama + alamat)
+    - Laporan PDF/print header
+    - Login screen
+    - Manual HTML header (template injection)
+    - About dialog
+
+**Definition of Done**
+
+- [ ] Edit `nama_perpustakaan` di Settings → semua tempat di atas update tanpa reload.
+- [ ] Logo upload → semua tempat update.
+- [ ] PDF Laporan generate setelah edit → header pakai data baru.
+
+---
+
+## Revisi #12 — Date picker calendar popup
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI |
+| **Prioritas** | P0 |
+| **Sesi** | 6 (peminjaman/pengembalian), reusable component |
+| **Dependency** | — |
+| **Reference** | `references/revision-12-date-picker.png` |
+
+**Scope v1 → v2**
+
+- v1: customtkinter date entry text field, format manual.
+- v2: `apps/desktop/src/components/ui/date-picker.tsx`:
+  - Bungkus shadcn `Popover` + `Calendar` (react-day-picker).
+  - Locale Indonesia (`date-fns/locale/id`).
+  - Range tahun configurable via prop `yearRange={[2020, 2030]}` (default
+    [currentYear-5, currentYear+5]).
+  - Tombol shortcut "Hari Ini" di footer.
+  - Keyboard nav (arrow keys, Page Up/Down ganti bulan).
+
+**Definition of Done**
+
+- [ ] Klik input → popup kalender muncul.
+- [ ] Bulan/hari dalam Bahasa Indonesia.
+- [ ] Tombol "Hari Ini" set tanggal hari ini + close popup.
+- [ ] Pakai di Peminjaman, Pengembalian, Laporan filter date range.
+
+---
+
+## Revisi #13 — Fix glitch fullscreen + responsive
+
+| Field | Value |
+|---|---|
+| **Kategori** | Bug / UI |
+| **Prioritas** | P0 |
+| **Sesi** | 3 |
+| **Dependency** | — |
+| **Reference** | `references/revision-13-resize-glitch.png` |
+
+**Scope v1 → v2**
+
+- v1: customtkinter resize sering glitch (widget overlap, scrollbar nyangkut).
+- v2:
+  - Tauri window: `resizable: true`, `fullscreen: false` default,
+    `minSize: { width: 800, height: 600 }`.
+  - Tailwind responsive: breakpoint 768 (md), 1280 (xl).
+  - Sidebar auto-collapse <1024px (lihat #7).
+  - CSS `transition` pada layout container biar resize smooth.
+  - Test manual: drag window edge → tidak ada flicker, tombol/menu tetap clickable.
+
+**Definition of Done**
+
+- [ ] Resize 800×600 → 1920×1080 → 800×600: tidak ada widget hilang/overlap.
+- [ ] Fullscreen toggle (F11): tidak ada glitch.
+- [ ] Test Playwright resize ke 3 viewport (768, 1280, 1920).
+
+---
+
+## Revisi #14 — Sistem KTA komplit
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI / Logic |
+| **Prioritas** | P1 |
+| **Sesi** | 10 |
+| **Dependency** | #4 (anggota), #5 (master data) |
+| **Reference** | `references/revision-14-kta.png` |
+
+**Scope v1 → v2**
+
+- v1: `services/pdf_service.py` generate KTA fixed template, font path sering
+  glitch (relative path PyInstaller).
+- v2:
+  - Template editor visual (drag-drop area) di Settings → simpan layout JSON
+    di `kta_templates` table.
+  - Auto-fill: `[nama]`, `[nis]`, `[kelas]`, `[foto]`, `[barcode_qr]`.
+  - Generate PDF pakai `pdf-lib` (browser-side) atau `printpdf` (Rust).
+  - Barcode QR berisi `member_id` → scan di Peminjaman langsung auto-fill.
+  - Fix font path: bundle font di `apps/desktop/src-tauri/resources/fonts/`
+    + load via `tauri::path::resolve_path`.
+
+**Definition of Done**
+
+- [ ] Template editor: pindah field, ubah font size/color, simpan.
+- [ ] Cetak KTA satu / batch (semua anggota terpilih).
+- [ ] Scan barcode QR di Peminjaman → field anggota auto-fill.
+- [ ] Test unit untuk template parser + auto-fill.
+
+---
+
+## Revisi #15 — Live search instant debounced
+
+| Field | Value |
+|---|---|
+| **Kategori** | UX |
+| **Prioritas** | P1 |
+| **Sesi** | 4 (anggota), reusable di 5/6/9 |
+| **Dependency** | — |
+| **Reference** | `references/revision-15-live-search.png` |
+
+**Scope v1 → v2**
+
+- v1: Search button manual, query di klik.
+- v2:
+  - Hook `useDebouncedSearch(query, 200)` di
+    `apps/desktop/src/hooks/use-debounced-search.ts`.
+  - Apply ke list view: Anggota, Buku, Peminjaman, Pengembalian, Laporan.
+  - Indicator: shadcn `Loader2` saat loading.
+  - Highlight match (substring bold) di hasil.
+
+**Definition of Done**
+
+- [ ] Ketik di search bar → list update tanpa klik tombol, delay 200ms.
+- [ ] Empty state saat 0 hasil ("Tidak ada hasil untuk '<query>'").
+- [ ] Hook reusable, ada test Vitest.
+
+---
+
+## Revisi #16 — Fix layout Data Buku
+
+| Field | Value |
+|---|---|
+| **Kategori** | Bug / UI |
+| **Prioritas** | P0 |
+| **Sesi** | 5 |
+| **Dependency** | — |
+| **Reference** | `references/revision-16-buku-layout.png`, `docs/screenshots/04-buku.png` |
+
+**Scope v1 → v2**
+
+- v1: `gui/views/buku_view.py` master/detail rusak (panel kanan kosong saat
+  no selection), animasi `bounce_book` empty state nyangkut.
+- v2:
+  - Layout master/detail pakai `ResizablePanelGroup` (shadcn).
+  - Empty state pakai illustration SVG + CTA.
+  - Pilih row di tabel kiri → detail di kanan update.
+  - Tombol Add/Edit/Delete di toolbar atas.
+
+**Definition of Done**
+
+- [ ] No selection → panel kanan tampil empty illustration + CTA.
+- [ ] Pilih row → detail muncul (cover, judul, ISBN, eksemplar list).
+- [ ] Resize panel divider smooth.
+
+---
+
+## Revisi #17 — Dropdown master data + CRUD di Settings
+
+| Field | Value |
+|---|---|
+| **Kategori** | Logic / UI |
+| **Prioritas** | P1 |
+| **Sesi** | 4 (anggota partial) + 5 (full) |
+| **Dependency** | — |
+| **Reference** | `references/revision-17-master-data.png` |
+
+**Scope v1 → v2**
+
+- v1: hanya DDC + Kelas yang punya CRUD di Settings, dropdown kategori
+  hardcoded.
+- v2:
+  - Tabel master data: `ddc`, `kategori`, `bahasa`, `jurusan`, `kelas`,
+    `agama`. Tambah migration untuk yang belum ada (kategori, bahasa,
+    jurusan, agama).
+  - CRUD page di Settings → 6 sub-tab.
+  - Seed data:
+    - DDC: dari `assets/ddc-source.txt` (sudah ada).
+    - Bahasa: ISO 639-1 list (10 paling umum: id, en, ar, jw, su, ...).
+    - Agama: 6 agama resmi Indonesia.
+    - Kelas: contoh 7A..12C (configurable).
+    - Kategori, jurusan: kosong default, user input.
+
+**Definition of Done**
+
+- [ ] 6 master data CRUD-able dari Settings.
+- [ ] Dropdown di form Anggota / Buku auto-pull dari master data.
+- [ ] Migration script seed default values saat first run.
+
+---
+
+## Revisi #18 — Fix Kunjungan animasi + filter
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI / Bug |
+| **Prioritas** | P1 |
+| **Sesi** | 7 |
+| **Dependency** | — |
+| **Reference** | `references/revision-18-kunjungan.png`, `docs/screenshots/05-kunjungan.png` |
+
+**Scope v1 → v2**
+
+- v1: `gui/views/kunjungan_view.py` animasi PIL bg solid (tidak transparent),
+  no quick stats, no filter date range.
+- v2:
+  - Replace animasi → SVG illustration transparent (asset #6).
+  - Quick stat card: Hari Ini / Minggu Ini / Bulan Ini (counter card).
+  - Filter date range (date picker #12).
+  - Tabel kunjungan dengan kolom: Nama, Kelas, Jam Masuk, Tujuan.
+  - Live search #15.
+
+**Definition of Done**
+
+- [ ] Bg illustration transparent (sesuai theme light/dark).
+- [ ] Quick stat 3 angka real-time.
+- [ ] Filter date range update tabel.
+
+---
+
+## Revisi #19 — Style dropdown match width
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI |
+| **Prioritas** | P2 |
+| **Sesi** | 4 |
+| **Dependency** | — |
+| **Reference** | `references/revision-19-dropdown.png` |
+
+**Scope v1 → v2**
+
+- v1: customtkinter dropdown popup width tidak match trigger.
+- v2: shadcn `Select` / `Combobox`:
+  - Set `--radix-select-trigger-width` di styles supaya popup = trigger width.
+  - Animasi `data-state=open` (slide-down 150ms).
+  - Keyboard nav (arrow up/down, Enter, Esc).
+
+**Definition of Done**
+
+- [ ] Popup width selalu sama dengan trigger.
+- [ ] Animasi smooth.
+- [ ] Test keyboard nav di Playwright.
+
+---
+
+## Revisi #20 — Autocomplete anggota & buku
+
+| Field | Value |
+|---|---|
+| **Kategori** | UX |
+| **Prioritas** | P0 |
+| **Sesi** | 4 (anggota), 6 (peminjaman pakai keduanya) |
+| **Dependency** | #15 |
+| **Reference** | `references/revision-20-autocomplete.png` |
+
+**Scope v1 → v2**
+
+- v1: input nama text plain, no suggestion.
+- v2: shadcn `Command` / `Combobox`:
+  - 2-line item: line 1 = nama, line 2 = NIS / kelas (anggota) atau ISBN /
+    judul (buku).
+  - Fuzzy match pakai `fuse.js` atau SQL `LIKE %q%`.
+  - "Smart suggest": rekomendasi berdasar history (e.g. anggota sering pinjam
+    → tampil duluan).
+
+**Definition of Done**
+
+- [ ] Ketik 2+ char → popup suggestion 2-line item.
+- [ ] Pilih item → form auto-fill data lengkap.
+- [ ] Performance <50ms untuk 1000 records.
+
+---
+
+## Revisi #21 — Redesign Peminjaman komplit
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI / UX |
+| **Prioritas** | P0 |
+| **Sesi** | 6 |
+| **Dependency** | #12, #20, #15 |
+| **Reference** | `references/revision-21-peminjaman.png`, `docs/screenshots/06-peminjaman.png` |
+
+**Scope v1 → v2**
+
+- v1: form linear, no info panel, no quick stats.
+- v2:
+  - Form layout 2-kolom: kiri form input, kanan panel info (anggota / buku
+    detail).
+  - Autocomplete #20 untuk anggota + buku.
+  - Date range picker #12 (tanggal pinjam, jatuh tempo).
+  - Validasi: anggota tidak punya pinjaman aktif yang melewati limit;
+    buku punya eksemplar tersedia.
+  - Print nota: PDF mini (5×7cm) ke printer thermal atau A4.
+  - Quick stats di header: Pinjam Aktif Hari Ini / Minggu Ini.
+
+**Definition of Done**
+
+- [ ] Pilih anggota → panel info (foto, nama, kelas, riwayat) muncul.
+- [ ] Pilih buku → panel info (cover, judul, eksemplar) muncul.
+- [ ] Validasi block submit kalau invalid (toast error).
+- [ ] Submit → buat record + print nota.
+- [ ] Test e2e Playwright happy path.
+
+---
+
+## Revisi #22 — Window resize fleksibel
+
+| Field | Value |
+|---|---|
+| **Kategori** | Bug |
+| **Prioritas** | P0 |
+| **Sesi** | 3 |
+| **Dependency** | — |
+| **Reference** | `references/revision-22-window-resize.png` |
+
+**Scope v1 → v2**
+
+- v1: Tk window kadang tombol/menu kepotong saat windowed.
+- v2: Tauri config:
+  - `resizable: true`
+  - `minWidth: 800`, `minHeight: 600`
+  - `fullscreen: false` default
+  - `maximized: true` saat first launch (boleh diubah user)
+
+**Definition of Done**
+
+- [ ] Resize ke 800×600 → semua tombol/menu masih clickable.
+- [ ] Resize ke 1920×1080 → layout fluid, no excessive whitespace.
+- [ ] Maximize/restore button works.
+
+---
+
+## Revisi #23 — Redesign Laporan komplit
+
+| Field | Value |
+|---|---|
+| **Kategori** | UI |
+| **Prioritas** | P0 |
+| **Sesi** | 9 |
+| **Dependency** | #6, #7, #8, #11, #12 |
+| **Reference** | `references/revision-23-laporan.png`, `docs/screenshots/08-laporan.png` |
+
+**Scope v1 → v2**
+
+- v1: Treeview + tabs.
+- v2: Layout sidebar nav (5 sub-page):
+  1. **Grafik Kunjungan**: line chart per bulan / tahun (recharts).
+  2. **Top Peminjam**: tabel + bar chart 10 besar.
+  3. **Top Buku**: tabel + bar chart 10 besar (filter periode).
+  4. **Kas**: tabel pemasukan denda + manual + chart cumulative.
+  5. **Backup**: tombol backup full DB + restore + jadwal.
+  - Filter date range di tiap sub-page (date picker #12).
+  - Export PDF + Excel pakai service shared.
+
+**Definition of Done**
+
+- [ ] 5 sub-page Laporan jalan dengan data real.
+- [ ] Export PDF / Excel works (header pakai identitas #11).
+- [ ] Backup → file `.db` + checksum SHA256 di folder backup user.
+
+---
+
+## Revisi #24 — Settings comprehensive 12 kategori
+
+| Field | Value |
+|---|---|
+| **Kategori** | UX |
+| **Prioritas** | P1 |
+| **Sesi** | 11 |
+| **Dependency** | #11, #14, #17, #25 |
+| **Reference** | `references/revision-24-settings.png`, `docs/screenshots/09-setting.png` |
+
+**Scope v1 → v2**
+
+- v1: 1 page settings flat.
+- v2: 12 sub-page nav (mirip Google Workspace settings):
+  1. Identitas Perpustakaan (#11)
+  2. Aturan Peminjaman (rename dari "Transaksi", #25)
+  3. Master Data (#17)
+  4. KTA Template (#14)
+  5. Tampilan (theme, font scale, density)
+  6. Bahasa (ID/EN)
+  7. Akun & Pengguna
+  8. Hak Akses (Permissions)
+  9. Backup & Restore
+  10. Sinkronisasi (Google Sheets, optional)
+  11. Audit Log
+  12. Tentang
+  - Search bar global (filter sub-page + setting items).
+  - Tooltip di tiap toggle.
+  - Tombol "Reset to default" per sub-page + global.
+
+**Definition of Done**
+
+- [ ] 12 sub-page nav works.
+- [ ] Search bar filter setting items real-time.
+- [ ] Tooltip muncul on-hover (delay 500ms).
+- [ ] "Reset to default" → confirm dialog → revert ke default values.
+
+---
+
+## Revisi #25 — Audit wording final
+
+| Field | Value |
+|---|---|
+| **Kategori** | UX |
+| **Prioritas** | P1 |
+| **Sesi** | 2 (partial baseline), 11 (full sweep) |
+| **Dependency** | — |
+| **Reference** | `references/revision-25-wording.png` |
+
+**Scope v1 → v2**
+
+- Rename "Transaksi" → "Aturan Peminjaman" (di Settings, menu).
+- Sweep semua label/dialog/error/i18n untuk konsistensi:
+  - Bahasa Indonesia formal (bukan "Lo / Gua").
+  - Hindari jargon teknis di error message ("Foreign key constraint" →
+    "Data masih dipakai di tempat lain").
+  - Capitalization konsisten (Title Case untuk label, sentence case untuk help text).
+- File i18n: `apps/desktop/src/i18n/id.json` + `en.json`.
+
+**Definition of Done**
+
+- [ ] Tidak ada lagi string "Transaksi" sebagai menu label.
+- [ ] Lint i18n: tidak ada key tidak terpakai / missing translation.
+- [ ] Review user (di PR Devin 11).
+
+---
+
+## Revisi #26 — Mouse wheel scroll global + smooth
+
+| Field | Value |
+|---|---|
+| **Kategori** | UX |
+| **Prioritas** | P2 |
+| **Sesi** | 12 |
+| **Dependency** | — |
+| **Reference** | `references/revision-26-scroll.png` |
+
+**Scope v1 → v2**
+
+- v1: customtkinter scroll kadang tidak responsif di area tertentu.
+- v2:
+  - Default browser scroll (smooth via `scroll-behavior: smooth`).
+  - Custom scrollbar via `tailwindcss-scrollbar` plugin atau
+    [`overlayscrollbars`](https://kingsora.github.io/OverlayScrollbars/):
+    auto-hide setelah idle 1.5s, fade-in saat scroll.
+  - Test: scroll di Dashboard, Tabel Anggota, Settings → semua smooth.
+
+**Definition of Done**
+
+- [ ] Scrollbar auto-hide saat idle, fade-in saat scroll.
+- [ ] Tidak ada area "dead zone" yang tidak terima wheel event.
+- [ ] Smooth scroll behavior at default.
+
+---
+
+## Coverage matrix (revisi → sesi)
+
+| Sesi | Revisi tercover |
+|---|---|
+| 1 (bootstrap) | — (dokumentasi only) |
+| 2 (scaffolding) | #5, #8, #10, #25 (partial) |
+| 3 (layout shell) | #7, #11 (foundation), #13, #22 |
+| 4 (anggota) | #15, #17 (anggota), #19, #20 (anggota) |
+| 5 (buku + master data) | #16, #17 (full) |
+| 6 (peminjaman/pengembalian) | #12, #21 |
+| 7 (kunjungan) | #18 |
+| 8 (dashboard) | #9 |
+| 9 (laporan) | #23 |
+| 10 (KTA) | #14 |
+| 11 (settings + manual) | #4, #24, #25 (full) |
+| 12 (installer + release) | #1, #2, #3, #6 (final), #26 |
+
+Semua 26 revisi tercover. Sesi 11 dan 12 jadi finishing pass (audit + asset polish).

--- a/docs/migration-v2/STACK_DECISION.md
+++ b/docs/migration-v2/STACK_DECISION.md
@@ -1,0 +1,297 @@
+# Stack Decision — Migration v2
+
+> Analisis keputusan stack untuk migrasi v1 (Python + customtkinter) → v2.
+> Setiap keputusan didukung tabel pro/kontra + rekomendasi default.
+> Devin 2 dst. WAJIB ikut keputusan ini kecuali ada alasan kuat (didiskusikan
+> di PR review user).
+
+## Ringkasan keputusan
+
+| Layer | Pilihan | Default v2 |
+|---|---|---|
+| Desktop runtime | Tauri 2.0 vs Electron | **Tauri 2.0** |
+| Frontend framework | React 18 + TS | React 18 + TS |
+| Styling | Tailwind 3 + shadcn/ui | Tailwind 3 + shadcn/ui |
+| State management | Zustand vs Redux Toolkit | **Zustand** |
+| Routing | TanStack Router vs React Router | **TanStack Router** |
+| DB strategy | better-sqlite3 vs sqlx (Rust) vs Python sidecar | **sqlx (Rust)** via `tauri-plugin-sql` |
+| Build tool | Vite | Vite |
+| Package manager | pnpm | pnpm |
+| Unit test | Vitest | Vitest |
+| E2E test | Playwright (Tauri WebView) | Playwright |
+| Charts | recharts vs chart.js vs visx | **recharts** |
+| Icons | `@phosphor-icons/react` | Phosphor (port dari v1) |
+| Animation | Framer Motion (selektif) + Tailwind | Framer Motion |
+| PDF | `pdf-lib` (browser) atau `printpdf` (Rust) | **`pdf-lib`** (frontend) |
+
+---
+
+## 1. Desktop runtime — Tauri 2.0 vs Electron
+
+| Kriteria | Tauri 2.0 | Electron |
+|---|---|---|
+| Bundle size | 5–15 MB | 80–150 MB |
+| RAM idle | 50–80 MB | 200–400 MB |
+| Performa | Native WebView OS (WebKit/WebView2) | Chromium bundled |
+| Update mechanism | `tauri-plugin-updater` | electron-updater |
+| Native API | Rust + `tauri-plugin-*` | Node.js + native modules |
+| Distribusi Windows | MSI / NSIS / Inno Setup | NSIS / MSI / squirrel |
+| Maturity | Stable v2.0 (2024+) | Stable bertahun-tahun |
+| Ecosystem React | Cocok via Vite | Cocok via webpack/vite |
+| Security model | Allowlist per-command, default-deny | Lebih permissive |
+| Cross-platform build | Linux / macOS / Windows (native per OS) | Linux / macOS / Windows |
+
+**Rekomendasi: Tauri 2.0**
+
+- Bundle size jauh lebih kecil → installer ~5–10 MB (vs ~80 MB Electron).
+  Cocok untuk distribusi sekolah dengan koneksi terbatas.
+- RAM footprint kecil → cocok untuk PC pustakawan generasi lama.
+- Security model lebih baik → cocok untuk app yang manage data anggota.
+- Sudah punya plugin official: `tauri-plugin-sql`, `tauri-plugin-fs`,
+  `tauri-plugin-dialog`, `tauri-plugin-printer` (community), `tauri-plugin-stronghold`.
+
+**Trade-off yang diterima:**
+
+- Native WebView per-OS bisa ada perbedaan rendering. Mitigasi: Playwright
+  test di Windows runner (utama target).
+- Rust learning curve untuk plugin custom. Mitigasi: minim Rust code, sebagian
+  besar logic di TS.
+
+---
+
+## 2. State management — Zustand vs Redux Toolkit
+
+| Kriteria | Zustand | Redux Toolkit |
+|---|---|---|
+| Boilerplate | Minimal | Moderate (slice, reducer) |
+| DevTools | Yes (zustand/middleware) | Yes (RTK built-in) |
+| Persist | `zustand/middleware/persist` | `redux-persist` |
+| Async | Built-in (just async function) | `createAsyncThunk` / RTK Query |
+| Bundle size | 2 KB | 11 KB (RTK) |
+| Tipe TS | Inferensi otomatis | Inferensi otomatis |
+| Familiar di team | Modern, simpler API | Klasik, banyak referensi |
+
+**Rekomendasi: Zustand**
+
+- App ini scope-nya medium (tidak super complex). Redux overkill.
+- Boilerplate Zustand lebih sedikit → speed iterasi 12 sesi.
+- Persist middleware cocok untuk theme / sidebar state.
+
+**Store yang akan dibuat:**
+
+- `themeStore` — light/dark/system + persist.
+- `sidebarStore` — collapsed state + persist.
+- `authStore` — user, token, permissions.
+- `identityStore` — nama_perpustakaan, logo, alamat (subscribe Tauri event).
+- `i18nStore` — bahasa aktif (ID/EN) + persist.
+
+---
+
+## 3. Routing — TanStack Router vs React Router
+
+| Kriteria | TanStack Router | React Router 6 |
+|---|---|---|
+| Type safety | Full TS inference (search params + path params) | Partial (manual typing) |
+| Data loaders | Built-in (mirip Remix) | `loader` (RR 6.4+) |
+| File-based routing | Optional via `@tanstack/router-plugin/vite` | No (manual) |
+| Maturity | Stable v1 (2024) | Sangat matang |
+| Bundle size | ~12 KB | ~15 KB |
+| Devtools | Yes (router-devtools) | No (built-in browser) |
+| Learning curve | Moderate (route tree concept) | Familiar untuk React dev |
+
+**Rekomendasi: TanStack Router**
+
+- Type safety end-to-end critical untuk app data-heavy.
+- Search param parsing built-in cocok untuk filter date range / pagination.
+- Devin akan generate route tree dari file structure (less boilerplate).
+
+**Struktur route:**
+
+```
+/login
+/dashboard
+/anggota
+/anggota/$id
+/buku
+/buku/$id
+/peminjaman
+/pengembalian
+/kunjungan
+/laporan/grafik
+/laporan/top-peminjam
+/laporan/top-buku
+/laporan/kas
+/laporan/backup
+/settings/identitas
+/settings/aturan-peminjaman
+/settings/master-data/$kategori
+/settings/kta
+/settings/tampilan
+... (12 sub-page settings)
+```
+
+---
+
+## 4. DB strategy — better-sqlite3 vs sqlx vs Python sidecar
+
+| Kriteria | better-sqlite3 (Node.js) | sqlx via tauri-plugin-sql (Rust) | Python sidecar |
+|---|---|---|---|
+| Tauri compat | ❌ Butuh Node.js (Electron) | ✅ Native plugin | ⚠️ Spawn subprocess |
+| Performance | Fast (sync API) | Fast (async) | Slower (IPC overhead) |
+| Bundle size | +3 MB sqlite + Node | +1 MB Rust binary | +20 MB Python embed |
+| Reuse v1 logic | ❌ Rewrite di TS/Rust | ❌ Rewrite di Rust | ✅ Reuse models/services |
+| Migration script | Manual SQL | Manual SQL / sqlx-migrate | Reuse `db/connection.py` |
+| Type safety | Manual schema typing | Strong (sqlx + macros) | Manual |
+
+**Rekomendasi: sqlx via `tauri-plugin-sql`**
+
+- Tidak butuh Node.js runtime di production (Tauri murni native).
+- Schema v1 (`src/perpustakaan/db/schema.sql`) di-reuse copy-paste karena
+  SQLite portable.
+- Logic CRUD ditulis di Rust (~30% rewrite) dengan TS interface untuk command.
+- Untuk Devin 12 migration script v1 → v2: bisa bikin Rust binary yang
+  baca DB v1 (sama schema, tinggal copy dengan validasi).
+
+**Struktur layer:**
+
+```
+apps/desktop/src-tauri/src/
+├── db/
+│   ├── mod.rs            # SQL pool + migrations
+│   ├── schema.sql        # COPY dari v1
+│   ├── anggota.rs        # CRUD anggota
+│   ├── buku.rs           # CRUD buku
+│   ├── peminjaman.rs     # CRUD + business logic
+│   └── ...
+├── commands/             # Tauri commands (bridge ke frontend)
+└── main.rs
+```
+
+**Alternatif fallback (kalau sqlx terlalu berat):**
+
+- Pakai `rusqlite` (lebih simple, sync API).
+- Trade-off: tidak pakai async, tapi cocok untuk app desktop kecil.
+
+---
+
+## 5. Frontend framework + utilities
+
+### React 18 + TypeScript
+
+- Wajib React 18 (concurrent features, automatic batching).
+- TS strict mode: `strict: true`, `noUncheckedIndexedAccess: true`.
+
+### Tailwind 3 + shadcn/ui
+
+- Tailwind 3 (jangan v4 yang masih shifting). PostCSS pipeline standar.
+- shadcn/ui = copy-paste components ke `src/components/ui/`.
+  - Pilih komponen yang dipakai: `Button`, `Input`, `Form`, `Card`,
+    `Dialog`, `DropdownMenu`, `Tooltip`, `Sheet`, `Tabs`, `Table`,
+    `Calendar`, `Popover`, `Select`, `Combobox`, `Toast`, `Sidebar`.
+- Theme: `cn()` utility + `class-variance-authority` (cva) untuk variants.
+
+### State + form
+
+- Zustand (state global) — section 2.
+- `react-hook-form` + `zod` (form validation, TS schema).
+
+### Charts
+
+- `recharts` — paling matang, theming via CSS var, cocok untuk
+  Dashboard + Laporan.
+- Alternatif: `visx` (lebih low-level, untuk chart custom).
+
+### Animation
+
+- Framer Motion (selektif: login entrance, sidebar collapse, dialog open).
+- Tailwind `animate-in` / `animate-out` untuk yang sederhana.
+
+### Icons
+
+- `@phosphor-icons/react` (port dari v1 `gui/phosphor.py`).
+- Konsisten dengan v1 → user familiar.
+
+---
+
+## 6. Build & tooling
+
+### Vite
+
+- Vite 5+ untuk React (support React 18 + TS via @vitejs/plugin-react).
+- Tauri sudah recommend Vite di template default.
+
+### pnpm
+
+- Workspace support penting karena struktur monorepo (`apps/desktop`,
+  `apps/web` (future), `packages/shared`).
+- Lebih cepat & disk-efficient dari npm/yarn.
+
+### Vitest
+
+- Unit test (komponen, hooks, utils, store).
+- Compat dengan Vite config → no separate jest config.
+
+### Playwright
+
+- E2E test via Tauri WebView (bisa attach via CDP).
+- Smoke flow: login → dashboard → tambah anggota → tambah buku → peminjaman.
+
+### GitHub Actions
+
+- Workflow baru `apps/desktop/.github/workflows/ci.yml` (atau di root).
+- Job:
+  - `lint-typecheck` (pnpm lint, pnpm typecheck)
+  - `unit-test` (pnpm test)
+  - `e2e-test` (pnpm e2e, Playwright pada Tauri build)
+  - `build-windows` (Tauri build MSI di Windows runner — di Devin 12)
+
+---
+
+## 7. PDF / Print
+
+| Tool | Pros | Cons |
+|---|---|---|
+| `pdf-lib` (frontend) | TS-native, no native dep, theme-aware | Tidak support print direct ke printer |
+| `printpdf` (Rust) | Native print API, ICC profile | Rust learning curve, bundle size +1 MB |
+| `react-pdf` | React component → PDF | Heavy bundle (~500 KB) |
+
+**Rekomendasi: `pdf-lib` (frontend)**
+
+- Generate PDF di TS, save lewat Tauri `dialog.save` + `fs.writeBinaryFile`.
+- Untuk print direct: pakai `tauri-plugin-printer` (community) di Devin 6/9/10.
+
+---
+
+## 8. i18n
+
+- Library: `react-i18next` (matang, plural rules, namespace).
+- File JSON: `apps/desktop/src/i18n/{id,en}/{common,auth,dashboard,...}.json`.
+- Default language: `id` (Indonesia). Fallback: `en`.
+- Reuse string dari v1 `src/perpustakaan/i18n.py` (extract → JSON).
+
+---
+
+## 9. Mengapa **bukan** opsi lain?
+
+### Mengapa tidak Electron?
+
+Sudah dijawab di section 1. Singkatnya: bundle size 8–10× lebih besar, RAM
+2–4× lebih besar. Untuk app sekolah offline yang harus jalan di PC kentang,
+Tauri menang telak.
+
+### Mengapa tidak Next.js?
+
+Next.js untuk SSR / SSG web app. Untuk desktop offline, Vite + React SPA
+sudah cukup dan lebih ringan.
+
+### Mengapa tidak Solid / Svelte?
+
+Ekosistem React untuk shadcn/ui + recharts paling lengkap. Devin lebih
+familiar React → speed iterasi.
+
+### Mengapa tidak Drizzle ORM?
+
+Bisa dipakai sebagai layer abstraksi di atas sqlx (TS-side typing). Tapi
+karena CRUD ditulis di Rust (server-side), Drizzle hanya cocok kalau pakai
+better-sqlite3 di Node.js (yang kita reject). Sqlx + Rust sudah type-safe
+via macro.

--- a/docs/migration-v2/references/INDEX.md
+++ b/docs/migration-v2/references/INDEX.md
@@ -1,0 +1,74 @@
+# References — Screenshot revisi v2
+
+> Folder ini menampung 36 screenshot yang berfungsi sebagai **referensi
+> visual** untuk 26 revisi di `REVISION_BACKLOG.md`. Beberapa revisi punya
+> >1 referensi (misal sebelum/sesudah, light/dark) → karena itu total ~36.
+>
+> **Diisi manual oleh user** (alvi arts). Devin tidak generate referensi
+> visual; hanya merefer dari `REVISION_BACKLOG.md` dan
+> `sessions/SESSION_NN.md`.
+
+## Naming convention
+
+`revision-NN-<short-name>[-<variant>].png`
+
+- `NN` = nomor revisi (01–26), zero-padded.
+- `<short-name>` = slug kebab-case (e.g. `login`, `sidebar`, `dashboard`).
+- `<variant>` (opsional) = `before`, `after`, `light`, `dark`, `mobile`,
+  `1`, `2`, dst.
+
+## Daftar reference yang diharapkan
+
+| Revisi | File pattern | Catatan |
+|---|---|---|
+| #1 Logo installer + .exe icon | `revision-01-installer-logo.png` | Mock tampilan Start Menu / Taskbar |
+| #2 Hapus language picker | `revision-02-no-language-picker.png` | Sebelum/sesudah |
+| #3 License + wizard graphic | `revision-03-license-and-wizard.png`, `revision-03-wizard-banner.png` | License page + wizard side-banner |
+| #4 Manual HTML | `revision-04-manual-html.png`, `revision-04-manual-mobile.png` | Desktop + mobile responsif |
+| #5 Login redesign | `revision-05-login.png`, `revision-05-login-dark.png` | 2 variant |
+| #6 Asset quality | `revision-06-assets-undraw.png`, `revision-06-assets-storyset.png` | Contoh asset SVG/PNG |
+| #7 Sidebar collapsible | `revision-07-sidebar.png`, `revision-07-sidebar-collapsed.png` | Expanded + collapsed |
+| #8 Theme switcher | `revision-08-theme-switcher.png` | Popup 3 row |
+| #9 Dashboard modern | `revision-09-dashboard.png`, `revision-09-dashboard-empty.png` | Filled + empty state |
+| #10 Ingat saya | `revision-10-remember-me.png` | Login screen highlight checkbox |
+| #11 Sync identitas | `revision-11-identity-sync.png` | Multi-component visual |
+| #12 Date picker | `revision-12-date-picker.png` | Calendar popup ID locale |
+| #13 Resize glitch fix | `revision-13-resize-glitch.png` | Animasi sequence resize |
+| #14 KTA komplit | `revision-14-kta.png`, `revision-14-kta-editor.png` | Card + editor |
+| #15 Live search | `revision-15-live-search.png` | Search bar + result highlight |
+| #16 Buku layout | `revision-16-buku-layout.png` | Master/detail |
+| #17 Master data | `revision-17-master-data.png` | Settings tabs 6 master |
+| #18 Kunjungan | `revision-18-kunjungan.png` | Quick stats + ilustrasi transparan |
+| #19 Dropdown styled | `revision-19-dropdown.png` | Popup match width |
+| #20 Autocomplete | `revision-20-autocomplete.png` | 2-line item suggestion |
+| #21 Peminjaman komplit | `revision-21-peminjaman.png` | 2-kolom + panel info |
+| #22 Window resize | `revision-22-window-resize.png` | Min/max state |
+| #23 Laporan komplit | `revision-23-laporan.png`, `revision-23-laporan-charts.png` | Sub-nav + charts |
+| #24 Settings 12 kategori | `revision-24-settings.png`, `revision-24-settings-search.png` | 12 sub-page + search |
+| #25 Wording audit | `revision-25-wording.png` | Sebelum/sesudah label |
+| #26 Scroll polish | `revision-26-scroll.png` | Scrollbar fade |
+
+## Fallback
+
+Kalau referensi belum ada saat sesi dimulai, Devin pakai screenshot v1
+di `docs/screenshots/` sebagai baseline visual:
+
+| v1 screenshot | Relevansi |
+|---|---|
+| `01-login.png` | Baseline #5 |
+| `02-dashboard.png` | Baseline #9 |
+| `03-anggota.png` | Baseline #15, #19, #20 |
+| `04-buku.png` | Baseline #16, #17 |
+| `05-kunjungan.png` | Baseline #18 |
+| `06-peminjaman.png` | Baseline #21 |
+| `07-pengembalian.png` | Baseline pengembalian (sesi 6) |
+| `08-laporan.png` | Baseline #23 |
+| `09-setting.png` | Baseline #24 |
+| `10-setting-bahasa.png` | Baseline #25 (bahasa) |
+| `11-setting-sync.png` | Baseline Settings sub-page sinkronisasi |
+| `12-laporan-grafik.png` | Baseline #23 (grafik) |
+| `13-laporan-top-peminjam.png` | Baseline #23 (top peminjam) |
+| `14-naik-kelas.png` | Baseline anggota naik kelas |
+| `15-cetak-nota.png` | Baseline #21 (nota) |
+| `16-tools-duplikat.png` | Baseline tools (Devin 11 settings opsional) |
+| `17-audit-log.png` | Baseline audit log (Devin 11) |

--- a/docs/migration-v2/sessions/SESSION_01.md
+++ b/docs/migration-v2/sessions/SESSION_01.md
@@ -1,0 +1,80 @@
+# SESSION 01 — Bootstrap migration plan
+
+> **Devin session 1/12.** Foundation only. NO kode aplikasi.
+
+## Goal
+
+Set up dokumentasi migrasi v2 lengkap supaya 11 sesi berikutnya punya
+single source of truth: scope, stack decision, arsitektur, mapping aset,
+breakdown per sesi, dan mekanisme tracking progress.
+
+## Scope
+
+- **Tidak ada kode aplikasi** (no React, Rust, Tauri config).
+- **Tidak menyentuh** v1 source (`src/perpustakaan/`, `tests/`, dll.).
+- Hanya menambah file di:
+  - `docs/migration-v2/*.md`
+  - `docs/migration-v2/sessions/*.md`
+  - `docs/migration-v2/references/INDEX.md` (placeholder, image dropped by user)
+
+## Revisi tercover
+
+— (sesi 1 tidak mengeksekusi revisi apa pun; hanya merencanakan)
+
+## Dependencies
+
+— (sesi paling awal)
+
+## Tasks breakdown
+
+1. Clone repo + branch baru `devin/<unix-ts>-migration-v2-bootstrap`.
+2. Tulis `REVISION_BACKLOG.md` (26 revisi, format ID + judul + kategori +
+   scope detail + dependency + prioritas + reference + DoD).
+3. Tulis `STACK_DECISION.md` (analisis Tauri vs Electron + sub-decisions
+   DB / state mgmt / routing).
+4. Tulis `ARCHITECTURE.md` (file structure, IPC layer, DB layer, build
+   pipeline, CI/CD).
+5. Tulis `ASSETS_REUSE.md` (REUSE / BUANG / PORT / MIGRATE matrix).
+6. Tulis `PROGRESS.md` machine-parseable (12 sesi, deps, status).
+7. Tulis `sessions/SESSION_01.md` ... `SESSION_12.md` (file ini + 11 lainnya).
+8. Tulis `INSTRUCTION_TEMPLATE.md` (universal copy-paste prompt).
+9. Tulis `references/INDEX.md` (catatan: image dropped manually by user;
+   include daftar 36 file pattern + binding ke revisi).
+10. Commit conventional + push branch.
+11. Buat PR (fetch template dulu) — title `docs(migration-v2): bootstrap migration plan`.
+12. Tunggu CI pass (legacy Python CI, harus tetap pass karena cuma nambah md).
+13. Final message ke user (link PR + instruksi merge).
+
+## Deliverables
+
+- File:
+  - `docs/migration-v2/REVISION_BACKLOG.md`
+  - `docs/migration-v2/STACK_DECISION.md`
+  - `docs/migration-v2/ARCHITECTURE.md`
+  - `docs/migration-v2/ASSETS_REUSE.md`
+  - `docs/migration-v2/PROGRESS.md`
+  - `docs/migration-v2/INSTRUCTION_TEMPLATE.md`
+  - `docs/migration-v2/sessions/SESSION_01.md` ... `SESSION_12.md`
+  - `docs/migration-v2/references/INDEX.md`
+- PR: 1 PR ke `main`, body lengkap dengan link ke tiap file.
+- Tests: tidak ada (docs only).
+
+## Definition of Done
+
+- [ ] Semua 7 set file di-commit.
+- [ ] PR dibuat dan CI pass.
+- [ ] PROGRESS.md sesi 1 berstatus IN_PROGRESS dengan PR link.
+- [ ] User notifikasi via final message untuk merge.
+- [ ] Setelah PR merge: user (atau Devin 2) update PROGRESS.md sesi 1 →
+      COMPLETED + completed_at.
+
+## Notes
+
+- File `references/` mengharapkan 36 PNG screenshot revisi yang diberikan
+  oleh user secara manual (Devin tidak bisa generate referensi visual).
+  Kalau belum ada saat sesi 2 mulai, Devin 2 cukup pakai `docs/screenshots/`
+  v1 sebagai baseline + skip referensi visual yang belum ada.
+- Devin 1 TIDAK mengubah `PROGRESS.md` sesi 1 → COMPLETED. Itu di-handle
+  saat PR sesi 1 di-merge: Devin 2 di awal sesinya akan baca state baru
+  dan optionally bisa flip status sesi 1 → COMPLETED. Atau user merge
+  langsung dan Devin 2 update sebagai bagian PR-nya.

--- a/docs/migration-v2/sessions/SESSION_02.md
+++ b/docs/migration-v2/sessions/SESSION_02.md
@@ -1,0 +1,153 @@
+# SESSION 02 — Scaffolding + login + theme + i18n
+
+> **Devin session 2/12.** Bikin pondasi project v2. Setelah sesi ini, app
+> sudah bisa di-`pnpm tauri dev`, login pakai admin/admin123 (reuse hash v1),
+> theme switcher works, i18n ID/EN works.
+
+## Goal
+
+- Scaffolding monorepo Tauri 2.0 + React 18 + TS + Tailwind + shadcn + Zustand +
+  TanStack Router + Vitest + Playwright.
+- Reuse SQLite schema v1 (copy `db/schema.sql`).
+- Login screen modern (revisi #5).
+- Theme switcher (revisi #8).
+- "Ingat Saya" auto-login (revisi #10).
+- i18n baseline ID/EN (sebagian audit wording revisi #25).
+- Setup CI/CD baru `ci-v2.yml` (lint + typecheck + unit test).
+
+## Revisi tercover
+
+- #5 (login redesign) — full
+- #8 (theme switcher) — full
+- #10 (Ingat Saya) — full
+- #25 (audit wording) — partial baseline (extract i18n; sweep final di Devin 11)
+
+## Dependencies
+
+- Sesi 1 COMPLETED (`PROGRESS.md` ada).
+
+## Tasks breakdown
+
+### 1. Workspace scaffold
+
+- Bikin root `package.json` workspace (`pnpm-workspace.yaml`).
+- Bikin `apps/desktop/` dengan template `pnpm create tauri-app` (React + TS
+  + Vite).
+- Tambah `packages/shared/` (TS-only, untuk types DTO).
+- Setup ESLint + Prettier + tsconfig strict.
+
+### 2. Tailwind + shadcn
+
+- Install Tailwind 3 + PostCSS + autoprefixer.
+- Init shadcn dengan `npx shadcn@latest init`.
+- Add komponen baseline: `Button`, `Input`, `Card`, `Form`, `Label`,
+  `Checkbox`, `DropdownMenu`, `Tooltip`, `Toast`.
+
+### 3. Tauri config
+
+- `apps/desktop/src-tauri/tauri.conf.json`:
+  - window: 1280×800, minWidth 800, minHeight 600, resizable, fullscreen
+    false.
+  - bundle: identifier `id.alviarts.perpustakaan`, productName
+    `PerpustakaanOffline`.
+- Plugin install: `tauri-plugin-sql` (sqlite), `tauri-plugin-fs`,
+  `tauri-plugin-stronghold` (untuk #10).
+
+### 4. DB layer (Rust)
+
+- Copy `src/perpustakaan/db/schema.sql` ke
+  `apps/desktop/src-tauri/src/db/schema.sql`.
+- Setup `tauri-plugin-sql` migration runner di `main.rs`.
+- Bikin command `auth.login(username, password)` (bcrypt verify) dan
+  `auth.login_with_token(token)` untuk Ingat Saya.
+- Token store di Stronghold / keyring (hindari plain file).
+
+### 5. Frontend stores
+
+- `src/stores/themeStore.ts` (light/dark/system, persist).
+- `src/stores/i18nStore.ts` (id/en, persist).
+- `src/stores/authStore.ts` (user, permissions, login/logout).
+
+### 6. Login screen (revisi #5)
+
+- `src/features/auth/Login.tsx`:
+  - Layout 2-kolom (`md:grid-cols-2`).
+  - Kolom kiri: form (username, password, "Ingat Saya" checkbox, submit).
+  - Kolom kanan: gradient background + ilustrasi (placeholder SVG sampai
+    Devin 12 swap #6).
+  - Animasi entrance Framer Motion (fade + slide-up).
+  - Identitas perpustakaan (nama + logo) dari `identityStore` (placeholder
+    kalau belum ada di settings — fallback ke "Perpustakaan Offline").
+
+### 7. Theme switcher (revisi #8)
+
+- `src/components/layout/ThemeSwitcher.tsx`:
+  - DropdownMenu icon button (`Sun` / `Moon` / `Monitor`).
+  - 3 row: Light, Dark, System.
+  - Apply via toggle `dark` class di `<html>` + persist Zustand.
+  - Anti-FOUC: inline script di `index.html` baca `localStorage` sebelum
+    React mount.
+
+### 8. i18n baseline
+
+- Install `react-i18next`.
+- Extract semua string dari `src/perpustakaan/i18n.py` → JSON.
+  Pecah jadi:
+  - `i18n/id/common.json`, `auth.json`, `dashboard.json`, `anggota.json`,
+    `buku.json`, `peminjaman.json`, `pengembalian.json`, `kunjungan.json`,
+    `laporan.json`, `settings.json`, `errors.json`.
+  - Mirror struktur untuk `en/`.
+- Apply audit wording awal (revisi #25): rename "Transaksi" → "Aturan
+  Peminjaman" di file relevan.
+
+### 9. Routing baseline
+
+- TanStack Router file-based di `src/routes/`:
+  - `__root.tsx` (layout shell placeholder)
+  - `login.tsx`
+  - `_authed.tsx` (auth guard)
+  - `_authed/dashboard.tsx` (placeholder card "Dashboard akan dibuat Devin 8")
+
+### 10. Testing setup
+
+- `vitest.config.ts` + sample test `auth.test.ts` (login validation).
+- `playwright.config.ts` + sample e2e `login.spec.ts` (happy path).
+
+### 11. CI/CD
+
+- `.github/workflows/ci-v2.yml`:
+  - Job `lint-typecheck`: pnpm lint, pnpm typecheck.
+  - Job `unit-test`: pnpm test (Vitest).
+  - (Tambah job `e2e` di Devin 3+ kalau Playwright stabil.)
+- JANGAN ubah `ci.yml` legacy Python.
+
+### 12. Update PROGRESS.md
+
+- Status sesi 2 → COMPLETED, completed_at, pr URL.
+
+## Deliverables
+
+- File baru:
+  - `pnpm-workspace.yaml`
+  - `apps/desktop/` (full scaffold)
+  - `apps/desktop/src-tauri/` (Cargo.toml, tauri.conf.json, main.rs,
+    db/schema.sql + migrations runner, commands/auth.rs)
+  - `apps/desktop/src/` (main.tsx, App.tsx, components/ui/*, components/layout/ThemeSwitcher.tsx,
+    features/auth/Login.tsx, stores/{theme,i18n,auth}.ts, i18n/{id,en}/*.json,
+    routes/*)
+  - `apps/desktop/tests/` (unit + e2e samples)
+  - `packages/shared/` (skeleton)
+  - `.github/workflows/ci-v2.yml`
+- Tests: 1+ Vitest unit, 1+ Playwright e2e (login happy path).
+- Screenshot login screen (light + dark) di PR description.
+
+## Definition of Done
+
+- [ ] `pnpm install && pnpm --filter desktop tauri dev` boot up tanpa error.
+- [ ] Login pakai `admin/admin123` (reuse hash v1) → masuk dashboard placeholder.
+- [ ] Theme switcher 3 opsi works + persist.
+- [ ] "Ingat Saya" centang → restart app → auto-login.
+- [ ] i18n ID/EN switchable di Settings placeholder.
+- [ ] CI v2 (lint/typecheck/test) pass.
+- [ ] CI legacy Python (ci.yml) tetap pass (no Python changes).
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_03.md
+++ b/docs/migration-v2/sessions/SESSION_03.md
@@ -1,0 +1,123 @@
+# SESSION 03 — Layout shell
+
+> **Devin session 3/12.** Sidebar + Header + responsive window. Setelah sesi
+> ini, app punya layout final yang reusable untuk semua page.
+
+## Goal
+
+- Sidebar collapsible (revisi #7) dengan chevron toggle, persist, Ctrl+B,
+  tooltip on-hover, auto-collapse <1024px.
+- Header dengan logo + nama perpustakaan, theme switcher, user menu, manual
+  button.
+- Window responsive (revisi #13, #22): resize tanpa glitch, fullscreen
+  works, minWidth 800×600.
+- Identitas perpustakaan sync foundation (revisi #11): Zustand store +
+  Tauri event listener.
+
+## Revisi tercover
+
+- #7 (sidebar collapsible) — full
+- #11 (sync identitas) — foundation (apply ke sidebar/header; component
+  lain ngikut di sesi masing-masing)
+- #13 (resize glitch fix) — full
+- #22 (window resize fleksibel) — full
+
+## Dependencies
+
+- Sesi 2 COMPLETED.
+
+## Tasks breakdown
+
+### 1. AppShell layout
+
+- `src/components/layout/AppShell.tsx`:
+  - Grid 2-kolom: Sidebar | (Header + main content).
+  - Apply ke route `_authed.tsx` (TanStack Router).
+
+### 2. Sidebar (revisi #7)
+
+- `src/components/layout/Sidebar.tsx`:
+  - Width: 240px expanded, 64px collapsed.
+  - Chevron toggle button di top (icon `CaretDoubleLeft` / `CaretDoubleRight`).
+  - Nav items: Dashboard, Anggota, Buku, Peminjaman, Pengembalian, Kunjungan,
+    Laporan, Settings (dengan icon Phosphor + label).
+  - Active state highlight (route match).
+  - Tooltip on-hover saat collapsed (shadcn `Tooltip`).
+  - Logo + nama perpustakaan di top (sync via `identityStore`).
+- `src/stores/sidebarStore.ts`:
+  - `collapsed: boolean`, `toggle()`, persist localStorage.
+  - Auto-collapse saat viewport <1024px (`useMediaQuery` + effect).
+- Keyboard shortcut `Ctrl+B`: register di `AppShell` lewat `useEffect`
+  + `keydown` listener.
+
+### 3. Header
+
+- `src/components/layout/Header.tsx`:
+  - Breadcrumbs (current route).
+  - Search global placeholder (Devin 4 yang isi).
+  - Manual button (placeholder, Devin 11 isi).
+  - Theme switcher (already done in Devin 2).
+  - User menu (avatar, name, "Logout").
+
+### 4. Identitas store (revisi #11)
+
+- `src/stores/identityStore.ts`:
+  - State: `nama`, `logo_path`, `alamat`, `kepala_perpustakaan`.
+  - Initial: load via Tauri command `identity.get`.
+  - Subscribe Tauri event `identity:changed` → update store.
+- Tauri command `identity.get` di `src-tauri/src/commands/identity.rs`:
+  - Read dari tabel `settings` (key `nama_perpustakaan`, dll.).
+- Apply di Sidebar logo + nama, Header (kalau dipakai), Login screen
+  (Devin 2 udah pakai placeholder, sekarang pakai store).
+
+### 5. Window config (revisi #22)
+
+- `tauri.conf.json`:
+  - `resizable: true`, `minWidth: 800`, `minHeight: 600`, `fullscreen: false`.
+  - `maximized: true` di first launch (boleh di-override user, save di
+    settings).
+- Rust: capture window state on close → save ke settings → restore on next
+  launch.
+
+### 6. Responsive (revisi #13)
+
+- Tailwind breakpoints standar (`md: 768`, `lg: 1024`, `xl: 1280`).
+- Sidebar auto-collapse <1024px.
+- Layout container: `min-h-screen`, `overflow-hidden` di shell, scroll di
+  main content area.
+- Test resize: drag dari 800×600 → 1920×1080 → 800×600 = no flicker, no
+  hidden buttons.
+
+### 7. E2E test
+
+- `tests/e2e/sidebar.spec.ts`:
+  - Klik chevron → sidebar collapse.
+  - Reload → sidebar tetap collapsed (persist).
+  - Press Ctrl+B → toggle.
+  - Resize ke 1023px → auto-collapse.
+
+### 8. Update PROGRESS.md
+
+- Sesi 3 → COMPLETED.
+
+## Deliverables
+
+- File baru:
+  - `src/components/layout/{AppShell,Sidebar,Header}.tsx`
+  - `src/stores/{sidebar,identity}.ts`
+  - `src-tauri/src/commands/identity.rs`
+  - `tests/e2e/sidebar.spec.ts`
+- Tests: e2e sidebar + responsive + Ctrl+B.
+- Screenshot/recording sidebar collapse + resize.
+
+## Definition of Done
+
+- [ ] Toggle chevron expand/collapse smooth (CSS transition 200ms).
+- [ ] State persist setelah reload (Zustand + localStorage).
+- [ ] `Ctrl+B` toggle works global (dari mana pun di app).
+- [ ] Tooltip muncul on-hover saat collapsed.
+- [ ] Resize <1024px → auto-collapse.
+- [ ] Resize 800×600 → 1920×1080 → no glitch, no hidden tombol.
+- [ ] Identitas perpustakaan muncul di Sidebar header (dari `identityStore`).
+- [ ] CI v2 + legacy Python pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_04.md
+++ b/docs/migration-v2/sessions/SESSION_04.md
@@ -1,0 +1,115 @@
+# SESSION 04 — Data Anggota CRUD + autocomplete + live search
+
+> **Devin session 4/12.** Halaman Data Anggota lengkap: list, form add/edit,
+> delete, import Excel, search debounced, autocomplete reusable.
+
+## Goal
+
+- CRUD anggota lengkap dengan tabel master/detail.
+- Live search debounced 200ms (revisi #15) reusable hook.
+- Autocomplete component (revisi #20) reusable, 2-line item, fuzzy match.
+- Dropdown styled (revisi #19) match width, animasi, keyboard nav.
+- Master data dropdown (kelas, jurusan, agama) hanya dari sisi consumer
+  (CRUD master data full di Devin 5).
+
+## Revisi tercover
+
+- #15 (live search debounced) — full (hook reusable + apply ke Anggota)
+- #17 (master data dropdown — sisi anggota) — partial (consume saja)
+- #19 (dropdown styled) — full
+- #20 (autocomplete anggota) — full
+
+## Dependencies
+
+- Sesi 3 COMPLETED.
+
+## Tasks breakdown
+
+### 1. Backend (Rust commands)
+
+- `src-tauri/src/commands/anggota.rs`:
+  - `anggota_list(query, limit, offset, sort_by, sort_dir)`
+  - `anggota_get(id)`
+  - `anggota_create(payload)`
+  - `anggota_update(id, payload)`
+  - `anggota_delete(id)`
+  - `anggota_import_excel(file_path)` (validation + dry-run preview)
+- Validasi di Rust: NIS unique, kelas exists, jurusan exists, agama exists.
+
+### 2. Reusable components
+
+- `src/hooks/use-debounced-search.ts` (revisi #15):
+  - Debounce 200ms, return `{ query, debouncedQuery, setQuery, isPending }`.
+- `src/components/shared/Autocomplete.tsx` (revisi #20):
+  - Props: `items`, `getItemKey`, `renderItem` (2-line), `onSelect`,
+    `placeholder`, `getMatchScore` (fuzzy).
+  - Implementation: shadcn `Command` + `Popover`.
+- `src/components/ui/select.tsx` (revisi #19):
+  - Pakai shadcn `Select`, override style supaya popup width = trigger
+    via `--radix-select-trigger-width` CSS var.
+  - Animasi `data-state` open/close (slide-down 150ms).
+
+### 3. Halaman Anggota
+
+- `src/routes/_authed/anggota.tsx` (list page):
+  - Toolbar: search input (use `useDebouncedSearch`), tombol "Tambah",
+    "Import Excel", filter dropdown (kelas, jurusan).
+  - DataTable: kolom (Foto, Nama, NIS, Kelas, Jurusan, Action).
+  - Sort by column header click.
+  - Pagination footer (limit 25/50/100).
+  - Empty state: ilustrasi + CTA "Tambah Anggota".
+- `src/routes/_authed/anggota/$id.tsx` (detail / edit):
+  - Form react-hook-form + zod schema.
+  - Field: Nama, NIS, Kelas (dropdown), Jurusan (dropdown), Agama
+    (dropdown), Tanggal Lahir (date picker — placeholder Devin 6 nanti
+    finalize), Foto (upload).
+  - Tombol "Simpan", "Batal", "Hapus" (confirmation dialog).
+- `src/routes/_authed/anggota/new.tsx` (form add).
+
+### 4. Import Excel
+
+- Tombol "Import Excel" → file picker (Tauri dialog).
+- Parse pakai `xlsx` lib di TS.
+- Show preview tabel + validasi error per row.
+- Confirm → batch insert via Rust command.
+
+### 5. Header global search
+
+- Header search bar terhubung ke route global (e.g. ke `/anggota?q=...` saat
+  user submit dari Header).
+
+### 6. Tests
+
+- Unit Vitest:
+  - `use-debounced-search.test.ts` (timing).
+  - `autocomplete.test.tsx` (render + select).
+- E2E Playwright:
+  - `anggota.spec.ts`: tambah, edit, delete, search, sort.
+
+### 7. Update PROGRESS.md
+
+- Sesi 4 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src-tauri/src/commands/anggota.rs`
+  - `src/hooks/use-debounced-search.ts`
+  - `src/components/shared/Autocomplete.tsx`
+  - `src/components/ui/select.tsx` (style adjust)
+  - `src/routes/_authed/anggota{.tsx,/index.tsx,/$id.tsx,/new.tsx}`
+  - i18n key tambahan di `id/anggota.json`, `en/anggota.json`.
+- Tests: 2+ unit, 1 e2e.
+- Screenshot: list view, form, autocomplete dropdown.
+
+## Definition of Done
+
+- [ ] Tambah anggota → muncul di list.
+- [ ] Edit anggota → update.
+- [ ] Delete anggota → confirm dialog → remove.
+- [ ] Search ketik 2 char → list filter dalam 200ms.
+- [ ] Autocomplete 2-line (nama + NIS/kelas) muncul.
+- [ ] Dropdown popup width = trigger.
+- [ ] Import Excel: pilih file → preview → confirm → batch insert success.
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_05.md
+++ b/docs/migration-v2/sessions/SESSION_05.md
@@ -1,0 +1,114 @@
+# SESSION 05 — Data Buku CRUD + Master Data komplit
+
+> **Devin session 5/12.** Halaman Buku + 6 master data (DDC, Kategori,
+> Bahasa, Jurusan, Kelas, Agama).
+
+## Goal
+
+- CRUD Buku lengkap (judul, ISBN, DDC, kategori, bahasa, eksemplar).
+- Layout master/detail fix (revisi #16) tanpa empty state nyangkut.
+- Master Data CRUD page di Settings (revisi #17 full):
+  - DDC, Kategori, Bahasa, Jurusan, Kelas, Agama.
+- Migration tabel baru (kategori, bahasa, jurusan, agama).
+- Seed data: DDC dari `assets/ddc-source.txt`, Bahasa dari ISO 639-1
+  (10 bahasa umum), Agama (6 agama resmi Indonesia), Kelas default 7A..12C.
+
+## Revisi tercover
+
+- #16 (fix layout Data Buku) — full
+- #17 (dropdown master data + CRUD) — full
+
+## Dependencies
+
+- Sesi 4 COMPLETED.
+
+## Tasks breakdown
+
+### 1. Migration baru
+
+- `src-tauri/src/db/migrations/002_master_data.sql`:
+  - `kategori`, `bahasa`, `jurusan`, `agama` (lihat ARCHITECTURE.md §4).
+  - Seed default values.
+- `src-tauri/src/db/migrations/003_kta_templates.sql` (untuk Devin 10).
+- Update migration runner di `main.rs`.
+
+### 2. Backend Rust commands
+
+- `src-tauri/src/commands/buku.rs`:
+  - `buku_list(query, limit, offset, filter_ddc, filter_kategori, ...)`
+  - `buku_get(id)` (sertakan eksemplar list)
+  - `buku_create(payload)`, `buku_update(id, payload)`, `buku_delete(id)`
+  - `buku_import_excel(file_path)`
+  - `eksemplar_create(buku_id, kode_unik)`, `eksemplar_delete(id)`
+- `src-tauri/src/commands/master_data.rs`:
+  - generic CRUD untuk 6 master data (atau per-tabel kalau lebih clear).
+  - `ddc_list`, `kategori_list`, ... (read by FE dropdown).
+
+### 3. Halaman Buku (revisi #16)
+
+- `src/routes/_authed/buku.tsx`:
+  - Layout master/detail pakai `ResizablePanelGroup` (shadcn).
+  - Panel kiri: tabel buku + search + filter.
+  - Panel kanan: detail buku terpilih (cover, judul, ISBN, DDC, eksemplar
+    list dengan barcode).
+  - Empty state (no row picked): SVG illustration + CTA.
+- Form add/edit buku: dialog (modal) atau side sheet.
+  - Dropdown DDC (autocomplete pakai #20), Kategori, Bahasa.
+  - Upload cover (Tauri file dialog → save ke
+    `%AppData%/PerpustakaanOffline/covers/`).
+- Import Excel buku (sama pattern dengan anggota).
+
+### 4. Master Data CRUD (revisi #17)
+
+- `src/routes/_authed/settings/master-data.tsx`:
+  - Tabs 6 kategori: DDC, Kategori, Bahasa, Jurusan, Kelas, Agama.
+  - Tiap tab: tabel + tombol Add/Edit/Delete (dialog form).
+  - Validasi: nama unique per tabel.
+- Pasang search di tiap tab (live search debounced).
+
+### 5. Seed data
+
+- `src-tauri/src/db/seed.rs` (atau ke migration):
+  - DDC: import dari `apps/desktop/src-tauri/resources/seed/ddc.txt` (copy
+    dari `assets/ddc-source.txt`).
+  - Bahasa: array 10 ISO 639-1 (id, en, ar, jw, su, jv, zh, ja, fr, de).
+  - Agama: ['Islam','Kristen','Katolik','Hindu','Buddha','Konghucu'].
+  - Kelas: 7A..7C, 8A..8C, ..., 12A..12C (configurable later via Settings).
+- Run on first launch (jika tabel masih kosong).
+
+### 6. Tests
+
+- Unit Vitest:
+  - `master-data.test.ts` (CRUD logic).
+  - `buku.test.ts` (zod schema validation).
+- E2E Playwright:
+  - `buku.spec.ts`: add buku + 3 eksemplar, edit, delete.
+  - `master-data.spec.ts`: add kategori, edit, delete.
+
+### 7. Update PROGRESS.md
+
+- Sesi 5 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src-tauri/src/db/migrations/002_master_data.sql`
+  - `src-tauri/src/commands/{buku,master_data}.rs`
+  - `src-tauri/src/db/seed.rs` (atau setara)
+  - `src/routes/_authed/buku.tsx` + nested
+  - `src/routes/_authed/settings/master-data.tsx`
+  - `src/features/buku/components/{BookList,BookDetail,BookForm}.tsx`
+  - i18n keys tambahan
+- Tests: 2+ unit, 2 e2e.
+- Screenshot: master/detail layout, master data tabs.
+
+## Definition of Done
+
+- [ ] Add buku + 3 eksemplar → tampil di list dengan badge "3/3 tersedia".
+- [ ] Layout master/detail: pilih row → detail muncul; no row → empty state.
+- [ ] 6 master data CRUD-able dari Settings.
+- [ ] Dropdown DDC/Kategori/Bahasa di form buku auto-pull dari master data.
+- [ ] Migration v2 jalan otomatis di first launch.
+- [ ] Seed data masuk.
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_06.md
+++ b/docs/migration-v2/sessions/SESSION_06.md
@@ -1,0 +1,131 @@
+# SESSION 06 — Peminjaman + Pengembalian
+
+> **Devin session 6/12.** Transaksi inti: pinjam, kembalikan, denda, print
+> nota. Pakai date picker custom + autocomplete dari sesi sebelumnya.
+
+## Goal
+
+- Date picker reusable (revisi #12): popup kalender, locale ID, range tahun
+  configurable, "Hari Ini".
+- Halaman Peminjaman (revisi #21): autocomplete anggota+buku, panel info,
+  validasi, print nota, quick stats.
+- Halaman Pengembalian: scan/select pinjaman aktif, hitung denda otomatis,
+  update eksemplar.
+
+## Revisi tercover
+
+- #12 (date picker) — full
+- #21 (Peminjaman komplit) — full
+
+## Dependencies
+
+- Sesi 4 COMPLETED (autocomplete anggota).
+- Sesi 5 COMPLETED (autocomplete buku + master data).
+
+## Tasks breakdown
+
+### 1. Date picker (revisi #12)
+
+- `src/components/ui/date-picker.tsx`:
+  - Bungkus shadcn `Popover` + `Calendar` (react-day-picker).
+  - Locale `id` dari `date-fns/locale`.
+  - Props: `value`, `onChange`, `yearRange?`, `disabled?`.
+  - Footer: button "Hari Ini" (set value ke today + close popup).
+  - Keyboard nav built-in dari react-day-picker.
+- `src/components/ui/date-range-picker.tsx`:
+  - 2 calendar side-by-side (from-to).
+  - Preset: "7 hari terakhir", "30 hari", "Bulan ini", "Tahun ini".
+
+### 2. Backend Rust commands
+
+- `src-tauri/src/commands/peminjaman.rs`:
+  - `peminjaman_list(filter_status, query, limit, offset)`
+  - `peminjaman_get(id)` (include items + anggota + denda calc)
+  - `peminjaman_create(anggota_id, buku_ids[], tgl_pinjam, tgl_jatuh_tempo)`
+    - Validasi: anggota tidak overdue / belum capai limit; eksemplar
+      available.
+  - `peminjaman_kembalikan(peminjaman_id, items[])` (sebagian / semua)
+    - Hitung denda = max(0, hari_telat * tarif).
+    - Update eksemplar status → tersedia.
+    - Insert kas record (denda).
+  - `peminjaman_quick_stats()` → { aktif_hari_ini, aktif_minggu_ini,
+    overdue_count }
+- `src-tauri/src/commands/pengembalian.rs`:
+  - `pengembalian_search(query)` — autocomplete pinjaman aktif via NIS atau
+    judul.
+
+### 3. Halaman Peminjaman (revisi #21)
+
+- `src/routes/_authed/peminjaman.tsx`:
+  - Header: quick stats 3 card (Aktif Hari Ini / Aktif Minggu Ini / Overdue).
+  - Layout 2-kolom:
+    - Kiri: form input
+      - Autocomplete Anggota (revisi #20).
+      - Autocomplete Buku (multi-select up to N).
+      - Date range picker (tgl pinjam, tgl jatuh tempo).
+      - Validasi inline.
+      - Submit + Print Nota toggle.
+    - Kanan: panel info
+      - Anggota terpilih: foto, nama, kelas, riwayat pinjam (mini-list).
+      - Buku terpilih: cover, judul, eksemplar tersedia.
+- `src/routes/_authed/peminjaman/list.tsx`:
+  - Tabel pinjaman aktif/lalu.
+
+### 4. Halaman Pengembalian
+
+- `src/routes/_authed/pengembalian.tsx`:
+  - Autocomplete (search NIS / judul / kode pinjaman).
+  - Tampil card detail: anggota, buku-buku, tgl pinjam, tgl jatuh tempo,
+    denda calculated.
+  - Tombol "Kembalikan Semua" / "Kembalikan Sebagian" (checkbox per item).
+  - Konfirmasi → submit → toast success + tombol "Print Nota Pengembalian".
+
+### 5. Print nota
+
+- `src/lib/pdf/nota.ts`:
+  - Generate PDF mini (5×7cm thermal atau A5).
+  - Pakai `pdf-lib`.
+  - Header: identitas perpustakaan (revisi #11 — pakai `identityStore`).
+  - Body: anggota, list buku, tgl pinjam, jatuh tempo, total denda.
+- Print via:
+  - Save → buka di default PDF viewer (cross-platform).
+  - Atau `tauri-plugin-printer` direct print (kalau available).
+
+### 6. Tests
+
+- Unit:
+  - `denda.test.ts` (hitung hari telat × tarif).
+  - `peminjaman-validation.test.ts` (limit per anggota, eksemplar
+    available).
+  - `date-picker.test.tsx` (locale, "Hari Ini" works).
+- E2E:
+  - `peminjaman.spec.ts`: pinjam → autocomplete → submit → print → kembalikan.
+  - `pengembalian.spec.ts`: search → kembalikan partial.
+
+### 7. Update PROGRESS.md
+
+- Sesi 6 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src/components/ui/{date-picker,date-range-picker}.tsx`
+  - `src-tauri/src/commands/{peminjaman,pengembalian}.rs`
+  - `src/routes/_authed/peminjaman.tsx` + nested
+  - `src/routes/_authed/pengembalian.tsx`
+  - `src/lib/pdf/nota.ts`
+  - i18n keys
+- Tests: 3+ unit, 2 e2e.
+- Recording: peminjaman happy path + pengembalian dengan denda.
+
+## Definition of Done
+
+- [ ] Date picker locale ID, "Hari Ini" works.
+- [ ] Pilih anggota → panel info muncul (foto, nama, kelas, riwayat).
+- [ ] Pilih buku → panel info muncul (cover, judul, eksemplar count).
+- [ ] Validasi block: anggota overdue, eksemplar 0.
+- [ ] Submit → record dibuat + nota PDF generated.
+- [ ] Pengembalian: hitung denda otomatis, update eksemplar status.
+- [ ] Quick stats real-time.
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_07.md
+++ b/docs/migration-v2/sessions/SESSION_07.md
@@ -1,0 +1,77 @@
+# SESSION 07 — Kunjungan redesign
+
+> **Devin session 7/12.** Halaman Kunjungan modern: ilustrasi transparan,
+> quick stats, filter date range.
+
+## Goal
+
+- Redesign Kunjungan (revisi #18):
+  - Bg ilustrasi transparent (asset SVG, theme-aware).
+  - 3 quick stat card (hari ini, minggu ini, bulan ini).
+  - Filter date range (pakai date picker dari Devin 6).
+  - Live search debounced (Devin 4 hook).
+  - Tabel kunjungan (Nama, Kelas, Jam Masuk, Tujuan).
+  - Tombol "Tambah Kunjungan" (autocomplete anggota → 1-click insert).
+
+## Revisi tercover
+
+- #18 (Kunjungan redesign) — full
+
+## Dependencies
+
+- Sesi 3 COMPLETED (layout shell).
+- Sesi 4 COMPLETED (autocomplete anggota + live search hook).
+
+## Tasks breakdown
+
+### 1. Backend
+
+- `src-tauri/src/commands/kunjungan.rs`:
+  - `kunjungan_list(date_from, date_to, query, limit, offset)`
+  - `kunjungan_create(anggota_id, tujuan)` — auto set jam masuk = now.
+  - `kunjungan_quick_stats()` → { hari_ini, minggu_ini, bulan_ini }.
+
+### 2. Frontend
+
+- `src/routes/_authed/kunjungan.tsx`:
+  - Header: 3 quick stat card (icon + angka besar + label).
+  - Toolbar: search input + date range picker + tombol "Tambah Kunjungan".
+  - Bg ilustrasi transparent SVG (placeholder, swap di Devin 12 #6).
+  - Tabel kunjungan dengan kolom Nama, Kelas, Jam Masuk, Tujuan, Action.
+
+### 3. Modal "Tambah Kunjungan"
+
+- Autocomplete anggota.
+- Dropdown tujuan (opsi: Membaca, Pinjam Buku, Tugas, Lainnya).
+- Submit → insert + close + refresh tabel.
+
+### 4. Tests
+
+- Unit: `quick-stats.test.ts` (date range calc).
+- E2E: `kunjungan.spec.ts`:
+  - Tambah kunjungan → quick stat hari ini +1.
+  - Filter range tanggal → tabel update.
+
+### 5. Update PROGRESS.md
+
+- Sesi 7 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src-tauri/src/commands/kunjungan.rs`
+  - `src/routes/_authed/kunjungan.tsx`
+  - `src/features/kunjungan/components/*`
+  - i18n keys
+- Tests: 1 unit + 1 e2e.
+- Screenshot kunjungan light + dark.
+
+## Definition of Done
+
+- [ ] 3 quick stat real-time.
+- [ ] Filter date range update tabel.
+- [ ] Bg ilustrasi transparent (light + dark variant).
+- [ ] Tambah kunjungan satu-klik via autocomplete.
+- [ ] Live search ketik 2+ char → filter dalam 200ms.
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_08.md
+++ b/docs/migration-v2/sessions/SESSION_08.md
@@ -1,0 +1,86 @@
+# SESSION 08 — Dashboard modern dengan charts
+
+> **Devin session 8/12.** Halaman Dashboard final: 3 hero card + donut + bar
+> + featured row.
+
+## Goal
+
+- Redesign Dashboard (revisi #9):
+  - Hero row: 3 KPI card (Total Anggota, Total Buku, Buku Dipinjam) + delta
+    bulan-vs-bulan-lalu.
+  - Donut chart distribusi DDC.
+  - Bar chart kunjungan 7 hari terakhir.
+  - Featured row: 5 anggota top + 5 buku top (mini-card).
+  - Hapus Treeview (legacy).
+
+## Revisi tercover
+
+- #9 (Dashboard modern) — full
+
+## Dependencies
+
+- Sesi 4, 5, 6 COMPLETED (perlu data anggota/buku/peminjaman).
+
+## Tasks breakdown
+
+### 1. Backend
+
+- `src-tauri/src/commands/dashboard.rs`:
+  - `dashboard_kpi()` → { total_anggota, total_buku, buku_dipinjam,
+    delta_anggota_pct, delta_buku_pct, delta_pinjam_pct }
+  - `dashboard_ddc_distribution()` → [{ ddc_class, count }]
+  - `dashboard_kunjungan_7d()` → [{ date, count }]
+  - `dashboard_top_peminjam(limit)` → top 5 anggota
+  - `dashboard_top_buku(limit)` → top 5 buku
+
+### 2. Frontend Dashboard
+
+- `src/routes/_authed/dashboard.tsx`:
+  - **Hero row**: 3 `<KpiCard>` (icon Phosphor, angka besar, delta arrow,
+    skeleton saat loading).
+  - **Charts row** (2-col):
+    - Donut DDC (`<PieChart>` recharts).
+    - Bar kunjungan 7d (`<BarChart>` recharts).
+  - **Featured row** (2-col):
+    - Top Peminjam (mini-card list).
+    - Top Buku (mini-card list).
+  - Theme-aware: ambil chart color dari Tailwind CSS var.
+  - Empty state: ilustrasi + CTA "Tambah anggota / buku" kalau DB kosong.
+
+### 3. Reusable component
+
+- `src/components/shared/KpiCard.tsx`
+- `src/components/shared/Chart{Pie,Bar,Line}.tsx` wrapper recharts (theme-aware).
+
+### 4. Tests
+
+- Unit: `kpi-delta.test.ts` (calc bulan-vs-bulan-lalu).
+- E2E: `dashboard.spec.ts`:
+  - Render KPI > 0 (pakai seed data).
+  - Donut & bar visible.
+  - Top 5 list visible.
+
+### 5. Update PROGRESS.md
+
+- Sesi 8 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src-tauri/src/commands/dashboard.rs`
+  - `src/routes/_authed/dashboard.tsx` (replace placeholder dari Devin 2)
+  - `src/components/shared/{KpiCard,ChartPie,ChartBar,ChartLine}.tsx`
+  - i18n keys
+- Tests: 1 unit + 1 e2e.
+- Screenshot dashboard light + dark, dengan empty state + filled state.
+
+## Definition of Done
+
+- [ ] 3 KPI card responsif (3-col ≥1024px, 1-col mobile).
+- [ ] Donut + bar render dengan data real.
+- [ ] Top 5 list render dengan data real.
+- [ ] Loading skeleton.
+- [ ] Empty state CTA.
+- [ ] Treeview legacy hilang.
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_09.md
+++ b/docs/migration-v2/sessions/SESSION_09.md
@@ -1,0 +1,104 @@
+# SESSION 09 — Laporan komplit
+
+> **Devin session 9/12.** 5 sub-page Laporan: Grafik, Top Peminjam, Top
+> Buku, Kas, Backup.
+
+## Goal
+
+- Redesign Laporan (revisi #23):
+  - Sidebar nav 5 sub-page.
+  - Filter date range di tiap sub-page.
+  - Grafik Kunjungan: line chart bulan/tahun.
+  - Top Peminjam: tabel + bar chart 10 besar.
+  - Top Buku: tabel + bar chart 10 besar.
+  - Kas: tabel + line chart cumulative + breakdown denda vs manual.
+  - Backup: backup full DB, restore, jadwal cron.
+- Export PDF + Excel (header pakai identitas).
+
+## Revisi tercover
+
+- #23 (Laporan komplit) — full
+
+## Dependencies
+
+- Sesi 6, 7, 8 COMPLETED.
+
+## Tasks breakdown
+
+### 1. Backend
+
+- `src-tauri/src/commands/laporan.rs`:
+  - `laporan_grafik_kunjungan(date_from, date_to, granularity: 'day' | 'month' | 'year')`
+  - `laporan_top_peminjam(date_from, date_to, limit)`
+  - `laporan_top_buku(date_from, date_to, limit)`
+  - `laporan_kas(date_from, date_to)` → { rows[], total_denda,
+    total_manual, cumulative[] }
+  - `laporan_export_pdf(jenis, date_from, date_to)` (return file path)
+  - `laporan_export_xlsx(jenis, date_from, date_to)`
+- `src-tauri/src/commands/backup.rs`:
+  - `backup_create(target_dir)` → file `.db` + checksum SHA256.
+  - `backup_restore(file_path)` (validation checksum).
+  - `backup_schedule_get()`, `backup_schedule_set(cron, enabled)`.
+
+### 2. Frontend
+
+- `src/routes/_authed/laporan.tsx` (parent layout dengan sub-nav).
+- `src/routes/_authed/laporan/grafik.tsx`
+- `src/routes/_authed/laporan/top-peminjam.tsx`
+- `src/routes/_authed/laporan/top-buku.tsx`
+- `src/routes/_authed/laporan/kas.tsx`
+- `src/routes/_authed/laporan/backup.tsx`
+
+Tiap sub-page:
+- Header: title + date range picker + tombol "Export PDF" + "Export Excel".
+- Body: chart + tabel.
+
+Backup page khusus:
+- Tombol "Backup Sekarang" → Tauri dialog.save → pilih folder.
+- Tombol "Restore" → file picker.
+- Section "Jadwal": toggle on/off, cron expression input + preview ("setiap
+  hari pukul 02:00").
+
+### 3. Export PDF / Excel
+
+- PDF pakai `pdf-lib` di TS:
+  - Header: logo + nama perpustakaan + alamat + "Laporan <jenis> - <periode>".
+  - Body: tabel.
+  - Footer: tanggal generate + signature line.
+- Excel pakai `xlsx` di TS:
+  - Sheet "Data" dengan header.
+
+### 4. Tests
+
+- Unit: `laporan-aggregator.test.ts` (sum, group by month/year).
+- E2E: `laporan.spec.ts`:
+  - Filter range → tabel update.
+  - Export PDF → file generated.
+  - Backup → file `.db` di target dir + checksum match.
+
+### 5. Update PROGRESS.md
+
+- Sesi 9 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src-tauri/src/commands/{laporan,backup}.rs`
+  - `src/routes/_authed/laporan/*.tsx`
+  - `src/lib/pdf/laporan.ts`
+  - `src/lib/excel/laporan.ts`
+  - i18n keys
+- Tests: 2 unit + 1 e2e.
+- Screenshot 5 sub-page.
+
+## Definition of Done
+
+- [ ] 5 sub-page nav works.
+- [ ] Filter date range update chart + tabel.
+- [ ] Export PDF → header pakai identitas perpustakaan.
+- [ ] Export Excel → file `.xlsx` valid.
+- [ ] Backup `.db` + SHA256 checksum.
+- [ ] Restore validates checksum.
+- [ ] Schedule cron runnable (test via Tauri scheduler atau cron-like).
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_10.md
+++ b/docs/migration-v2/sessions/SESSION_10.md
@@ -1,0 +1,117 @@
+# SESSION 10 — KTA system komplit
+
+> **Devin session 10/12.** Kartu Tanda Anggota: template editor visual,
+> auto-fill, barcode QR, print batch.
+
+## Goal
+
+- Sistem KTA (revisi #14):
+  - Fix font path (bundle TTF di Tauri resources).
+  - Template editor visual (drag-drop area, font size/color picker).
+  - Field auto-fill: `[nama]`, `[nis]`, `[kelas]`, `[foto]`, `[barcode_qr]`.
+  - Barcode QR berisi `member_id` → scan di Peminjaman langsung auto-fill.
+  - Print: 1 anggota / batch (semua anggota terpilih).
+
+## Revisi tercover
+
+- #14 (KTA system) — full
+
+## Dependencies
+
+- Sesi 4 COMPLETED (anggota CRUD).
+- Sesi 5 COMPLETED (master data + migration `kta_templates`).
+
+## Tasks breakdown
+
+### 1. Backend
+
+- `src-tauri/src/commands/kta.rs`:
+  - `kta_template_list()`, `kta_template_get(id)`, `kta_template_create()`,
+    `kta_template_update()`, `kta_template_delete()`.
+  - `kta_template_set_default(id)`.
+  - `kta_render(anggota_id, template_id)` — return PDF bytes.
+  - `kta_render_batch(anggota_ids[], template_id)` — return PDF multi-page.
+
+### 2. Bundle font
+
+- `apps/desktop/src-tauri/resources/fonts/`:
+  - Inter (regular, semibold, bold) untuk teks.
+  - JetBrains Mono untuk NIS/barcode label.
+  - Code39 / IDAutomation HC39M (bila perlu untuk barcode 1D).
+- Load via `tauri::path::resolve_path` di Rust, atau kalau pakai pdf-lib di
+  TS: `fs.readBinaryFile` lewat Tauri.
+
+### 3. Template editor (frontend)
+
+- `src/routes/_authed/settings/kta.tsx`:
+  - Canvas editor (HTML/CSS based, bukan native canvas) — pakai
+    `react-rnd` atau `dnd-kit` untuk drag-drop field.
+  - Toolbar: tambah field (nama, nis, kelas, foto, qr), set font/size/color,
+    background, dimensi (default ID-1: 85.6×53.98mm).
+  - Save layout JSON ke `kta_templates`.
+  - Set default toggle.
+  - Tombol "Preview" → render PDF inline.
+
+### 4. PDF render (backend or frontend)
+
+- Pilihan A (frontend `pdf-lib`):
+  - Lebih portable.
+  - Render layout JSON → PDF.
+- Pilihan B (backend Rust `printpdf`):
+  - Native, akurat ukuran.
+  - Bundle size kecil tambahan.
+- Default: A (`pdf-lib`), fallback B kalau perlu.
+
+### 5. Barcode QR
+
+- `src/lib/barcode.ts`:
+  - QR code pakai `qrcode` lib (TS).
+  - Embed `member:<id>` URL scheme atau JSON `{member_id}`.
+  - Render ke PNG → embed di PDF.
+- Reader di Peminjaman:
+  - Input listener (USB scanner emulasi keyboard) atau kamera (skip kamera
+    untuk MVP).
+  - Parse → autofocus → autofill anggota field.
+
+### 6. Print
+
+- Sub-page "Cetak KTA" di Settings atau dari halaman Anggota:
+  - Pilih anggota (multi-select dari list).
+  - Pilih template.
+  - Tombol "Cetak" → render PDF → buka di OS print dialog atau
+    `tauri-plugin-printer`.
+
+### 7. Tests
+
+- Unit: `kta-template-render.test.ts` (parse layout JSON → PDF dimensions).
+- Unit: `barcode-qr.test.ts` (encode → decode round-trip).
+- E2E: `kta.spec.ts`:
+  - Edit template → simpan.
+  - Render KTA satu anggota → file PDF generated.
+
+### 8. Update PROGRESS.md
+
+- Sesi 10 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src-tauri/src/commands/kta.rs`
+  - `src-tauri/resources/fonts/*`
+  - `src/routes/_authed/settings/kta.tsx`
+  - `src/features/kta/components/{TemplateEditor,FieldDraggable,Preview}.tsx`
+  - `src/lib/pdf/kta.ts`
+  - `src/lib/barcode.ts`
+  - i18n keys
+- Tests: 2+ unit + 1 e2e.
+- Screenshot template editor + KTA preview.
+
+## Definition of Done
+
+- [ ] Template editor: drag field, ubah font/size, save.
+- [ ] Render KTA satu anggota → PDF file dengan barcode QR.
+- [ ] Render batch (e.g. 10 anggota) → PDF multi-page.
+- [ ] Scan QR di Peminjaman → autofill.
+- [ ] Font path stable (test build production).
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_11.md
+++ b/docs/migration-v2/sessions/SESSION_11.md
@@ -1,0 +1,136 @@
+# SESSION 11 — Settings comprehensive + manual book + audit wording
+
+> **Devin session 11/12.** Settings 12 sub-page final + Manual HTML +
+> sweep wording terakhir.
+
+## Goal
+
+- Settings 12 sub-page (revisi #24): mirip Google Workspace settings, search
+  bar global, tooltip, reset to default.
+- Manual HTML responsif (revisi #4): generate dari Markdown, bundle ke
+  resources, buka via tombol Header.
+- Audit wording final (revisi #25): sweep semua label/dialog/error/i18n.
+
+## Revisi tercover
+
+- #4 (manual HTML) — full
+- #24 (Settings 12 kategori) — full
+- #25 (audit wording) — full sweep
+
+## Dependencies
+
+- Sesi 3 COMPLETED (header).
+- Sesi 5 COMPLETED (master data).
+- Sesi 10 COMPLETED (KTA template editor).
+
+## Tasks breakdown
+
+### 1. Settings layout
+
+- `src/routes/_authed/settings.tsx` (parent layout):
+  - Sidebar nav 12 sub-page (icon + label):
+    1. Identitas Perpustakaan
+    2. Aturan Peminjaman (rename dari "Transaksi")
+    3. Master Data (sudah ada di Devin 5, integrasi sub-nav)
+    4. KTA Template (sudah ada di Devin 10, integrasi sub-nav)
+    5. Tampilan (theme, font scale, density)
+    6. Bahasa (ID/EN)
+    7. Akun & Pengguna (CRUD users + role)
+    8. Hak Akses (Permissions matrix)
+    9. Backup & Restore (sudah ada di Devin 9, integrasi sub-nav)
+    10. Sinkronisasi (Google Sheets opsional)
+    11. Audit Log
+    12. Tentang
+  - Search bar global di top sidebar nav (filter setting items real-time).
+  - Tombol "Reset to default" per sub-page + global.
+
+### 2. Tiap sub-page (yang belum dibuat sesi sebelumnya)
+
+- **#1 Identitas**: form nama_perpustakaan, alamat, kepala, NPSN, logo
+  upload.
+  - Submit → emit Tauri event `identity:changed`.
+- **#2 Aturan Peminjaman**: limit per anggota, durasi default, tarif denda
+  per hari, hari libur.
+- **#5 Tampilan**: theme dropdown (already #8), font scale slider, density
+  (compact/comfortable).
+- **#6 Bahasa**: select ID/EN.
+- **#7 Akun & Pengguna**: tabel users CRUD (admin/pustakawan), reset password.
+- **#8 Hak Akses**: matrix per-role permissions (checkbox per command).
+- **#10 Sinkronisasi**: setup Google Sheets API key, tombol "Sync sekarang",
+  status terakhir.
+- **#11 Audit Log**: tabel filterable (user, action, target, timestamp).
+- **#12 Tentang**: versi app, link GitHub, kredit "alvi arts / vwrks", tombol
+  "Buka Manual" (link revisi #4).
+
+### 3. Manual HTML (revisi #4)
+
+- Source: split `docs/manual.md` (legacy) + content tambahan v2 →
+  `docs/migration-v2/manual/*.md`.
+  - Chapter: Pengantar, Setup, Login, Anggota, Buku, Peminjaman, Pengembalian,
+    Kunjungan, Laporan, KTA, Settings, FAQ, Troubleshooting.
+- Build:
+  - Pakai static gen sederhana: VitePress / mdBook / Astro starter
+    minimal.
+  - Output `dist/` di-copy ke `apps/desktop/src-tauri/resources/manual/`.
+  - Build step: `pnpm --filter manual build` (sub-package `apps/manual` atau
+    integrated).
+- Frontend:
+  - Tauri command `open_manual()` → `shell.open(path/to/index.html)`.
+  - Tombol "Manual" di Header membuka di browser default.
+- Manual harus:
+  - Responsif (breakpoint 768).
+  - Search bar.
+  - Dark mode toggle.
+  - Header inject identitas perpustakaan (template).
+
+### 4. Audit wording (revisi #25)
+
+- Grep semua "Transaksi" → ganti "Aturan Peminjaman" di:
+  - i18n JSON (id + en)
+  - Component label
+  - Toast / dialog
+  - PDF/Excel header
+- Sweep konsistensi:
+  - Title Case untuk label utama
+  - Sentence case untuk help text
+  - Error message friendly (no "Foreign key constraint", dll.)
+- Lint i18n: pastikan tidak ada key tidak terpakai (custom script
+  `pnpm i18n:lint`).
+
+### 5. Tests
+
+- Unit: `i18n-coverage.test.ts` (semua key di id + en).
+- Unit: `settings-search.test.ts` (filter logic).
+- E2E: `settings.spec.ts`:
+  - Search "denda" → muncul di "Aturan Peminjaman" hanya.
+  - Reset to default → konfirmasi → revert.
+  - Buka Manual → window/tab baru terbuka dengan URL manual.
+
+### 6. Update PROGRESS.md
+
+- Sesi 11 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `src/routes/_authed/settings/*.tsx` (12 sub-page total)
+  - `apps/manual/` (atau setara, generate HTML)
+  - `apps/desktop/src-tauri/resources/manual/index.html` + assets
+  - `apps/desktop/src-tauri/src/commands/manual.rs` (open command)
+  - i18n full coverage
+  - `scripts/i18n-lint.ts`
+- Tests: 2+ unit + 1 e2e.
+- Screenshot 12 sub-page settings + manual page.
+
+## Definition of Done
+
+- [ ] 12 sub-page nav works.
+- [ ] Search bar real-time filter.
+- [ ] Tooltip on-hover.
+- [ ] Reset to default works (confirm dialog → revert).
+- [ ] Manual HTML responsif + search + dark mode + identitas inject.
+- [ ] Tombol Manual di Header membuka browser default.
+- [ ] Tidak ada string "Transaksi" sebagai menu.
+- [ ] i18n lint pass (no missing/orphan keys).
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.

--- a/docs/migration-v2/sessions/SESSION_12.md
+++ b/docs/migration-v2/sessions/SESSION_12.md
@@ -1,0 +1,153 @@
+# SESSION 12 — Installer + release v1.0.0
+
+> **Devin session 12/12.** Bundle Windows installer (Tauri MSI / Inno Setup),
+> swap final asset high-res, scrollbar polish, migration script v1 → v2,
+> tag release.
+
+## Goal
+
+- Installer Windows polish:
+  - Logo `.ico` di Start Menu / Search / Taskbar (revisi #1).
+  - Hapus "Select Setup Language" dialog (revisi #2).
+  - License page custom kredit + replace CD/box wizard graphic (revisi #3).
+- Swap final asset high-res unDraw/Storyset (revisi #6).
+- Mouse wheel scroll + scrollbar fade-auto (revisi #26).
+- Migration script `.db` v1 → v2.
+- Cleanup legacy v1 (move ke `legacy/v1/` atau hapus, lihat ASSETS_REUSE.md §6).
+- Tag release `v1.0.0`.
+
+## Revisi tercover
+
+- #1 (logo installer + .exe icon) — full
+- #2 (hapus language picker) — full
+- #3 (license + wizard graphic) — full
+- #6 (asset high-res) — full (final pass; sebagian ditambah di sesi UI)
+- #26 (scrollbar polish) — full
+
+## Dependencies
+
+- Sesi 2..11 SEMUA COMPLETED.
+
+## Tasks breakdown
+
+### 1. Icon bundle (revisi #1)
+
+- `apps/desktop/src-tauri/icons/`:
+  - `32x32.png`, `128x128.png`, `128x128@2x.png` (256×256), `icon.icns` (mac),
+    `icon.ico` (win, multi-size 16/32/48/256).
+- Source: 1024×1024 SVG / PNG di `apps/desktop/src-tauri/icons/source/`.
+- Generate via `tauri icon <source.png>`.
+- Verifikasi di Windows: install MSI → Start Menu / Search / Taskbar /
+  Alt-Tab semua pakai logo.
+
+### 2. Inno Setup config (revisi #2, #3)
+
+- Pilihan A: pakai Tauri NSIS bundler (default Tauri).
+- Pilihan B: pakai Tauri WiX MSI (untuk MSI).
+- Untuk customisasi license + wizard graphic + no-language-picker:
+  - Pakai Tauri Inno Setup template via custom `tauri-plugin-` atau
+    standalone Inno setelah build Tauri.
+  - File `apps/desktop/src-tauri/installer/inno-setup.iss`:
+    - `[Setup] ShowLanguageDialog=no`
+    - `LicenseFile=docs/legal/LICENSE-installer.txt`
+    - `WizardImageFile=installer/assets/wizard-banner.bmp` (164×314)
+    - `WizardSmallImageFile=installer/assets/wizard-small.bmp` (55×58)
+- Wizard graphic: render logo Nusantara → BMP (atau pakai `WizardStyle=modern`
+  yang support PNG).
+
+### 3. License file
+
+- `docs/legal/LICENSE-installer.txt`:
+  - Header: "Perpustakaan Offline v2 — alvi arts / vwrks"
+  - Body: isi LICENSE root (MIT / GPL).
+  - Footer: link GitHub.
+
+### 4. Swap asset high-res (revisi #6)
+
+- Replace placeholder SVG/PNG di `apps/desktop/public/illustrations/` dengan
+  asset final (download dari unDraw / Storyset).
+- Update `CREDITS.md` dengan attribution.
+- Verifikasi: tidak ada lagi PIL procedural rendering di runtime; semua asset
+  SVG / 1024px+.
+
+### 5. Scrollbar polish (revisi #26)
+
+- Install `tailwind-scrollbar` atau pakai `overlayscrollbars-react`.
+- Apply ke main scroll area + tabel.
+- CSS: scrollbar fade-out setelah idle 1.5s, fade-in saat scroll.
+- `scroll-behavior: smooth` di `<html>`.
+- Test: scroll di Dashboard / tabel besar / Settings → smooth + fade works.
+
+### 6. Migration script v1 → v2
+
+- `scripts/migrate-v1-to-v2.ts` (TS, run via `tsx` atau Node):
+  - Argv: input `.db` v1 path, output v2 path.
+  - Open v1 read-only.
+  - Buat v2 fresh dengan schema (apply migrations).
+  - Copy row tabel inti (anggota, buku, peminjaman, dll.).
+  - Seed tabel baru kalau perlu.
+  - Validasi count match.
+  - Backup `.db` v1 → `<filename>.v1-backup-<timestamp>.db`.
+  - Print summary.
+- UI button "Import dari v1" di Settings → Backup tab (call command bridge
+  ke script).
+
+### 7. Cleanup legacy v1 (opsional, behind flag)
+
+- Move `src/perpustakaan/`, `tests/`, `build.spec`, `installer/` ke
+  `legacy/v1/`, atau biarkan di main lalu hapus di tag berikut (v1.1).
+- Disable `.github/workflows/ci.yml` (rename `.disabled` atau hapus).
+- Update `README.md` jadi panduan v2.
+
+### 8. Release v1.0.0
+
+- Bump `apps/desktop/src-tauri/tauri.conf.json` `version` → `1.0.0`.
+- Bump `apps/desktop/package.json` `version` → `1.0.0`.
+- Tag git `v1.0.0` (Devin push tag, user yang final approve).
+- Workflow `ci-v2.yml` job `build-windows` triggered on tag → upload MSI
+  + EXE artifact + GitHub Release draft.
+
+### 9. Tests
+
+- E2E full smoke: `tests/e2e/smoke-full.spec.ts`:
+  - Login → Dashboard → Anggota add → Buku add → Peminjaman → Pengembalian
+    → Laporan export → Logout.
+- Migration test: `tests/migration.test.ts` — pakai sample `.db` v1
+  fixture, run script, validate count.
+- Build smoke test (CI): `pnpm --filter desktop tauri build` selesai tanpa
+  error di Windows runner.
+
+### 10. Update PROGRESS.md
+
+- Sesi 12 → COMPLETED.
+
+## Deliverables
+
+- File:
+  - `apps/desktop/src-tauri/icons/*` (8+ size variants)
+  - `apps/desktop/src-tauri/installer/inno-setup.iss` + assets
+  - `docs/legal/LICENSE-installer.txt`
+  - `apps/desktop/public/illustrations/*` (final asset)
+  - `apps/desktop/public/illustrations/CREDITS.md`
+  - `scripts/migrate-v1-to-v2.ts`
+  - Bump version
+  - Git tag `v1.0.0`
+- Tests: 1 e2e full smoke + 1 migration unit + CI build success.
+- Artifact: MSI + EXE installer di GitHub Release.
+- Recording: install MSI di Windows VM → launch → login → flow lengkap.
+
+## Definition of Done
+
+- [ ] MSI installer Windows generated tanpa error.
+- [ ] Install: no "Select Setup Language" dialog.
+- [ ] License page tampil custom + kredit alvi arts / vwrks.
+- [ ] Wizard graphic = logo Nusantara, bukan box CD.
+- [ ] Logo .ico muncul di Start Menu / Search / Taskbar / Alt-Tab.
+- [ ] Migration script: ambil `.db` v1 → output v2 valid, count match.
+- [ ] Scrollbar fade-auto + smooth scroll.
+- [ ] Asset high-res semua.
+- [ ] Release `v1.0.0` tag pushed (CI build artifact).
+- [ ] CI pass.
+- [ ] PROGRESS.md updated.
+- [ ] User confirm dengan install MSI + smoke test manual sebelum publish
+      release ke publik.


### PR DESCRIPTION
## Summary

Bootstrap migration plan untuk full rewrite Perpustakaan Offline dari Python + customtkinter (v1) ke modern stack: Tauri 2.0 + React 18 + TypeScript + Tailwind 3 + shadcn/ui + Zustand + Vite + pnpm + Vitest + Playwright.

**No kode aplikasi.** PR ini hanya menambah file dokumentasi di `docs/migration-v2/` sebagai foundation untuk 11 sesi Devin berikutnya yang akan eksekusi migrasi sequential.

### Deliverables (19 file, 3.581 baris)

- [`PROGRESS.md`](docs/migration-v2/PROGRESS.md) — state machine-parseable 12 sesi (id/title/status/pr/completed_at/dependencies). Source of truth Devin berikutnya untuk pilih sesi yang harus dikerjakan.
- [`REVISION_BACKLOG.md`](docs/migration-v2/REVISION_BACKLOG.md) — 26 revisi dengan kategori UI/UX/Bug/Asset/Logic, scope detail (file v1 → lokasi v2), dependency, prioritas P0/P1/P2, link ke `references/revision-NN-*.png`, definition of done. Termasuk coverage matrix revisi → sesi.
- [`STACK_DECISION.md`](docs/migration-v2/STACK_DECISION.md) — analisis Tauri 2.0 vs Electron (rekomendasi Tauri) + sub-decisions: DB strategy (sqlx via tauri-plugin-sql), state mgmt (Zustand), routing (TanStack Router), charts (recharts), PDF (pdf-lib).
- [`ARCHITECTURE.md`](docs/migration-v2/ARCHITECTURE.md) — diagram FE/IPC/BE/DB, file structure monorepo (`apps/desktop/`, `packages/shared/`), build pipeline (Vite + Tauri CLI + GitHub Actions), tabel baru di v2 (`kategori`, `bahasa`, `jurusan`, `agama`, `kta_templates`, `auth_tokens`).
- [`ASSETS_REUSE.md`](docs/migration-v2/ASSETS_REUSE.md) — REUSE/BUANG/PORT/MIGRATE matrix per file v1, plus quick-reference tabel.
- [`sessions/SESSION_01.md`..`SESSION_12.md`](docs/migration-v2/sessions/) — breakdown per sesi: Goal, Scope, Revisi tercover, Dependency, Tasks, Deliverables, Definition of Done.
- [`INSTRUCTION_TEMPLATE.md`](docs/migration-v2/INSTRUCTION_TEMPLATE.md) — copy-paste prompt universal untuk semua sesi (Devin auto-detect dirinya sesi keberapa dari `PROGRESS.md`).
- [`references/INDEX.md`](docs/migration-v2/references/INDEX.md) — placeholder + naming convention 36 screenshot referensi (di-isi manual oleh user).

### 12 sesi breakdown ringkas

| # | Sesi | Revisi tercover | Dep |
|---|---|---|---|
| 1 | Bootstrap (PR ini) | — | — |
| 2 | Scaffolding + login + theme + i18n | #5, #8, #10, #25 (partial) | 1 |
| 3 | Layout shell (sidebar + responsive) | #7, #11 (foundation), #13, #22 | 2 |
| 4 | Data Anggota CRUD + autocomplete | #15, #17 (partial), #19, #20 | 3 |
| 5 | Data Buku + Master Data komplit | #16, #17 (full) | 4 |
| 6 | Peminjaman + Pengembalian | #12, #21 | 4, 5 |
| 7 | Kunjungan redesign | #18 | 3, 4 |
| 8 | Dashboard modern + charts | #9 | 4, 5, 6 |
| 9 | Laporan komplit | #23 | 6, 7, 8 |
| 10 | KTA system | #14 | 4, 5 |
| 11 | Settings 12 kategori + manual + audit | #4, #24, #25 (full) | 3, 5, 10 |
| 12 | Installer MSI + release v1.0.0 | #1, #2, #3, #6 (final), #26 | 2..11 |

Semua 26 revisi tercover, sesi 11 & 12 jadi finishing pass (audit + asset polish + release).

## Review & Testing Checklist for Human

PR ini docs-only, low risk. Fokus review:

- [ ] Skim `STACK_DECISION.md` — setuju dengan default Tauri 2.0 + Zustand + TanStack Router + sqlx? Kalau ada preference lain (mis. better-sqlite3, Redux Toolkit, React Router), sebut sekarang sebelum Devin 2 mulai scaffolding.
- [ ] Skim `REVISION_BACKLOG.md` coverage matrix — mapping 26 revisi → 12 sesi sudah sesuai ekspektasi?
- [ ] Drop 36 screenshot referensi ke `docs/migration-v2/references/` (naming pattern di `references/INDEX.md`). Boleh nyusul, tapi makin cepat makin baik supaya Devin sesi UI (2/3/4/5/6/7/8/9) punya baseline visual yang akurat.

### Notes

- Devin 1 tidak modifikasi v1 source (`src/perpustakaan/`, `tests/`, `build.spec`, `installer/`). Cleanup legacy di-handle Devin 12 setelah v2 stable.
- Setelah PR ini merge, Devin 2 baca `PROGRESS.md` (sesi 1 status `IN_PROGRESS` di branch ini → bisa di-flip ke `COMPLETED` saat Devin 2 mulai, atau di commit follow-up kecil).
- CI legacy Python (`ci.yml`) tetap aktif dan harus tetap pass — PR ini cuma nambah file Markdown, jadi seharusnya green.
- Workaround auth: PAT user dipakai karena Devin GitHub App tidak terdeteksi di git-manager untuk repo ini. Sesi 2 dst. akan pakai PAT yang sama (sudah di-save repo-scoped).

Devin session 1/12.

---

Session URL: https://app.devin.ai/sessions/faf9175cbd7c4a10869638772fe7b1b8
Requested by: vielz883019 (vielz883019@proton.me)