### PR TITLE
feat(session-05): data buku CRUD + master data lengkap + Settings tabs

### DIFF
--- a/apps/desktop/src-tauri/src/commands/buku.rs
+++ b/apps/desktop/src-tauri/src/commands/buku.rs
@@ -1,0 +1,507 @@
+use rusqlite::{params, params_from_iter, OptionalExtension, ToSql};
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+/// Single buku row mirroring the SQLite `buku` table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Buku {
+    pub id: i64,
+    pub kode_buku: String,
+    pub judul: String,
+    pub pengarang: Option<String>,
+    pub penerbit: Option<String>,
+    pub tahun_terbit: Option<i64>,
+    pub kode_ddc: Option<String>,
+    pub kategori: Option<String>,
+    pub isbn: Option<String>,
+    pub jumlah_eksemplar: i64,
+    pub jumlah_tersedia: i64,
+    pub sumber: Option<String>,
+    pub harga: i64,
+    pub cover_path: Option<String>,
+    pub bahasa: Option<String>,
+    pub deskripsi: Option<String>,
+    pub rak: Option<String>,
+    pub tanggal_input: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Eksemplar {
+    pub id: i64,
+    pub buku_id: i64,
+    pub kode_eksemplar: String,
+    pub status: String,
+    pub catatan: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BukuInput {
+    pub kode_buku: String,
+    pub judul: String,
+    pub pengarang: Option<String>,
+    pub penerbit: Option<String>,
+    pub tahun_terbit: Option<i64>,
+    pub kode_ddc: Option<String>,
+    pub kategori: Option<String>,
+    pub isbn: Option<String>,
+    pub jumlah_eksemplar: Option<i64>,
+    pub sumber: Option<String>,
+    pub harga: Option<i64>,
+    pub cover_path: Option<String>,
+    pub bahasa: Option<String>,
+    pub deskripsi: Option<String>,
+    pub rak: Option<String>,
+    pub tanggal_input: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BukuListArgs {
+    pub query: Option<String>,
+    pub kategori: Option<String>,
+    pub bahasa: Option<String>,
+    pub kode_ddc: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+    pub sort_by: Option<String>,
+    pub sort_dir: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BukuListResult {
+    pub items: Vec<Buku>,
+    pub total: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BukuDetail {
+    pub buku: Buku,
+    pub eksemplar: Vec<Eksemplar>,
+}
+
+const SORT_FIELDS: &[&str] = &[
+    "judul",
+    "kode_buku",
+    "pengarang",
+    "kategori",
+    "kode_ddc",
+    "tahun_terbit",
+    "tanggal_input",
+    "created_at",
+];
+
+fn validate_sort(sort_by: &str, sort_dir: &str) -> AppResult<(String, String)> {
+    let by = SORT_FIELDS
+        .iter()
+        .find(|f| **f == sort_by)
+        .ok_or_else(|| AppError::Validation(format!("unsupported sort_by '{sort_by}'")))?;
+    let dir = match sort_dir.to_ascii_uppercase().as_str() {
+        "ASC" => "ASC",
+        "DESC" => "DESC",
+        other => {
+            return Err(AppError::Validation(format!(
+                "unsupported sort_dir '{other}'"
+            )))
+        }
+    };
+    Ok(((*by).to_string(), dir.to_string()))
+}
+
+fn map_buku_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Buku> {
+    Ok(Buku {
+        id: row.get("id")?,
+        kode_buku: row.get("kode_buku")?,
+        judul: row.get("judul")?,
+        pengarang: row.get("pengarang")?,
+        penerbit: row.get("penerbit")?,
+        tahun_terbit: row.get("tahun_terbit")?,
+        kode_ddc: row.get("kode_ddc")?,
+        kategori: row.get("kategori")?,
+        isbn: row.get("isbn")?,
+        jumlah_eksemplar: row.get("jumlah_eksemplar")?,
+        jumlah_tersedia: row.get("jumlah_tersedia")?,
+        sumber: row.get("sumber")?,
+        harga: row.get("harga")?,
+        cover_path: row.get("cover_path")?,
+        bahasa: row.get("bahasa")?,
+        deskripsi: row.get("deskripsi")?,
+        rak: row.get("rak")?,
+        tanggal_input: row.get("tanggal_input")?,
+        created_at: row.get("created_at")?,
+        updated_at: row.get("updated_at")?,
+    })
+}
+
+fn map_eksemplar_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Eksemplar> {
+    Ok(Eksemplar {
+        id: row.get("id")?,
+        buku_id: row.get("buku_id")?,
+        kode_eksemplar: row.get("kode_eksemplar")?,
+        status: row.get("status")?,
+        catatan: row.get("catatan")?,
+        created_at: row.get("created_at")?,
+        updated_at: row.get("updated_at")?,
+    })
+}
+
+#[tauri::command]
+pub fn buku_list(state: State<'_, AppState>, args: BukuListArgs) -> AppResult<BukuListResult> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let limit = args.limit.unwrap_or(100).clamp(1, 500);
+    let offset = args.offset.unwrap_or(0).max(0);
+    let (sort_by, sort_dir) = validate_sort(
+        args.sort_by.as_deref().unwrap_or("judul"),
+        args.sort_dir.as_deref().unwrap_or("ASC"),
+    )?;
+
+    let mut filters: Vec<String> = Vec::new();
+    let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+
+    if let Some(q) = args.query.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        filters.push(
+            "(judul LIKE ?1 OR kode_buku LIKE ?1 OR pengarang LIKE ?1 OR isbn LIKE ?1)"
+                .to_string(),
+        );
+        params.push(Box::new(format!("%{q}%")));
+    }
+    if let Some(k) = args.kategori.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        filters.push(format!("kategori = ?{}", params.len() + 1));
+        params.push(Box::new(k.to_string()));
+    }
+    if let Some(b) = args.bahasa.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        filters.push(format!("bahasa = ?{}", params.len() + 1));
+        params.push(Box::new(b.to_string()));
+    }
+    if let Some(d) = args.kode_ddc.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        filters.push(format!("kode_ddc LIKE ?{}", params.len() + 1));
+        params.push(Box::new(format!("{d}%")));
+    }
+
+    let where_clause = if filters.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", filters.join(" AND "))
+    };
+
+    let count_sql = format!("SELECT COUNT(*) FROM buku{where_clause}");
+    let total: i64 = conn.query_row(&count_sql, params_from_iter(params.iter()), |r| r.get(0))?;
+
+    let list_sql = format!(
+        "SELECT * FROM buku{where_clause} ORDER BY {sort_by} {sort_dir} LIMIT ?{lim} OFFSET ?{off}",
+        lim = params.len() + 1,
+        off = params.len() + 2
+    );
+    let mut stmt = conn.prepare(&list_sql)?;
+    let mut all_params: Vec<Box<dyn ToSql>> = params;
+    all_params.push(Box::new(limit));
+    all_params.push(Box::new(offset));
+    let rows = stmt
+        .query_map(params_from_iter(all_params.iter()), map_buku_row)?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(BukuListResult { items: rows, total })
+}
+
+#[tauri::command]
+pub fn buku_get(state: State<'_, AppState>, id: i64) -> AppResult<BukuDetail> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let buku = conn
+        .query_row("SELECT * FROM buku WHERE id = ?1", params![id], map_buku_row)
+        .optional()?
+        .ok_or_else(|| AppError::NotFound(format!("buku id={id}")))?;
+    let mut stmt = conn.prepare(
+        "SELECT * FROM eksemplar WHERE buku_id = ?1 ORDER BY kode_eksemplar ASC",
+    )?;
+    let eksemplar = stmt
+        .query_map(params![id], map_eksemplar_row)?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(BukuDetail { buku, eksemplar })
+}
+
+fn validate_buku_input(input: &BukuInput) -> AppResult<()> {
+    if input.kode_buku.trim().is_empty() {
+        return Err(AppError::Validation("kode_buku required".into()));
+    }
+    if input.judul.trim().is_empty() {
+        return Err(AppError::Validation("judul required".into()));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn buku_create(state: State<'_, AppState>, input: BukuInput) -> AppResult<Buku> {
+    validate_buku_input(&input)?;
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let dup: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM buku WHERE kode_buku = ?1",
+        params![input.kode_buku.trim()],
+        |r| r.get(0),
+    )?;
+    if dup > 0 {
+        return Err(AppError::Validation(format!(
+            "kode_buku '{}' sudah dipakai",
+            input.kode_buku
+        )));
+    }
+    let jumlah = input.jumlah_eksemplar.unwrap_or(1).max(0);
+    let harga = input.harga.unwrap_or(0).max(0);
+    conn.execute(
+        "INSERT INTO buku (kode_buku, judul, pengarang, penerbit, tahun_terbit, kode_ddc,
+            kategori, isbn, jumlah_eksemplar, jumlah_tersedia, sumber, harga, cover_path,
+            bahasa, deskripsi, rak, tanggal_input)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
+            COALESCE(?16, date('now')))",
+        params![
+            input.kode_buku.trim(),
+            input.judul.trim(),
+            input.pengarang,
+            input.penerbit,
+            input.tahun_terbit,
+            input.kode_ddc,
+            input.kategori,
+            input.isbn,
+            jumlah,
+            input.sumber,
+            harga,
+            input.cover_path,
+            input.bahasa,
+            input.deskripsi,
+            input.rak,
+            input.tanggal_input,
+        ],
+    )?;
+    let id = conn.last_insert_rowid();
+    let buku =
+        conn.query_row("SELECT * FROM buku WHERE id = ?1", params![id], map_buku_row)?;
+    Ok(buku)
+}
+
+#[tauri::command]
+pub fn buku_update(state: State<'_, AppState>, id: i64, input: BukuInput) -> AppResult<Buku> {
+    validate_buku_input(&input)?;
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let dup: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM buku WHERE kode_buku = ?1 AND id <> ?2",
+        params![input.kode_buku.trim(), id],
+        |r| r.get(0),
+    )?;
+    if dup > 0 {
+        return Err(AppError::Validation(format!(
+            "kode_buku '{}' sudah dipakai buku lain",
+            input.kode_buku
+        )));
+    }
+    let updated = conn.execute(
+        "UPDATE buku SET kode_buku = ?1, judul = ?2, pengarang = ?3, penerbit = ?4,
+            tahun_terbit = ?5, kode_ddc = ?6, kategori = ?7, isbn = ?8, jumlah_eksemplar = ?9,
+            sumber = ?10, harga = ?11, cover_path = ?12, bahasa = ?13, deskripsi = ?14,
+            rak = ?15, updated_at = datetime('now')
+         WHERE id = ?16",
+        params![
+            input.kode_buku.trim(),
+            input.judul.trim(),
+            input.pengarang,
+            input.penerbit,
+            input.tahun_terbit,
+            input.kode_ddc,
+            input.kategori,
+            input.isbn,
+            input.jumlah_eksemplar.unwrap_or(1),
+            input.sumber,
+            input.harga.unwrap_or(0),
+            input.cover_path,
+            input.bahasa,
+            input.deskripsi,
+            input.rak,
+            id,
+        ],
+    )?;
+    if updated == 0 {
+        return Err(AppError::NotFound(format!("buku id={id}")));
+    }
+    let buku =
+        conn.query_row("SELECT * FROM buku WHERE id = ?1", params![id], map_buku_row)?;
+    Ok(buku)
+}
+
+#[tauri::command]
+pub fn buku_delete(state: State<'_, AppState>, id: i64) -> AppResult<()> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let deleted = conn.execute("DELETE FROM buku WHERE id = ?1", params![id])?;
+    if deleted == 0 {
+        return Err(AppError::NotFound(format!("buku id={id}")));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn eksemplar_create(
+    state: State<'_, AppState>,
+    buku_id: i64,
+    kode: String,
+) -> AppResult<Eksemplar> {
+    let kode = kode.trim();
+    if kode.is_empty() {
+        return Err(AppError::Validation("kode_eksemplar required".into()));
+    }
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let dup: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM eksemplar WHERE kode_eksemplar = ?1",
+        params![kode],
+        |r| r.get(0),
+    )?;
+    if dup > 0 {
+        return Err(AppError::Validation(format!(
+            "kode_eksemplar '{kode}' sudah dipakai"
+        )));
+    }
+    conn.execute(
+        "INSERT INTO eksemplar (buku_id, kode_eksemplar, status) VALUES (?1, ?2, 'tersedia')",
+        params![buku_id, kode],
+    )?;
+    let id = conn.last_insert_rowid();
+    let row = conn.query_row(
+        "SELECT * FROM eksemplar WHERE id = ?1",
+        params![id],
+        map_eksemplar_row,
+    )?;
+    // Sync jumlah counters on the parent buku.
+    sync_buku_counts(&conn, buku_id)?;
+    Ok(row)
+}
+
+#[tauri::command]
+pub fn eksemplar_delete(state: State<'_, AppState>, id: i64) -> AppResult<()> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let buku_id: Option<i64> = conn
+        .query_row("SELECT buku_id FROM eksemplar WHERE id = ?1", params![id], |r| {
+            r.get(0)
+        })
+        .optional()?;
+    let buku_id = buku_id.ok_or_else(|| AppError::NotFound(format!("eksemplar id={id}")))?;
+    conn.execute("DELETE FROM eksemplar WHERE id = ?1", params![id])?;
+    sync_buku_counts(&conn, buku_id)?;
+    Ok(())
+}
+
+fn sync_buku_counts(conn: &rusqlite::Connection, buku_id: i64) -> AppResult<()> {
+    let total: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM eksemplar WHERE buku_id = ?1",
+        params![buku_id],
+        |r| r.get(0),
+    )?;
+    let available: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM eksemplar WHERE buku_id = ?1 AND status = 'tersedia'",
+        params![buku_id],
+        |r| r.get(0),
+    )?;
+    if total > 0 {
+        conn.execute(
+            "UPDATE buku SET jumlah_eksemplar = ?1, jumlah_tersedia = ?2,
+                updated_at = datetime('now') WHERE id = ?3",
+            params![total, available, buku_id],
+        )?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BukuImportItem {
+    pub kode_buku: String,
+    pub judul: String,
+    pub pengarang: Option<String>,
+    pub penerbit: Option<String>,
+    pub tahun_terbit: Option<i64>,
+    pub kode_ddc: Option<String>,
+    pub kategori: Option<String>,
+    pub isbn: Option<String>,
+    pub jumlah_eksemplar: Option<i64>,
+    pub bahasa: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BukuImportResult {
+    pub inserted: i64,
+    pub skipped: i64,
+    pub errors: Vec<BukuImportError>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BukuImportError {
+    pub row: usize,
+    pub message: String,
+}
+
+#[tauri::command]
+pub fn buku_import(
+    state: State<'_, AppState>,
+    items: Vec<BukuImportItem>,
+) -> AppResult<BukuImportResult> {
+    let mut conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let tx = conn.transaction()?;
+    let mut inserted = 0;
+    let mut skipped = 0;
+    let mut errors: Vec<BukuImportError> = Vec::new();
+    for (idx, item) in items.iter().enumerate() {
+        if item.kode_buku.trim().is_empty() || item.judul.trim().is_empty() {
+            errors.push(BukuImportError {
+                row: idx + 1,
+                message: "kode_buku and judul are required".into(),
+            });
+            skipped += 1;
+            continue;
+        }
+        let dup: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM buku WHERE kode_buku = ?1",
+            params![item.kode_buku.trim()],
+            |r| r.get(0),
+        )?;
+        if dup > 0 {
+            errors.push(BukuImportError {
+                row: idx + 1,
+                message: format!("kode_buku '{}' sudah ada", item.kode_buku),
+            });
+            skipped += 1;
+            continue;
+        }
+        let jumlah = item.jumlah_eksemplar.unwrap_or(1).max(0);
+        tx.execute(
+            "INSERT INTO buku (kode_buku, judul, pengarang, penerbit, tahun_terbit, kode_ddc,
+                kategori, isbn, jumlah_eksemplar, jumlah_tersedia, bahasa)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9, ?10)",
+            params![
+                item.kode_buku.trim(),
+                item.judul.trim(),
+                item.pengarang,
+                item.penerbit,
+                item.tahun_terbit,
+                item.kode_ddc,
+                item.kategori,
+                item.isbn,
+                jumlah,
+                item.bahasa,
+            ],
+        )?;
+        inserted += 1;
+    }
+    tx.commit()?;
+    Ok(BukuImportResult {
+        inserted,
+        skipped,
+        errors,
+    })
+}

--- a/apps/desktop/src-tauri/src/commands/master_data.rs
+++ b/apps/desktop/src-tauri/src/commands/master_data.rs
@@ -1,0 +1,460 @@
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+/// Generic master-data record. `id` is `None` for primary-key-as-string tables
+/// like `bahasa` (kode is the PK) and `ddc` (kode is the PK).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MasterItem {
+    pub id: Option<i64>,
+    pub kode: Option<String>,
+    pub nama: String,
+    pub deskripsi: Option<String>,
+    pub urutan: Option<i64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MasterInput {
+    pub kode: Option<String>,
+    pub nama: String,
+    pub deskripsi: Option<String>,
+    pub urutan: Option<i64>,
+}
+
+fn allowed_table(name: &str) -> AppResult<&'static str> {
+    match name {
+        "kategori" => Ok("kategori"),
+        "bahasa" => Ok("bahasa"),
+        "jurusan" => Ok("jurusan"),
+        "agama" => Ok("agama"),
+        "kelas" => Ok("kelas"),
+        "ddc" => Ok("ddc"),
+        other => Err(AppError::Validation(format!("unknown master table '{other}'"))),
+    }
+}
+
+#[tauri::command]
+pub fn master_list(
+    state: State<'_, AppState>,
+    table: String,
+    query: Option<String>,
+) -> AppResult<Vec<MasterItem>> {
+    let table = allowed_table(&table)?;
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let q = query
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("%{s}%"));
+
+    let (sql, like) = match (table, q.as_deref()) {
+        ("bahasa", Some(_)) => (
+            "SELECT NULL as id, kode as kode, nama, NULL as deskripsi, NULL as urutan
+             FROM bahasa WHERE nama LIKE ?1 OR kode LIKE ?1 ORDER BY nama ASC"
+                .to_string(),
+            true,
+        ),
+        ("bahasa", None) => (
+            "SELECT NULL as id, kode as kode, nama, NULL as deskripsi, NULL as urutan
+             FROM bahasa ORDER BY nama ASC"
+                .to_string(),
+            false,
+        ),
+        ("ddc", Some(_)) => (
+            "SELECT NULL as id, kode as kode, deskripsi as nama, NULL as deskripsi,
+                    depth as urutan
+             FROM ddc WHERE kode LIKE ?1 OR deskripsi LIKE ?1
+             ORDER BY kode ASC LIMIT 200"
+                .to_string(),
+            true,
+        ),
+        ("ddc", None) => (
+            "SELECT NULL as id, kode as kode, deskripsi as nama, NULL as deskripsi,
+                    depth as urutan
+             FROM ddc ORDER BY kode ASC LIMIT 200"
+                .to_string(),
+            false,
+        ),
+        ("kategori", Some(_)) => (
+            "SELECT id, NULL as kode, nama, deskripsi, urutan FROM kategori
+             WHERE nama LIKE ?1 ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            true,
+        ),
+        ("kategori", None) => (
+            "SELECT id, NULL as kode, nama, deskripsi, urutan FROM kategori
+             ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            false,
+        ),
+        ("kelas", Some(_)) => (
+            "SELECT id, NULL as kode, nama, NULL as deskripsi, urutan FROM kelas
+             WHERE nama LIKE ?1 ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            true,
+        ),
+        ("kelas", None) => (
+            "SELECT id, NULL as kode, nama, NULL as deskripsi, urutan FROM kelas
+             ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            false,
+        ),
+        ("jurusan", Some(_)) => (
+            "SELECT id, kode, nama, NULL as deskripsi, urutan FROM jurusan
+             WHERE nama LIKE ?1 OR kode LIKE ?1 ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            true,
+        ),
+        ("jurusan", None) => (
+            "SELECT id, kode, nama, NULL as deskripsi, urutan FROM jurusan
+             ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            false,
+        ),
+        ("agama", Some(_)) => (
+            "SELECT id, NULL as kode, nama, NULL as deskripsi, urutan FROM agama
+             WHERE nama LIKE ?1 ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            true,
+        ),
+        ("agama", None) => (
+            "SELECT id, NULL as kode, nama, NULL as deskripsi, urutan FROM agama
+             ORDER BY urutan ASC, nama ASC"
+                .to_string(),
+            false,
+        ),
+        _ => unreachable!(),
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mapper = |row: &rusqlite::Row<'_>| -> rusqlite::Result<MasterItem> {
+        Ok(MasterItem {
+            id: row.get::<_, Option<i64>>("id")?,
+            kode: row.get::<_, Option<String>>("kode")?,
+            nama: row.get::<_, String>("nama")?,
+            deskripsi: row.get::<_, Option<String>>("deskripsi")?,
+            urutan: row.get::<_, Option<i64>>("urutan")?,
+        })
+    };
+    let rows = if like {
+        stmt.query_map(params![q.as_deref().unwrap_or("")], mapper)?
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map([], mapper)?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    Ok(rows)
+}
+
+#[tauri::command]
+pub fn master_create(
+    state: State<'_, AppState>,
+    table: String,
+    input: MasterInput,
+) -> AppResult<MasterItem> {
+    let table = allowed_table(&table)?;
+    if input.nama.trim().is_empty() {
+        return Err(AppError::Validation("nama required".into()));
+    }
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+
+    match table {
+        "bahasa" => {
+            let kode = input
+                .kode
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| AppError::Validation("kode required for bahasa".into()))?;
+            let dup: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM bahasa WHERE kode = ?1 OR nama = ?2",
+                params![kode, input.nama.trim()],
+                |r| r.get(0),
+            )?;
+            if dup > 0 {
+                return Err(AppError::Validation(format!(
+                    "bahasa '{kode}' / '{}' sudah ada",
+                    input.nama
+                )));
+            }
+            conn.execute(
+                "INSERT INTO bahasa (kode, nama) VALUES (?1, ?2)",
+                params![kode, input.nama.trim()],
+            )?;
+            Ok(MasterItem {
+                id: None,
+                kode: Some(kode.to_string()),
+                nama: input.nama.trim().to_string(),
+                deskripsi: None,
+                urutan: None,
+            })
+        }
+        "ddc" => {
+            let kode = input
+                .kode
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| AppError::Validation("kode required for ddc".into()))?;
+            let dup: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM ddc WHERE kode = ?1",
+                params![kode],
+                |r| r.get(0),
+            )?;
+            if dup > 0 {
+                return Err(AppError::Validation(format!("ddc '{kode}' sudah ada")));
+            }
+            let depth = input.urutan.unwrap_or(0);
+            conn.execute(
+                "INSERT INTO ddc (kode, deskripsi, depth) VALUES (?1, ?2, ?3)",
+                params![kode, input.nama.trim(), depth],
+            )?;
+            Ok(MasterItem {
+                id: None,
+                kode: Some(kode.to_string()),
+                nama: input.nama.trim().to_string(),
+                deskripsi: None,
+                urutan: Some(depth),
+            })
+        }
+        "kategori" => {
+            let dup: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM kategori WHERE LOWER(nama) = LOWER(?1)",
+                params![input.nama.trim()],
+                |r| r.get(0),
+            )?;
+            if dup > 0 {
+                return Err(AppError::Validation(format!(
+                    "kategori '{}' sudah ada",
+                    input.nama
+                )));
+            }
+            conn.execute(
+                "INSERT INTO kategori (nama, deskripsi, urutan) VALUES (?1, ?2, ?3)",
+                params![input.nama.trim(), input.deskripsi, input.urutan.unwrap_or(0)],
+            )?;
+            let id = conn.last_insert_rowid();
+            Ok(MasterItem {
+                id: Some(id),
+                kode: None,
+                nama: input.nama.trim().to_string(),
+                deskripsi: input.deskripsi,
+                urutan: input.urutan.or(Some(0)),
+            })
+        }
+        "jurusan" => {
+            let dup: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM jurusan WHERE LOWER(nama) = LOWER(?1)",
+                params![input.nama.trim()],
+                |r| r.get(0),
+            )?;
+            if dup > 0 {
+                return Err(AppError::Validation(format!(
+                    "jurusan '{}' sudah ada",
+                    input.nama
+                )));
+            }
+            conn.execute(
+                "INSERT INTO jurusan (nama, kode, urutan) VALUES (?1, ?2, ?3)",
+                params![input.nama.trim(), input.kode, input.urutan.unwrap_or(0)],
+            )?;
+            let id = conn.last_insert_rowid();
+            Ok(MasterItem {
+                id: Some(id),
+                kode: input.kode,
+                nama: input.nama.trim().to_string(),
+                deskripsi: None,
+                urutan: input.urutan.or(Some(0)),
+            })
+        }
+        "kelas" => {
+            let dup: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM kelas WHERE LOWER(nama) = LOWER(?1)",
+                params![input.nama.trim()],
+                |r| r.get(0),
+            )?;
+            if dup > 0 {
+                return Err(AppError::Validation(format!(
+                    "kelas '{}' sudah ada",
+                    input.nama
+                )));
+            }
+            let tingkat = input
+                .nama
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+                .parse::<i64>()
+                .ok();
+            conn.execute(
+                "INSERT INTO kelas (nama, tingkat, urutan) VALUES (?1, ?2, ?3)",
+                params![input.nama.trim(), tingkat, input.urutan.unwrap_or(0)],
+            )?;
+            let id = conn.last_insert_rowid();
+            Ok(MasterItem {
+                id: Some(id),
+                kode: None,
+                nama: input.nama.trim().to_string(),
+                deskripsi: None,
+                urutan: input.urutan.or(Some(0)),
+            })
+        }
+        "agama" => {
+            let dup: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM agama WHERE LOWER(nama) = LOWER(?1)",
+                params![input.nama.trim()],
+                |r| r.get(0),
+            )?;
+            if dup > 0 {
+                return Err(AppError::Validation(format!(
+                    "agama '{}' sudah ada",
+                    input.nama
+                )));
+            }
+            conn.execute(
+                "INSERT INTO agama (nama, urutan) VALUES (?1, ?2)",
+                params![input.nama.trim(), input.urutan.unwrap_or(0)],
+            )?;
+            let id = conn.last_insert_rowid();
+            Ok(MasterItem {
+                id: Some(id),
+                kode: None,
+                nama: input.nama.trim().to_string(),
+                deskripsi: None,
+                urutan: input.urutan.or(Some(0)),
+            })
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[tauri::command]
+pub fn master_update(
+    state: State<'_, AppState>,
+    table: String,
+    key: String,
+    input: MasterInput,
+) -> AppResult<MasterItem> {
+    let table = allowed_table(&table)?;
+    if input.nama.trim().is_empty() {
+        return Err(AppError::Validation("nama required".into()));
+    }
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    match table {
+        "bahasa" => {
+            let updated = conn.execute(
+                "UPDATE bahasa SET nama = ?1 WHERE kode = ?2",
+                params![input.nama.trim(), key],
+            )?;
+            if updated == 0 {
+                return Err(AppError::NotFound(format!("bahasa '{key}'")));
+            }
+            Ok(MasterItem {
+                id: None,
+                kode: Some(key),
+                nama: input.nama.trim().to_string(),
+                deskripsi: None,
+                urutan: None,
+            })
+        }
+        "ddc" => {
+            let updated = conn.execute(
+                "UPDATE ddc SET deskripsi = ?1 WHERE kode = ?2",
+                params![input.nama.trim(), key],
+            )?;
+            if updated == 0 {
+                return Err(AppError::NotFound(format!("ddc '{key}'")));
+            }
+            Ok(MasterItem {
+                id: None,
+                kode: Some(key),
+                nama: input.nama.trim().to_string(),
+                deskripsi: None,
+                urutan: input.urutan,
+            })
+        }
+        other => {
+            let id: i64 = key.parse().map_err(|_| {
+                AppError::Validation(format!("invalid id for {other}: '{key}'"))
+            })?;
+            let sql = match other {
+                "kategori" => {
+                    "UPDATE kategori SET nama = ?1, deskripsi = ?2, urutan = ?3 WHERE id = ?4"
+                }
+                "jurusan" => {
+                    "UPDATE jurusan SET nama = ?1, kode = ?2, urutan = ?3 WHERE id = ?4"
+                }
+                "kelas" => {
+                    "UPDATE kelas SET nama = ?1, tingkat = ?2, urutan = ?3 WHERE id = ?4"
+                }
+                "agama" => "UPDATE agama SET nama = ?1, urutan = ?3 WHERE id = ?4",
+                _ => unreachable!(),
+            };
+            let aux: rusqlite::types::Value = match other {
+                "kategori" => input
+                    .deskripsi
+                    .clone()
+                    .map(rusqlite::types::Value::Text)
+                    .unwrap_or(rusqlite::types::Value::Null),
+                "jurusan" => input
+                    .kode
+                    .clone()
+                    .map(rusqlite::types::Value::Text)
+                    .unwrap_or(rusqlite::types::Value::Null),
+                "kelas" => {
+                    let tingkat = input
+                        .nama
+                        .chars()
+                        .take_while(|c| c.is_ascii_digit())
+                        .collect::<String>()
+                        .parse::<i64>()
+                        .ok();
+                    tingkat
+                        .map(rusqlite::types::Value::Integer)
+                        .unwrap_or(rusqlite::types::Value::Null)
+                }
+                "agama" => rusqlite::types::Value::Null,
+                _ => unreachable!(),
+            };
+            let updated = conn.execute(
+                sql,
+                params![input.nama.trim(), aux, input.urutan.unwrap_or(0), id],
+            )?;
+            if updated == 0 {
+                return Err(AppError::NotFound(format!("{other} id={id}")));
+            }
+            Ok(MasterItem {
+                id: Some(id),
+                kode: input.kode,
+                nama: input.nama.trim().to_string(),
+                deskripsi: input.deskripsi,
+                urutan: input.urutan.or(Some(0)),
+            })
+        }
+    }
+}
+
+#[tauri::command]
+pub fn master_delete(state: State<'_, AppState>, table: String, key: String) -> AppResult<()> {
+    let table = allowed_table(&table)?;
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let deleted = match table {
+        "bahasa" => conn.execute("DELETE FROM bahasa WHERE kode = ?1", params![key])?,
+        "ddc" => conn.execute("DELETE FROM ddc WHERE kode = ?1", params![key])?,
+        other => {
+            let id: i64 = key.parse().map_err(|_| {
+                AppError::Validation(format!("invalid id for {other}: '{key}'"))
+            })?;
+            conn.execute(&format!("DELETE FROM {other} WHERE id = ?1"), params![id])?
+        }
+    };
+    if deleted == 0 {
+        return Err(AppError::NotFound(format!("{table} '{key}'")));
+    }
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod anggota;
 pub mod auth;
+pub mod buku;
 pub mod identity;
+pub mod master_data;
 pub mod window_state;

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -27,8 +27,149 @@ pub fn open_connection(path: &Path) -> AppResult<Connection> {
 
 pub fn run_migrations(conn: &Connection) -> AppResult<()> {
     conn.execute_batch(SCHEMA_SQL)?;
+    conn.execute_batch(MASTER_DATA_SQL)?;
     apply_additive_migrations(conn)?;
+    seed_master_data(conn)?;
     log::info!("schema migrations applied (idempotent)");
+    Ok(())
+}
+
+const MASTER_DATA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS kategori (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    nama  TEXT NOT NULL UNIQUE,
+    deskripsi TEXT,
+    urutan INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS bahasa (
+    kode TEXT PRIMARY KEY,
+    nama TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS jurusan (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    nama  TEXT NOT NULL UNIQUE,
+    kode  TEXT,
+    urutan INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS agama (
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    nama  TEXT NOT NULL UNIQUE,
+    urutan INTEGER NOT NULL DEFAULT 0
+);
+"#;
+
+/// Default seed values for master data tables. Inserted only on first launch
+/// (when the table is empty) so manual edits in Settings persist across upgrades.
+fn seed_master_data(conn: &Connection) -> AppResult<()> {
+    seed_if_empty(conn, "agama", AGAMA_SEED, |conn, idx, name| {
+        conn.execute(
+            "INSERT INTO agama (nama, urutan) VALUES (?1, ?2)",
+            rusqlite::params![name, idx as i64],
+        )
+        .map(|_| ())
+    })?;
+    seed_if_empty(conn, "kategori", KATEGORI_SEED, |conn, idx, name| {
+        conn.execute(
+            "INSERT INTO kategori (nama, urutan) VALUES (?1, ?2)",
+            rusqlite::params![name, idx as i64],
+        )
+        .map(|_| ())
+    })?;
+    seed_if_empty(conn, "kelas", KELAS_SEED, |conn, idx, name| {
+        let tingkat = name
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect::<String>()
+            .parse::<i64>()
+            .ok();
+        conn.execute(
+            "INSERT INTO kelas (nama, tingkat, urutan) VALUES (?1, ?2, ?3)",
+            rusqlite::params![name, tingkat, idx as i64],
+        )
+        .map(|_| ())
+    })?;
+    seed_if_empty(conn, "jurusan", JURUSAN_SEED, |conn, idx, name| {
+        conn.execute(
+            "INSERT INTO jurusan (nama, urutan) VALUES (?1, ?2)",
+            rusqlite::params![name, idx as i64],
+        )
+        .map(|_| ())
+    })?;
+    seed_bahasa_if_empty(conn)?;
+    Ok(())
+}
+
+const AGAMA_SEED: &[&str] = &["Islam", "Kristen", "Katolik", "Hindu", "Buddha", "Konghucu"];
+
+const KATEGORI_SEED: &[&str] = &[
+    "Fiksi",
+    "Non-fiksi",
+    "Referensi",
+    "Buku Pelajaran",
+    "Karya Ilmiah",
+    "Majalah",
+    "Komik",
+    "Biografi",
+];
+
+const KELAS_SEED: &[&str] = &[
+    "7A", "7B", "7C", "8A", "8B", "8C", "9A", "9B", "9C", "10A", "10B", "10C", "11A", "11B",
+    "11C", "12A", "12B", "12C",
+];
+
+const JURUSAN_SEED: &[&str] = &["IPA", "IPS", "Bahasa", "TKJ", "RPL", "Multimedia"];
+
+const BAHASA_SEED: &[(&str, &str)] = &[
+    ("id", "Indonesia"),
+    ("en", "Inggris"),
+    ("ar", "Arab"),
+    ("jw", "Jawa"),
+    ("su", "Sunda"),
+    ("zh", "Mandarin"),
+    ("ja", "Jepang"),
+    ("fr", "Prancis"),
+    ("de", "Jerman"),
+    ("ms", "Melayu"),
+];
+
+fn seed_if_empty<F>(
+    conn: &Connection,
+    table: &str,
+    items: &[&str],
+    mut insert: F,
+) -> AppResult<()>
+where
+    F: FnMut(&Connection, usize, &str) -> rusqlite::Result<()>,
+{
+    let count: i64 =
+        conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })?;
+    if count > 0 {
+        return Ok(());
+    }
+    for (idx, name) in items.iter().enumerate() {
+        insert(conn, idx, name)?;
+    }
+    log::info!("seeded {} default rows into {table}", items.len());
+    Ok(())
+}
+
+fn seed_bahasa_if_empty(conn: &Connection) -> AppResult<()> {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM bahasa", [], |row| row.get(0))?;
+    if count > 0 {
+        return Ok(());
+    }
+    for (kode, nama) in BAHASA_SEED {
+        conn.execute(
+            "INSERT INTO bahasa (kode, nama) VALUES (?1, ?2)",
+            rusqlite::params![kode, nama],
+        )?;
+    }
+    log::info!("seeded {} default bahasa rows", BAHASA_SEED.len());
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -50,6 +50,18 @@ pub fn run() {
             commands::anggota::anggota_import,
             commands::anggota::anggota_distinct,
             commands::anggota::kelas_list,
+            commands::buku::buku_list,
+            commands::buku::buku_get,
+            commands::buku::buku_create,
+            commands::buku::buku_update,
+            commands::buku::buku_delete,
+            commands::buku::buku_import,
+            commands::buku::eksemplar_create,
+            commands::buku::eksemplar_delete,
+            commands::master_data::master_list,
+            commands::master_data::master_create,
+            commands::master_data::master_update,
+            commands::master_data::master_delete,
         ])
         .build(tauri::generate_context!())
         .expect("failed to build tauri app")

--- a/apps/desktop/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/Sidebar.tsx
@@ -29,7 +29,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { to: '/dashboard', labelKey: 'common:menu.dashboard', Icon: LayoutDashboard },
   { to: '/anggota', labelKey: 'common:menu.anggota', Icon: Users },
-  { to: '/buku', labelKey: 'common:menu.buku', Icon: BookOpen, pending: true },
+  { to: '/buku', labelKey: 'common:menu.buku', Icon: BookOpen },
   { to: '/peminjaman', labelKey: 'common:menu.peminjaman', Icon: ArrowLeftRight, pending: true },
   { to: '/pengembalian', labelKey: 'common:menu.pengembalian', Icon: Undo2, pending: true },
   { to: '/kunjungan', labelKey: 'common:menu.kunjungan', Icon: CalendarCheck, pending: true },

--- a/apps/desktop/src/components/shared/DataTable.tsx
+++ b/apps/desktop/src/components/shared/DataTable.tsx
@@ -35,6 +35,8 @@ export interface DataTableProps<T> {
   onSortChange?: (next: { key: string; dir: 'asc' | 'desc' } | null) => void;
   onRowClick?: (row: T) => void;
   className?: string;
+  /** Highlight the row whose key matches (e.g. for master/detail selection). */
+  highlightedRowKey?: React.Key;
   /** `data-testid` for e2e tests on the surrounding container. */
   'data-testid'?: string;
 }
@@ -49,6 +51,7 @@ export function DataTable<T>({
   onSortChange,
   onRowClick,
   className,
+  highlightedRowKey,
   ...rest
 }: DataTableProps<T>): React.ReactElement {
   const handleSort = (col: DataTableColumn<T>): void => {
@@ -117,21 +120,29 @@ export function DataTable<T>({
               </TableCell>
             </TableRow>
           ) : (
-            rows.map((row) => (
-              <TableRow
-                key={rowKey(row)}
-                className={onRowClick ? 'cursor-pointer' : undefined}
-                onClick={onRowClick ? () => onRowClick(row) : undefined}
-              >
-                {columns.map((col) => (
-                  <TableCell key={col.key} className={col.cellClassName}>
-                    {col.cell
-                      ? col.cell(row)
-                      : String((row as unknown as Record<string, unknown>)[col.key] ?? '')}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))
+            rows.map((row) => {
+              const key = rowKey(row);
+              const highlighted = highlightedRowKey != null && key === highlightedRowKey;
+              return (
+                <TableRow
+                  key={key}
+                  className={cn(
+                    onRowClick && 'cursor-pointer',
+                    highlighted && 'bg-muted/60 hover:bg-muted/60',
+                  )}
+                  onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  data-state={highlighted ? 'selected' : undefined}
+                >
+                  {columns.map((col) => (
+                    <TableCell key={col.key} className={col.cellClassName}>
+                      {col.cell
+                        ? col.cell(row)
+                        : String((row as unknown as Record<string, unknown>)[col.key] ?? '')}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              );
+            })
           )}
         </TableBody>
       </Table>

--- a/apps/desktop/src/features/buku/BukuForm.tsx
+++ b/apps/desktop/src/features/buku/BukuForm.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useMemo } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Autocomplete, type AutocompleteOption } from '@/components/shared/Autocomplete';
+import { bukuFormSchema, type BukuFormValues } from './schema';
+import type { Buku } from '@/lib/buku';
+import type { MasterItem } from '@/lib/masterData';
+import { cn } from '@/lib/utils';
+
+interface BukuFormProps {
+  initial?: Buku | null;
+  onSubmit: (values: BukuFormValues) => Promise<void>;
+  onCancel: () => void;
+  onDelete?: () => void;
+  submitLabel: string;
+  ddcOptions: MasterItem[];
+  kategoriOptions: MasterItem[];
+  bahasaOptions: MasterItem[];
+}
+
+function toFormValues(initial: Buku | null | undefined): BukuFormValues {
+  return {
+    kodeBuku: initial?.kodeBuku ?? '',
+    judul: initial?.judul ?? '',
+    pengarang: initial?.pengarang ?? '',
+    penerbit: initial?.penerbit ?? '',
+    tahunTerbit: initial?.tahunTerbit ? String(initial.tahunTerbit) : '',
+    kodeDdc: initial?.kodeDdc ?? '',
+    kategori: initial?.kategori ?? '',
+    isbn: initial?.isbn ?? '',
+    jumlahEksemplar: initial?.jumlahEksemplar
+      ? String(initial.jumlahEksemplar)
+      : '1',
+    sumber: initial?.sumber ?? '',
+    harga: initial?.harga ? String(initial.harga) : '',
+    bahasa: initial?.bahasa ?? '',
+    deskripsi: initial?.deskripsi ?? '',
+    rak: initial?.rak ?? '',
+    coverPath: initial?.coverPath ?? '',
+  };
+}
+
+function masterToOptions(items: MasterItem[]): AutocompleteOption[] {
+  return items
+    .map((m) => ({
+      value: m.kode ?? m.nama,
+      label: m.kode ? `${m.kode} — ${m.nama}` : m.nama,
+      hint: m.kode && m.kode !== m.nama ? m.nama : undefined,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function BukuForm({
+  initial,
+  onSubmit,
+  onCancel,
+  onDelete,
+  submitLabel,
+  ddcOptions,
+  kategoriOptions,
+  bahasaOptions,
+}: BukuFormProps) {
+  const { t } = useTranslation(['buku', 'common']);
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting, isDirty },
+  } = useForm<BukuFormValues>({
+    resolver: zodResolver(bukuFormSchema),
+    defaultValues: toFormValues(initial),
+  });
+
+  useEffect(() => {
+    reset(toFormValues(initial));
+  }, [initial, reset]);
+
+  const ddcAuto = useMemo(() => masterToOptions(ddcOptions), [ddcOptions]);
+  const kategoriAuto = useMemo(
+    () =>
+      kategoriOptions
+        .map((m) => ({ value: m.nama, label: m.nama }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [kategoriOptions],
+  );
+  const bahasaAuto = useMemo(
+    () =>
+      bahasaOptions
+        .map((m) => ({
+          value: m.kode ?? m.nama,
+          label: `${m.kode ?? '?'} — ${m.nama}`,
+          hint: m.nama,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [bahasaOptions],
+  );
+
+  const renderError = (key: string | undefined): string | null => {
+    if (!key) return null;
+    const i18nKey = `buku:validation.${key}`;
+    const value = t(i18nKey);
+    return value === i18nKey ? key : value;
+  };
+
+  return (
+    <form
+      data-testid="buku-form"
+      onSubmit={handleSubmit(async (values) => {
+        await onSubmit(values);
+      })}
+      className="space-y-6"
+    >
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t('buku:form.newTitle')}</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <Field
+            label={t('buku:fields.kodeBuku')}
+            error={renderError(errors.kodeBuku?.message as string | undefined)}
+            required
+          >
+            <Input
+              data-testid="field-kodeBuku"
+              placeholder={t('buku:fields.kodeBukuPlaceholder')}
+              autoFocus={!initial}
+              {...register('kodeBuku')}
+            />
+          </Field>
+          <Field
+            label={t('buku:fields.judul')}
+            error={renderError(errors.judul?.message as string | undefined)}
+            required
+          >
+            <Input
+              data-testid="field-judul"
+              placeholder={t('buku:fields.judulPlaceholder')}
+              {...register('judul')}
+            />
+          </Field>
+          <Field label={t('buku:fields.pengarang')}>
+            <Input data-testid="field-pengarang" {...register('pengarang')} />
+          </Field>
+          <Field label={t('buku:fields.penerbit')}>
+            <Input {...register('penerbit')} />
+          </Field>
+          <Field label={t('buku:fields.tahunTerbit')}>
+            <Input type="number" min={1900} max={2100} {...register('tahunTerbit')} />
+          </Field>
+          <Field label={t('buku:fields.isbn')}>
+            <Input {...register('isbn')} />
+          </Field>
+          <Field label={t('buku:fields.kodeDdc')}>
+            <Controller
+              control={control}
+              name="kodeDdc"
+              render={({ field }) => (
+                <Autocomplete
+                  data-testid="field-kodeDdc"
+                  options={ddcAuto}
+                  value={field.value || null}
+                  onChange={(v) => field.onChange(v ?? '')}
+                  placeholder={t('buku:fields.kodeDdcPlaceholder')}
+                  allowCustomValue
+                />
+              )}
+            />
+          </Field>
+          <Field label={t('buku:fields.kategori')}>
+            <Controller
+              control={control}
+              name="kategori"
+              render={({ field }) => (
+                <Autocomplete
+                  data-testid="field-kategori"
+                  options={kategoriAuto}
+                  value={field.value || null}
+                  onChange={(v) => field.onChange(v ?? '')}
+                  placeholder={t('buku:fields.kategoriPlaceholder')}
+                  allowCustomValue
+                />
+              )}
+            />
+          </Field>
+          <Field label={t('buku:fields.bahasa')}>
+            <Controller
+              control={control}
+              name="bahasa"
+              render={({ field }) => (
+                <Autocomplete
+                  data-testid="field-bahasa"
+                  options={bahasaAuto}
+                  value={field.value || null}
+                  onChange={(v) => field.onChange(v ?? '')}
+                  placeholder={t('buku:fields.bahasaPlaceholder')}
+                  allowCustomValue
+                />
+              )}
+            />
+          </Field>
+          <Field label={t('buku:fields.jumlahEksemplar')}>
+            <Input
+              type="number"
+              min={0}
+              data-testid="field-jumlahEksemplar"
+              {...register('jumlahEksemplar')}
+            />
+          </Field>
+          <Field label={t('buku:fields.sumber')}>
+            <Input {...register('sumber')} />
+          </Field>
+          <Field label={t('buku:fields.harga')}>
+            <Input type="number" min={0} {...register('harga')} />
+          </Field>
+          <Field label={t('buku:fields.rak')}>
+            <Input {...register('rak')} />
+          </Field>
+          <Field
+            label={t('buku:fields.deskripsi')}
+            className="md:col-span-2"
+          >
+            <Input {...register('deskripsi')} />
+          </Field>
+          <Field
+            label={t('buku:fields.coverPath')}
+            hint={t('buku:fields.coverPathHint')}
+            className="md:col-span-2"
+          >
+            <Input {...register('coverPath')} />
+          </Field>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="submit"
+          disabled={isSubmitting || (!isDirty && !!initial)}
+          data-testid="form-submit"
+        >
+          {isSubmitting ? t('common:states.loading') : submitLabel}
+        </Button>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+          {t('common:actions.cancel')}
+        </Button>
+        {onDelete && initial && (
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onDelete}
+            className="ml-auto"
+            data-testid="form-delete"
+          >
+            {t('buku:form.deleteButton')}
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+interface FieldProps {
+  label: React.ReactNode;
+  error?: string | null;
+  hint?: string;
+  required?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+function Field({ label, error, hint, required, children, className }: FieldProps) {
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <Label className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <span>{label}</span>
+        {required && <span className="text-destructive">*</span>}
+      </Label>
+      {children}
+      {hint && !error && <p className="text-xs text-muted-foreground">{hint}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/buku/BukuList.tsx
+++ b/apps/desktop/src/features/buku/BukuList.tsx
@@ -1,0 +1,445 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useSearch } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import {
+  BookOpenText,
+  ChevronLeft,
+  ChevronRight,
+  FileSpreadsheet,
+  Pencil,
+  Plus,
+  Search,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { DataTable, type DataTableColumn } from '@/components/shared/DataTable';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
+import { bukuApi, type Buku, type BukuDetail } from '@/lib/buku';
+import { masterDataApi, type MasterItem } from '@/lib/masterData';
+import { useToast } from '@/components/ui/toast-manager';
+import { ImportBukuDialog } from './ImportBukuDialog';
+
+const PAGE_SIZE = 20;
+
+interface BukuListSearch {
+  q?: string;
+  kategori?: string;
+  bahasa?: string;
+  page?: number;
+  selected?: number;
+}
+
+interface BukuListProps {
+  search: BukuListSearch;
+  onSearchChange: (next: Partial<BukuListSearch>) => void;
+}
+
+export function BukuList({ search, onSearchChange }: BukuListProps) {
+  const { t } = useTranslation(['buku', 'common']);
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  const initialQ = search.q ?? '';
+  const { query, debouncedQuery, setQuery } = useDebouncedSearch({
+    delay: 200,
+    initialValue: initialQ,
+  });
+
+  useEffect(() => {
+    if ((search.q ?? '') !== query) setQuery(search.q ?? '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search.q]);
+
+  const [items, setItems] = useState<Buku[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [sort, setSort] = useState<{ key: string; dir: 'asc' | 'desc' } | null>({
+    key: 'judul',
+    dir: 'asc',
+  });
+  const [kategoriOptions, setKategoriOptions] = useState<MasterItem[]>([]);
+  const [bahasaOptions, setBahasaOptions] = useState<MasterItem[]>([]);
+  const [importOpen, setImportOpen] = useState(false);
+  const [detail, setDetail] = useState<BukuDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const page = Math.max(1, search.page ?? 1);
+  const offset = (page - 1) * PAGE_SIZE;
+  const selectedId = search.selected ?? null;
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await bukuApi.list({
+        query: debouncedQuery,
+        kategori: search.kategori || undefined,
+        bahasa: search.bahasa || undefined,
+        limit: PAGE_SIZE,
+        offset,
+        sortBy: sort?.key ?? 'judul',
+        sortDir: sort?.dir,
+      });
+      setItems(res.items);
+      setTotal(res.total);
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('buku:feedback.loadError'),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [debouncedQuery, search.kategori, search.bahasa, offset, sort, showToast, t]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  useEffect(() => {
+    void Promise.all([
+      masterDataApi.list('kategori').then(setKategoriOptions).catch(() => undefined),
+      masterDataApi.list('bahasa').then(setBahasaOptions).catch(() => undefined),
+    ]);
+  }, []);
+
+  useEffect(() => {
+    if ((search.q ?? '') !== debouncedQuery) {
+      onSearchChange({ q: debouncedQuery || undefined, page: 1 });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedQuery]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null);
+      return;
+    }
+    setDetailLoading(true);
+    bukuApi
+      .get(selectedId)
+      .then((d) => setDetail(d))
+      .catch((err) => {
+        showToast({
+          variant: 'destructive',
+          title: t('buku:feedback.loadError'),
+          description: err instanceof Error ? err.message : String(err),
+        });
+        setDetail(null);
+      })
+      .finally(() => setDetailLoading(false));
+  }, [selectedId, showToast, t]);
+
+  const columns: DataTableColumn<Buku>[] = useMemo(
+    () => [
+      {
+        key: 'kodeBuku',
+        header: t('buku:columns.kode'),
+        sortable: true,
+        cell: (row) => <span className="font-mono text-xs">{row.kodeBuku}</span>,
+        className: 'w-28',
+      },
+      {
+        key: 'judul',
+        header: t('buku:columns.judul'),
+        sortable: true,
+        cell: (row) => (
+          <div className="flex flex-col">
+            <span className="font-medium">{row.judul}</span>
+            {row.pengarang && (
+              <span className="text-xs text-muted-foreground">{row.pengarang}</span>
+            )}
+          </div>
+        ),
+      },
+      {
+        key: 'kategori',
+        header: t('buku:columns.kategori'),
+        sortable: true,
+        cell: (row) => row.kategori ?? '—',
+      },
+      {
+        key: 'kodeDdc',
+        header: t('buku:columns.ddc'),
+        sortable: true,
+        cell: (row) => (row.kodeDdc ? <span className="font-mono text-xs">{row.kodeDdc}</span> : '—'),
+      },
+      {
+        key: 'jumlahTersedia',
+        header: t('buku:columns.tersedia'),
+        cell: (row) => (
+          <Badge
+            variant={row.jumlahTersedia > 0 ? 'success' : 'warning'}
+            data-testid={`buku-badge-${row.id}`}
+          >
+            {row.jumlahTersedia} / {row.jumlahEksemplar}
+          </Badge>
+        ),
+        className: 'w-32',
+      },
+    ],
+    [t],
+  );
+
+  const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const showingFrom = total === 0 ? 0 : offset + 1;
+  const showingTo = Math.min(offset + PAGE_SIZE, total);
+
+  return (
+    <div className="container mx-auto max-w-7xl p-6 md:p-8">
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{t('buku:title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('buku:subtitle')}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="outline" onClick={() => setImportOpen(true)} data-testid="buku-import">
+            <FileSpreadsheet className="mr-2 h-4 w-4" />
+            {t('buku:list.import')}
+          </Button>
+          <Button asChild data-testid="buku-add">
+            <Link to="/buku/new">
+              <Plus className="mr-2 h-4 w-4" />
+              {t('buku:list.addNew')}
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="mb-4 grid gap-3 md:grid-cols-[2fr,1fr,1fr]">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            data-testid="buku-search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('buku:list.searchPlaceholder')}
+            className="pl-9"
+          />
+        </div>
+        <Select
+          value={search.kategori ?? '__all__'}
+          onValueChange={(v) =>
+            onSearchChange({ kategori: v === '__all__' ? undefined : v, page: 1 })
+          }
+        >
+          <SelectTrigger data-testid="filter-kategori">
+            <SelectValue placeholder={t('buku:list.filterKategori')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">{t('buku:list.filterAll')}</SelectItem>
+            {kategoriOptions.map((opt) => (
+              <SelectItem key={opt.id ?? opt.nama} value={opt.nama}>
+                {opt.nama}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={search.bahasa ?? '__all__'}
+          onValueChange={(v) =>
+            onSearchChange({ bahasa: v === '__all__' ? undefined : v, page: 1 })
+          }
+        >
+          <SelectTrigger data-testid="filter-bahasa">
+            <SelectValue placeholder={t('buku:list.filterBahasa')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">{t('buku:list.filterAll')}</SelectItem>
+            {bahasaOptions.map((opt) => (
+              <SelectItem key={opt.kode ?? opt.nama} value={opt.kode ?? opt.nama}>
+                {opt.kode ? `${opt.kode} — ${opt.nama}` : opt.nama}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[3fr,2fr]">
+        <div>
+          <DataTable
+            data-testid="buku-table"
+            columns={columns}
+            rows={items}
+            rowKey={(row) => row.id}
+            isLoading={isLoading}
+            empty={
+              (search.q ?? '') || search.kategori || search.bahasa
+                ? t('buku:list.emptyFiltered')
+                : t('buku:list.empty')
+            }
+            sort={sort}
+            onSortChange={setSort}
+            onRowClick={(row) => onSearchChange({ selected: row.id })}
+            highlightedRowKey={selectedId ?? undefined}
+          />
+
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+            <span>{t('buku:list.showing', { from: showingFrom, to: showingTo, total })}</span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => onSearchChange({ page: Math.max(1, page - 1) })}
+                data-testid="page-prev"
+              >
+                <ChevronLeft className="mr-1 h-3 w-3" />
+                Prev
+              </Button>
+              <span>
+                {page} / {lastPage}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= lastPage}
+                onClick={() => onSearchChange({ page: page + 1 })}
+                data-testid="page-next"
+              >
+                Next
+                <ChevronRight className="ml-1 h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <BukuDetailPanel
+          detail={detail}
+          isLoading={detailLoading}
+          onEdit={(id) => void navigate({ to: '/buku/$id', params: { id: String(id) } })}
+        />
+      </div>
+
+      <ImportBukuDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        onImported={() => {
+          void reload();
+        }}
+      />
+    </div>
+  );
+}
+
+interface BukuDetailPanelProps {
+  detail: BukuDetail | null;
+  isLoading: boolean;
+  onEdit: (id: number) => void;
+}
+
+function BukuDetailPanel({ detail, isLoading, onEdit }: BukuDetailPanelProps) {
+  const { t } = useTranslation(['buku']);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-md border bg-card p-6 text-sm text-muted-foreground">
+        {t('buku:list.loadingDetail')}
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div
+        data-testid="buku-empty-detail"
+        className="flex min-h-[280px] flex-col items-center justify-center rounded-md border border-dashed bg-card p-8 text-center"
+      >
+        <BookOpenText className="mb-3 h-10 w-10 text-muted-foreground" aria-hidden />
+        <h3 className="text-base font-semibold">{t('buku:detail.emptyTitle')}</h3>
+        <p className="text-sm text-muted-foreground">{t('buku:detail.emptyHint')}</p>
+      </div>
+    );
+  }
+
+  const { buku, eksemplar } = detail;
+  return (
+    <div className="space-y-4 rounded-md border bg-card p-5" data-testid="buku-detail">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-mono text-muted-foreground">{buku.kodeBuku}</p>
+          <h2 className="text-lg font-semibold leading-tight">{buku.judul}</h2>
+          {buku.pengarang && (
+            <p className="text-sm text-muted-foreground">{buku.pengarang}</p>
+          )}
+        </div>
+        <Button size="sm" variant="outline" onClick={() => onEdit(buku.id)} data-testid="buku-detail-edit">
+          <Pencil className="mr-1 h-3 w-3" />
+          {t('buku:detail.edit')}
+        </Button>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <DT label={t('buku:detail.kategori')} value={buku.kategori} />
+        <DT label={t('buku:detail.bahasa')} value={buku.bahasa} />
+        <DT label={t('buku:detail.kodeDdc')} value={buku.kodeDdc} />
+        <DT label={t('buku:detail.tahunTerbit')} value={buku.tahunTerbit?.toString()} />
+        <DT label={t('buku:detail.penerbit')} value={buku.penerbit} />
+        <DT label={t('buku:detail.isbn')} value={buku.isbn} />
+        <DT label={t('buku:detail.rak')} value={buku.rak} />
+        <DT label={t('buku:detail.sumber')} value={buku.sumber} />
+      </dl>
+
+      {buku.deskripsi && (
+        <div className="rounded-md bg-muted/50 p-3 text-sm">{buku.deskripsi}</div>
+      )}
+
+      <div>
+        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {t('buku:detail.eksemplarTitle', { count: eksemplar.length })}
+        </p>
+        <div className="flex flex-wrap gap-2" data-testid="buku-eksemplar-list">
+          {eksemplar.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              {t('buku:detail.eksemplarEmpty')}
+            </p>
+          )}
+          {eksemplar.map((e) => (
+            <Badge
+              key={e.id}
+              variant={e.status === 'tersedia' ? 'success' : 'warning'}
+              className="font-mono"
+            >
+              {e.kodeEksemplar}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DT({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="text-foreground">{value ?? '—'}</dd>
+    </>
+  );
+}
+
+export function useBukuListSearchSync(): {
+  search: BukuListSearch;
+  patch: (next: Partial<BukuListSearch>) => void;
+} {
+  const navigate = useNavigate();
+  const search = useSearch({ from: '/_authed/buku/' }) as BukuListSearch;
+  const patch = useCallback(
+    (next: Partial<BukuListSearch>) => {
+      void navigate({
+        to: '/buku',
+        search: (prev) => ({ ...(prev as BukuListSearch), ...next }),
+      });
+    },
+    [navigate],
+  );
+  return { search, patch };
+}

--- a/apps/desktop/src/features/buku/ImportBukuDialog.tsx
+++ b/apps/desktop/src/features/buku/ImportBukuDialog.tsx
@@ -1,0 +1,245 @@
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { read, utils, type WorkBook } from 'xlsx';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { bukuApi, type BukuImportItem, type BukuImportResult } from '@/lib/buku';
+import { useToast } from '@/components/ui/toast-manager';
+
+interface ImportBukuDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImported: (result: BukuImportResult) => void;
+}
+
+const HEADER_MAP: Record<string, keyof BukuImportItem> = {
+  kode_buku: 'kodeBuku',
+  kodebuku: 'kodeBuku',
+  kode: 'kodeBuku',
+  judul: 'judul',
+  title: 'judul',
+  pengarang: 'pengarang',
+  author: 'pengarang',
+  penerbit: 'penerbit',
+  publisher: 'penerbit',
+  tahun: 'tahunTerbit',
+  tahun_terbit: 'tahunTerbit',
+  year: 'tahunTerbit',
+  ddc: 'kodeDdc',
+  kode_ddc: 'kodeDdc',
+  kategori: 'kategori',
+  category: 'kategori',
+  isbn: 'isbn',
+  jumlah: 'jumlahEksemplar',
+  jumlah_eksemplar: 'jumlahEksemplar',
+  copies: 'jumlahEksemplar',
+  bahasa: 'bahasa',
+  language: 'bahasa',
+};
+
+function normalizeHeader(raw: string): keyof BukuImportItem | null {
+  const cleaned = raw.toLowerCase().trim().replace(/[\s./-]+/g, '_');
+  return HEADER_MAP[cleaned] ?? null;
+}
+
+function rowsFromWorkbook(wb: WorkBook): BukuImportItem[] {
+  const sheetName = wb.SheetNames[0];
+  if (!sheetName) return [];
+  const sheet = wb.Sheets[sheetName];
+  if (!sheet) return [];
+  const raw = utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: '', raw: false });
+  return raw
+    .map((rawRow) => {
+      const item: BukuImportItem = { kodeBuku: '', judul: '' };
+      for (const [key, value] of Object.entries(rawRow)) {
+        const mapped = normalizeHeader(key);
+        if (!mapped) continue;
+        const str =
+          typeof value === 'string' ? value.trim() : value == null ? '' : String(value).trim();
+        if (mapped === 'kodeBuku' || mapped === 'judul') {
+          item[mapped] = str;
+        } else if (mapped === 'tahunTerbit' || mapped === 'jumlahEksemplar') {
+          const n = Number(str);
+          item[mapped] = Number.isFinite(n) ? Math.trunc(n) : null;
+        } else {
+          item[mapped] = str.length > 0 ? str : null;
+        }
+      }
+      return item;
+    })
+    .filter((item) => item.kodeBuku || item.judul);
+}
+
+export function ImportBukuDialog({ open, onOpenChange, onImported }: ImportBukuDialogProps) {
+  const { t } = useTranslation(['buku', 'common']);
+  const { showToast } = useToast();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [filename, setFilename] = useState<string | null>(null);
+  const [rows, setRows] = useState<BukuImportItem[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const reset = (): void => {
+    setFilename(null);
+    setRows([]);
+    setParseError(null);
+    if (fileRef.current) fileRef.current.value = '';
+  };
+
+  const handleFile = async (file: File): Promise<void> => {
+    try {
+      setParseError(null);
+      const buf = await file.arrayBuffer();
+      const wb = read(buf, { type: 'array' });
+      const parsed = rowsFromWorkbook(wb);
+      setFilename(file.name);
+      setRows(parsed);
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : String(err));
+      setRows([]);
+    }
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    if (rows.length === 0) return;
+    setBusy(true);
+    try {
+      const result = await bukuApi.importBatch(rows);
+      onImported(result);
+      showToast({
+        title: t('buku:feedback.importSuccess', { inserted: result.inserted }),
+        description: t('buku:import.summary', {
+          inserted: result.inserted,
+          skipped: result.skipped,
+        }),
+      });
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('buku:feedback.importSuccess', { inserted: 0 }),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t('buku:import.title')}</DialogTitle>
+          <DialogDescription>{t('buku:import.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".xlsx,.xls,.csv"
+              data-testid="buku-import-file-input"
+              className="hidden"
+              onChange={async (e) => {
+                const file = e.target.files?.[0];
+                if (file) await handleFile(file);
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => fileRef.current?.click()}
+              data-testid="buku-import-pick-file"
+            >
+              {t('buku:import.pickFile')}
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {filename
+                ? t('buku:import.filename', { name: filename })
+                : t('buku:import.noFile')}
+            </span>
+          </div>
+
+          {parseError && (
+            <p className="text-sm text-destructive">
+              {t('buku:import.parseError', { message: parseError })}
+            </p>
+          )}
+
+          {rows.length > 0 && (
+            <div className="rounded-md border">
+              <div className="border-b px-3 py-2">
+                <p className="text-sm font-medium">
+                  {t('buku:import.previewTitle', { count: rows.length })}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t('buku:import.previewSubtitle')}
+                </p>
+              </div>
+              <div className="max-h-72 overflow-y-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>#</TableHead>
+                      <TableHead>{t('buku:columns.kode')}</TableHead>
+                      <TableHead>{t('buku:columns.judul')}</TableHead>
+                      <TableHead>{t('buku:columns.kategori')}</TableHead>
+                      <TableHead>{t('buku:columns.ddc')}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.slice(0, 50).map((row, idx) => (
+                      <TableRow key={`${row.kodeBuku}-${idx}`}>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {idx + 1}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">{row.kodeBuku}</TableCell>
+                        <TableCell>{row.judul}</TableCell>
+                        <TableCell>{row.kategori ?? '—'}</TableCell>
+                        <TableCell>{row.kodeDdc ?? '—'}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={busy || rows.length === 0} data-testid="buku-import-submit">
+            {busy
+              ? t('common:states.loading')
+              : t('buku:import.submit', { count: rows.length })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/features/buku/schema.ts
+++ b/apps/desktop/src/features/buku/schema.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+const optionalString = z.string().trim();
+
+export const bukuFormSchema = z.object({
+  kodeBuku: z.string().trim().min(1, 'kodeBukuRequired'),
+  judul: z.string().trim().min(1, 'judulRequired'),
+  pengarang: optionalString.optional(),
+  penerbit: optionalString.optional(),
+  tahunTerbit: optionalString.optional(),
+  kodeDdc: optionalString.optional(),
+  kategori: optionalString.optional(),
+  isbn: optionalString.optional(),
+  jumlahEksemplar: optionalString.optional(),
+  sumber: optionalString.optional(),
+  harga: optionalString.optional(),
+  bahasa: optionalString.optional(),
+  deskripsi: optionalString.optional(),
+  rak: optionalString.optional(),
+  coverPath: optionalString.optional(),
+});
+
+export type BukuFormValues = z.infer<typeof bukuFormSchema>;
+
+const toIntOrNull = (v?: string): number | null => {
+  if (!v || !v.trim()) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : null;
+};
+
+export function toBukuInput(values: BukuFormValues): {
+  kodeBuku: string;
+  judul: string;
+  pengarang: string | null;
+  penerbit: string | null;
+  tahunTerbit: number | null;
+  kodeDdc: string | null;
+  kategori: string | null;
+  isbn: string | null;
+  jumlahEksemplar: number | null;
+  sumber: string | null;
+  harga: number | null;
+  bahasa: string | null;
+  deskripsi: string | null;
+  rak: string | null;
+  coverPath: string | null;
+} {
+  const norm = (v?: string): string | null => (v && v.trim() ? v.trim() : null);
+  return {
+    kodeBuku: values.kodeBuku.trim(),
+    judul: values.judul.trim(),
+    pengarang: norm(values.pengarang),
+    penerbit: norm(values.penerbit),
+    tahunTerbit: toIntOrNull(values.tahunTerbit),
+    kodeDdc: norm(values.kodeDdc),
+    kategori: norm(values.kategori),
+    isbn: norm(values.isbn),
+    jumlahEksemplar: toIntOrNull(values.jumlahEksemplar),
+    sumber: norm(values.sumber),
+    harga: toIntOrNull(values.harga),
+    bahasa: norm(values.bahasa),
+    deskripsi: norm(values.deskripsi),
+    rak: norm(values.rak),
+    coverPath: norm(values.coverPath),
+  };
+}

--- a/apps/desktop/src/features/master-data/MasterDataPage.tsx
+++ b/apps/desktop/src/features/master-data/MasterDataPage.tsx
@@ -1,0 +1,368 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pencil, Plus, Search, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { DataTable, type DataTableColumn } from '@/components/shared/DataTable';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
+import { useToast } from '@/components/ui/toast-manager';
+import {
+  masterDataApi,
+  type MasterInput,
+  type MasterItem,
+  type MasterTable,
+} from '@/lib/masterData';
+import { cn } from '@/lib/utils';
+
+const TABLES: { id: MasterTable; key: string; needsKode?: boolean }[] = [
+  { id: 'ddc', key: 'ddc', needsKode: true },
+  { id: 'kategori', key: 'kategori' },
+  { id: 'bahasa', key: 'bahasa', needsKode: true },
+  { id: 'jurusan', key: 'jurusan' },
+  { id: 'kelas', key: 'kelas' },
+  { id: 'agama', key: 'agama' },
+];
+
+export function MasterDataPage() {
+  const { t } = useTranslation(['masterData', 'common']);
+  const { showToast } = useToast();
+  const [active, setActive] = useState<MasterTable>('ddc');
+  const { query, debouncedQuery, setQuery } = useDebouncedSearch({
+    delay: 200,
+    initialValue: '',
+  });
+  const [items, setItems] = useState<MasterItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editing, setEditing] = useState<MasterItem | null | 'new'>(null);
+  const [deleting, setDeleting] = useState<MasterItem | null>(null);
+
+  const config = TABLES.find((t) => t.id === active)!;
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const rows = await masterDataApi.list(active, debouncedQuery || undefined);
+      setItems(rows);
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('masterData:feedback.loadError'),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [active, debouncedQuery, showToast, t]);
+
+  useEffect(() => {
+    void reload();
+    // Reset search when switching tabs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const columns: DataTableColumn<MasterItem>[] = useMemo(() => {
+    const cols: DataTableColumn<MasterItem>[] = [];
+    if (config.needsKode) {
+      cols.push({
+        key: 'kode',
+        header: t('masterData:columns.kode'),
+        cell: (row) => <span className="font-mono text-xs">{row.kode ?? '—'}</span>,
+        className: 'w-32',
+      });
+    }
+    cols.push({
+      key: 'nama',
+      header: t('masterData:columns.nama'),
+      cell: (row) => <span className="font-medium">{row.nama}</span>,
+    });
+    if (active === 'kategori') {
+      cols.push({
+        key: 'deskripsi',
+        header: t('masterData:columns.deskripsi'),
+        cell: (row) => row.deskripsi ?? '—',
+      });
+    }
+    cols.push({
+      key: '__actions',
+      header: '',
+      cell: (row) => (
+        <div className="flex justify-end gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setEditing(row)}
+            data-testid={`master-edit-${row.kode ?? row.id}`}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setDeleting(row)}
+            data-testid={`master-delete-${row.kode ?? row.id}`}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ),
+      className: 'w-24',
+    });
+    return cols;
+  }, [active, config, t]);
+
+  return (
+    <div className="container mx-auto max-w-5xl p-6 md:p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold tracking-tight">{t('masterData:title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('masterData:subtitle')}</p>
+      </div>
+
+      <div
+        className="mb-4 flex flex-wrap gap-2 border-b pb-2"
+        role="tablist"
+        data-testid="master-tabs"
+      >
+        {TABLES.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={tab.id === active}
+            data-testid={`master-tab-${tab.id}`}
+            onClick={() => {
+              setActive(tab.id);
+              setQuery('');
+            }}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-sm transition-colors',
+              tab.id === active
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            )}
+          >
+            {t(`masterData:tabs.${tab.key}`)}
+          </button>
+        ))}
+      </div>
+
+      <div className="mb-4 grid gap-3 md:grid-cols-[2fr,auto]">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            data-testid="master-search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('masterData:list.searchPlaceholder')}
+            className="pl-9"
+          />
+        </div>
+        <Button onClick={() => setEditing('new')} data-testid="master-add">
+          <Plus className="mr-2 h-4 w-4" />
+          {t('masterData:list.addNew')}
+        </Button>
+      </div>
+
+      <DataTable
+        data-testid="master-table"
+        columns={columns}
+        rows={items}
+        rowKey={(row) => row.kode ?? row.id ?? row.nama}
+        isLoading={isLoading}
+        empty={t('masterData:list.empty')}
+      />
+
+      <MasterEditDialog
+        table={active}
+        needsKode={config.needsKode ?? false}
+        item={editing === 'new' ? null : editing}
+        open={editing !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditing(null);
+        }}
+        onSaved={() => {
+          setEditing(null);
+          void reload();
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleting !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleting(null);
+        }}
+        title={t('masterData:delete.title', { name: deleting?.nama ?? '' })}
+        description={t('masterData:delete.description')}
+        confirmText={t('common:actions.delete')}
+        destructive
+        onConfirm={async () => {
+          if (!deleting) return;
+          try {
+            const key = deleting.kode ?? String(deleting.id ?? '');
+            await masterDataApi.remove(active, key);
+            showToast({ title: t('masterData:feedback.deleteSuccess') });
+            setDeleting(null);
+            void reload();
+          } catch (err) {
+            showToast({
+              variant: 'destructive',
+              title: t('masterData:feedback.deleteError'),
+              description: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+interface MasterEditDialogProps {
+  table: MasterTable;
+  needsKode: boolean;
+  item: MasterItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+}
+
+function MasterEditDialog({
+  table,
+  needsKode,
+  item,
+  open,
+  onOpenChange,
+  onSaved,
+}: MasterEditDialogProps) {
+  const { t } = useTranslation(['masterData', 'common']);
+  const { showToast } = useToast();
+  const [kode, setKode] = useState('');
+  const [nama, setNama] = useState('');
+  const [deskripsi, setDeskripsi] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setKode(item?.kode ?? '');
+      setNama(item?.nama ?? '');
+      setDeskripsi(item?.deskripsi ?? '');
+    }
+  }, [open, item]);
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!nama.trim()) {
+      showToast({
+        variant: 'destructive',
+        title: t('masterData:feedback.namaRequired'),
+      });
+      return;
+    }
+    if (needsKode && !kode.trim()) {
+      showToast({
+        variant: 'destructive',
+        title: t('masterData:feedback.kodeRequired'),
+      });
+      return;
+    }
+    setBusy(true);
+    try {
+      const input: MasterInput = {
+        kode: needsKode ? kode.trim() : null,
+        nama: nama.trim(),
+        deskripsi: deskripsi.trim() || null,
+        urutan: item?.urutan ?? null,
+      };
+      if (item) {
+        const key = item.kode ?? String(item.id ?? '');
+        await masterDataApi.update(table, key, input);
+        showToast({ title: t('masterData:feedback.updateSuccess') });
+      } else {
+        await masterDataApi.create(table, input);
+        showToast({ title: t('masterData:feedback.createSuccess') });
+      }
+      onSaved();
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: item ? t('masterData:feedback.updateError') : t('masterData:feedback.createError'),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {item
+              ? t('masterData:dialog.editTitle')
+              : t('masterData:dialog.newTitle')}
+          </DialogTitle>
+          <DialogDescription>
+            {t(`masterData:tabs.${table}`)}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          {needsKode && (
+            <div className="space-y-1.5">
+              <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                {t('masterData:columns.kode')}
+              </Label>
+              <Input
+                value={kode}
+                onChange={(e) => setKode(e.target.value)}
+                disabled={!!item}
+                data-testid="master-form-kode"
+              />
+            </div>
+          )}
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+              {t('masterData:columns.nama')}
+            </Label>
+            <Input
+              value={nama}
+              onChange={(e) => setNama(e.target.value)}
+              data-testid="master-form-nama"
+              autoFocus
+            />
+          </div>
+          {table === 'kategori' && (
+            <div className="space-y-1.5">
+              <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                {t('masterData:columns.deskripsi')}
+              </Label>
+              <Input
+                value={deskripsi}
+                onChange={(e) => setDeskripsi(e.target.value)}
+                data-testid="master-form-deskripsi"
+              />
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={busy} data-testid="master-form-submit">
+            {busy ? t('common:states.loading') : t('common:actions.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/i18n/en/buku.json
+++ b/apps/desktop/src/i18n/en/buku.json
@@ -1,4 +1,100 @@
 {
   "title": "Books",
-  "placeholder": "Books CRUD will be built in Devin Session 5."
+  "subtitle": "Manage the library's book collection and per-copy stock.",
+  "list": {
+    "addNew": "Add Book",
+    "import": "Import Excel",
+    "searchPlaceholder": "Search title, code, author, ISBN…",
+    "filterAll": "All",
+    "filterKategori": "Category",
+    "filterBahasa": "Language",
+    "empty": "No books yet. Add the first one or import from Excel.",
+    "emptyFiltered": "No books match the current filters.",
+    "showing": "Showing {{from}}–{{to}} of {{total}}",
+    "loadingDetail": "Loading detail…"
+  },
+  "columns": {
+    "kode": "Code",
+    "judul": "Title",
+    "kategori": "Category",
+    "ddc": "DDC",
+    "tersedia": "Available"
+  },
+  "fields": {
+    "kodeBuku": "Book Code",
+    "kodeBukuPlaceholder": "e.g. B0001",
+    "judul": "Title",
+    "judulPlaceholder": "Full book title",
+    "pengarang": "Author",
+    "penerbit": "Publisher",
+    "tahunTerbit": "Year",
+    "kodeDdc": "DDC Code",
+    "kodeDdcPlaceholder": "Pick a DDC classification",
+    "kategori": "Category",
+    "kategoriPlaceholder": "Fiction / Non-fiction / …",
+    "bahasa": "Language",
+    "bahasaPlaceholder": "Pick a language",
+    "isbn": "ISBN",
+    "jumlahEksemplar": "Copies",
+    "sumber": "Source",
+    "harga": "Price (Rp)",
+    "rak": "Shelf",
+    "deskripsi": "Description",
+    "coverPath": "Cover Path",
+    "coverPathHint": "Cover file path relative to %AppData%/PerpustakaanOffline/covers/."
+  },
+  "form": {
+    "newTitle": "Add Book",
+    "newSubtitle": "Fill in the book details.",
+    "editTitle": "Book Detail",
+    "editSubtitle": "Update or delete this book.",
+    "submitCreate": "Save",
+    "submitUpdate": "Update",
+    "deleteButton": "Delete Book"
+  },
+  "validation": {
+    "kodeBukuRequired": "Book code is required",
+    "judulRequired": "Title is required"
+  },
+  "delete": {
+    "title": "Delete book \"{{name}}\"?",
+    "description": "This will also remove all copies of this book and cannot be undone."
+  },
+  "import": {
+    "title": "Import Books from Excel",
+    "description": "Recognised headers: kode_buku, judul, pengarang, penerbit, tahun, ddc, kategori, isbn, jumlah, bahasa.",
+    "pickFile": "Choose File",
+    "noFile": "No file selected.",
+    "filename": "File: {{name}}",
+    "previewTitle": "Preview ({{count}} rows)",
+    "previewSubtitle": "First 50 rows shown in the preview.",
+    "parseError": "Failed to parse file: {{message}}",
+    "submit": "Import {{count}} books",
+    "summary": "{{inserted}} saved, {{skipped}} skipped."
+  },
+  "feedback": {
+    "loadError": "Failed to load books.",
+    "createSuccess": "Book created successfully.",
+    "createError": "Failed to create book: {{message}}",
+    "updateSuccess": "Book updated successfully.",
+    "updateError": "Failed to update book: {{message}}",
+    "deleteSuccess": "Book deleted.",
+    "deleteError": "Failed to delete book.",
+    "importSuccess": "{{inserted}} books imported."
+  },
+  "detail": {
+    "emptyTitle": "Pick a book to see details",
+    "emptyHint": "Click any row in the left table to view copies and full info.",
+    "edit": "Edit",
+    "kategori": "Category",
+    "bahasa": "Language",
+    "kodeDdc": "DDC",
+    "tahunTerbit": "Year",
+    "penerbit": "Publisher",
+    "isbn": "ISBN",
+    "rak": "Shelf",
+    "sumber": "Source",
+    "eksemplarTitle": "Copies ({{count}})",
+    "eksemplarEmpty": "No physical copies yet."
+  }
 }

--- a/apps/desktop/src/i18n/en/master-data.json
+++ b/apps/desktop/src/i18n/en/master-data.json
@@ -1,0 +1,41 @@
+{
+  "title": "Master Data",
+  "subtitle": "Maintain reference data: DDC, category, language, major, class, and religion.",
+  "tabs": {
+    "ddc": "DDC",
+    "kategori": "Category",
+    "bahasa": "Language",
+    "jurusan": "Major",
+    "kelas": "Class",
+    "agama": "Religion"
+  },
+  "list": {
+    "searchPlaceholder": "Search name or code…",
+    "addNew": "Add",
+    "empty": "No data yet."
+  },
+  "columns": {
+    "kode": "Code",
+    "nama": "Name",
+    "deskripsi": "Description"
+  },
+  "dialog": {
+    "newTitle": "Add Entry",
+    "editTitle": "Edit Entry"
+  },
+  "delete": {
+    "title": "Delete \"{{name}}\"?",
+    "description": "This action cannot be undone."
+  },
+  "feedback": {
+    "loadError": "Failed to load master data.",
+    "namaRequired": "Name is required.",
+    "kodeRequired": "Code is required.",
+    "createSuccess": "Entry created.",
+    "createError": "Failed to create entry.",
+    "updateSuccess": "Entry updated.",
+    "updateError": "Failed to update entry.",
+    "deleteSuccess": "Entry deleted.",
+    "deleteError": "Failed to delete entry."
+  }
+}

--- a/apps/desktop/src/i18n/id/buku.json
+++ b/apps/desktop/src/i18n/id/buku.json
@@ -1,4 +1,100 @@
 {
   "title": "Buku",
-  "placeholder": "CRUD buku akan dibuat di Devin Session 5."
+  "subtitle": "Kelola koleksi buku perpustakaan beserta eksemplarnya.",
+  "list": {
+    "addNew": "Tambah Buku",
+    "import": "Import Excel",
+    "searchPlaceholder": "Cari judul, kode, pengarang, ISBN…",
+    "filterAll": "Semua",
+    "filterKategori": "Kategori",
+    "filterBahasa": "Bahasa",
+    "empty": "Belum ada buku. Tambahkan buku pertama atau import dari Excel.",
+    "emptyFiltered": "Tidak ada buku yang cocok dengan filter.",
+    "showing": "Menampilkan {{from}}–{{to}} dari {{total}}",
+    "loadingDetail": "Memuat detail…"
+  },
+  "columns": {
+    "kode": "Kode",
+    "judul": "Judul",
+    "kategori": "Kategori",
+    "ddc": "DDC",
+    "tersedia": "Tersedia"
+  },
+  "fields": {
+    "kodeBuku": "Kode Buku",
+    "kodeBukuPlaceholder": "Mis. B0001",
+    "judul": "Judul",
+    "judulPlaceholder": "Judul lengkap buku",
+    "pengarang": "Pengarang",
+    "penerbit": "Penerbit",
+    "tahunTerbit": "Tahun Terbit",
+    "kodeDdc": "Kode DDC",
+    "kodeDdcPlaceholder": "Pilih kelasifikasi DDC",
+    "kategori": "Kategori",
+    "kategoriPlaceholder": "Fiksi / Non-fiksi / …",
+    "bahasa": "Bahasa",
+    "bahasaPlaceholder": "Pilih bahasa",
+    "isbn": "ISBN",
+    "jumlahEksemplar": "Jumlah Eksemplar",
+    "sumber": "Sumber",
+    "harga": "Harga (Rp)",
+    "rak": "Rak",
+    "deskripsi": "Deskripsi",
+    "coverPath": "Cover Path",
+    "coverPathHint": "Path file cover relatif ke %AppData%/PerpustakaanOffline/covers/."
+  },
+  "form": {
+    "newTitle": "Tambah Buku",
+    "newSubtitle": "Lengkapi data buku.",
+    "editTitle": "Detail Buku",
+    "editSubtitle": "Update atau hapus data buku.",
+    "submitCreate": "Simpan",
+    "submitUpdate": "Update",
+    "deleteButton": "Hapus Buku"
+  },
+  "validation": {
+    "kodeBukuRequired": "Kode buku wajib diisi",
+    "judulRequired": "Judul wajib diisi"
+  },
+  "delete": {
+    "title": "Hapus buku \"{{name}}\"?",
+    "description": "Tindakan ini juga menghapus seluruh eksemplar buku dan tidak dapat dibatalkan."
+  },
+  "import": {
+    "title": "Import Buku dari Excel",
+    "description": "Header yang dikenali: kode_buku, judul, pengarang, penerbit, tahun, ddc, kategori, isbn, jumlah, bahasa.",
+    "pickFile": "Pilih File",
+    "noFile": "Belum ada file dipilih.",
+    "filename": "File: {{name}}",
+    "previewTitle": "Preview ({{count}} baris)",
+    "previewSubtitle": "Maksimal 50 baris pertama ditampilkan di preview.",
+    "parseError": "Gagal membaca file: {{message}}",
+    "submit": "Import {{count}} buku",
+    "summary": "{{inserted}} disimpan, {{skipped}} dilewati."
+  },
+  "feedback": {
+    "loadError": "Gagal memuat data buku.",
+    "createSuccess": "Buku berhasil ditambahkan.",
+    "createError": "Gagal menambahkan buku: {{message}}",
+    "updateSuccess": "Buku berhasil diperbarui.",
+    "updateError": "Gagal memperbarui buku: {{message}}",
+    "deleteSuccess": "Buku berhasil dihapus.",
+    "deleteError": "Gagal menghapus buku.",
+    "importSuccess": "{{inserted}} buku diimport."
+  },
+  "detail": {
+    "emptyTitle": "Pilih buku untuk melihat detail",
+    "emptyHint": "Klik salah satu baris di tabel kiri untuk melihat eksemplar dan info lengkap.",
+    "edit": "Edit",
+    "kategori": "Kategori",
+    "bahasa": "Bahasa",
+    "kodeDdc": "DDC",
+    "tahunTerbit": "Tahun",
+    "penerbit": "Penerbit",
+    "isbn": "ISBN",
+    "rak": "Rak",
+    "sumber": "Sumber",
+    "eksemplarTitle": "Eksemplar ({{count}})",
+    "eksemplarEmpty": "Belum ada eksemplar fisik."
+  }
 }

--- a/apps/desktop/src/i18n/id/master-data.json
+++ b/apps/desktop/src/i18n/id/master-data.json
@@ -1,0 +1,41 @@
+{
+  "title": "Master Data",
+  "subtitle": "Kelola data referensi: DDC, kategori, bahasa, jurusan, kelas, dan agama.",
+  "tabs": {
+    "ddc": "DDC",
+    "kategori": "Kategori",
+    "bahasa": "Bahasa",
+    "jurusan": "Jurusan",
+    "kelas": "Kelas",
+    "agama": "Agama"
+  },
+  "list": {
+    "searchPlaceholder": "Cari nama atau kode…",
+    "addNew": "Tambah",
+    "empty": "Belum ada data."
+  },
+  "columns": {
+    "kode": "Kode",
+    "nama": "Nama",
+    "deskripsi": "Deskripsi"
+  },
+  "dialog": {
+    "newTitle": "Tambah Data",
+    "editTitle": "Edit Data"
+  },
+  "delete": {
+    "title": "Hapus \"{{name}}\"?",
+    "description": "Tindakan ini tidak dapat dibatalkan."
+  },
+  "feedback": {
+    "loadError": "Gagal memuat master data.",
+    "namaRequired": "Nama wajib diisi.",
+    "kodeRequired": "Kode wajib diisi.",
+    "createSuccess": "Data berhasil ditambahkan.",
+    "createError": "Gagal menambahkan data.",
+    "updateSuccess": "Data berhasil diperbarui.",
+    "updateError": "Gagal memperbarui data.",
+    "deleteSuccess": "Data berhasil dihapus.",
+    "deleteError": "Gagal menghapus data."
+  }
+}

--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -11,6 +11,7 @@ import idPengembalian from './id/pengembalian.json';
 import idKunjungan from './id/kunjungan.json';
 import idLaporan from './id/laporan.json';
 import idSettings from './id/settings.json';
+import idMasterData from './id/master-data.json';
 import idErrors from './id/errors.json';
 
 import enCommon from './en/common.json';
@@ -23,6 +24,7 @@ import enPengembalian from './en/pengembalian.json';
 import enKunjungan from './en/kunjungan.json';
 import enLaporan from './en/laporan.json';
 import enSettings from './en/settings.json';
+import enMasterData from './en/master-data.json';
 import enErrors from './en/errors.json';
 
 export const NAMESPACES = [
@@ -36,6 +38,7 @@ export const NAMESPACES = [
   'kunjungan',
   'laporan',
   'settings',
+  'masterData',
   'errors',
 ] as const;
 
@@ -54,6 +57,7 @@ const resources = {
     kunjungan: idKunjungan,
     laporan: idLaporan,
     settings: idSettings,
+    masterData: idMasterData,
     errors: idErrors,
   },
   en: {
@@ -67,6 +71,7 @@ const resources = {
     kunjungan: enKunjungan,
     laporan: enLaporan,
     settings: enSettings,
+    masterData: enMasterData,
     errors: enErrors,
   },
 } as const;

--- a/apps/desktop/src/lib/buku.ts
+++ b/apps/desktop/src/lib/buku.ts
@@ -1,0 +1,437 @@
+import { isTauri } from '@/lib/auth';
+
+export interface Buku {
+  id: number;
+  kodeBuku: string;
+  judul: string;
+  pengarang?: string | null;
+  penerbit?: string | null;
+  tahunTerbit?: number | null;
+  kodeDdc?: string | null;
+  kategori?: string | null;
+  isbn?: string | null;
+  jumlahEksemplar: number;
+  jumlahTersedia: number;
+  sumber?: string | null;
+  harga: number;
+  coverPath?: string | null;
+  bahasa?: string | null;
+  deskripsi?: string | null;
+  rak?: string | null;
+  tanggalInput: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Eksemplar {
+  id: number;
+  bukuId: number;
+  kodeEksemplar: string;
+  status: 'tersedia' | 'dipinjam' | 'hilang' | 'rusak';
+  catatan?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BukuInput {
+  kodeBuku: string;
+  judul: string;
+  pengarang?: string | null;
+  penerbit?: string | null;
+  tahunTerbit?: number | null;
+  kodeDdc?: string | null;
+  kategori?: string | null;
+  isbn?: string | null;
+  jumlahEksemplar?: number | null;
+  sumber?: string | null;
+  harga?: number | null;
+  coverPath?: string | null;
+  bahasa?: string | null;
+  deskripsi?: string | null;
+  rak?: string | null;
+  tanggalInput?: string | null;
+}
+
+export interface BukuListArgs {
+  query?: string;
+  kategori?: string;
+  bahasa?: string;
+  kodeDdc?: string;
+  limit?: number;
+  offset?: number;
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
+}
+
+export interface BukuListResult {
+  items: Buku[];
+  total: number;
+}
+
+export interface BukuDetail {
+  buku: Buku;
+  eksemplar: Eksemplar[];
+}
+
+export interface BukuImportItem {
+  kodeBuku: string;
+  judul: string;
+  pengarang?: string | null;
+  penerbit?: string | null;
+  tahunTerbit?: number | null;
+  kodeDdc?: string | null;
+  kategori?: string | null;
+  isbn?: string | null;
+  jumlahEksemplar?: number | null;
+  bahasa?: string | null;
+}
+
+export interface BukuImportError {
+  row: number;
+  message: string;
+}
+
+export interface BukuImportResult {
+  inserted: number;
+  skipped: number;
+  errors: BukuImportError[];
+}
+
+interface BukuRpc {
+  list(args: BukuListArgs): Promise<BukuListResult>;
+  get(id: number): Promise<BukuDetail>;
+  create(input: BukuInput): Promise<Buku>;
+  update(id: number, input: BukuInput): Promise<Buku>;
+  remove(id: number): Promise<void>;
+  importBatch(items: BukuImportItem[]): Promise<BukuImportResult>;
+  eksemplarCreate(bukuId: number, kode: string): Promise<Eksemplar>;
+  eksemplarRemove(id: number): Promise<void>;
+  __resetMock(): void;
+}
+
+const STORAGE_KEY = 'po:buku-mock';
+const SEED: Buku[] = [
+  {
+    id: 1,
+    kodeBuku: 'B0001',
+    judul: 'Bumi Manusia',
+    pengarang: 'Pramoedya Ananta Toer',
+    penerbit: 'Hasta Mitra',
+    tahunTerbit: 1980,
+    kodeDdc: '813',
+    kategori: 'Fiksi',
+    isbn: '978-979-97312-3-2',
+    jumlahEksemplar: 3,
+    jumlahTersedia: 3,
+    sumber: 'BOS',
+    harga: 75000,
+    coverPath: null,
+    bahasa: 'id',
+    deskripsi: 'Tetralogi Pulau Buru, jilid pertama.',
+    rak: 'A1',
+    tanggalInput: '2025-01-15',
+    createdAt: '2025-01-15T08:00:00Z',
+    updatedAt: '2025-01-15T08:00:00Z',
+  },
+  {
+    id: 2,
+    kodeBuku: 'B0002',
+    judul: 'Laskar Pelangi',
+    pengarang: 'Andrea Hirata',
+    penerbit: 'Bentang Pustaka',
+    tahunTerbit: 2005,
+    kodeDdc: '813',
+    kategori: 'Fiksi',
+    isbn: '978-979-3062-79-2',
+    jumlahEksemplar: 2,
+    jumlahTersedia: 2,
+    sumber: 'Hibah',
+    harga: 65000,
+    coverPath: null,
+    bahasa: 'id',
+    deskripsi: null,
+    rak: 'A1',
+    tanggalInput: '2025-02-10',
+    createdAt: '2025-02-10T09:00:00Z',
+    updatedAt: '2025-02-10T09:00:00Z',
+  },
+  {
+    id: 3,
+    kodeBuku: 'B0003',
+    judul: 'Sapiens: A Brief History of Humankind',
+    pengarang: 'Yuval Noah Harari',
+    penerbit: 'Harvill Secker',
+    tahunTerbit: 2011,
+    kodeDdc: '909',
+    kategori: 'Non-fiksi',
+    isbn: '978-0-09-959008-8',
+    jumlahEksemplar: 1,
+    jumlahTersedia: 1,
+    sumber: null,
+    harga: 150000,
+    coverPath: null,
+    bahasa: 'en',
+    deskripsi: null,
+    rak: 'B2',
+    tanggalInput: '2025-03-05',
+    createdAt: '2025-03-05T10:00:00Z',
+    updatedAt: '2025-03-05T10:00:00Z',
+  },
+];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function readMock(): Buku[] {
+  if (typeof window === 'undefined') return [...SEED];
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(SEED));
+    return [...SEED];
+  }
+  try {
+    const parsed = JSON.parse(raw) as Buku[];
+    return Array.isArray(parsed) ? parsed : [...SEED];
+  } catch {
+    return [...SEED];
+  }
+}
+
+function writeMock(items: Buku[]): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+function nextId(items: Buku[]): number {
+  return items.reduce((max, it) => Math.max(max, it.id), 0) + 1;
+}
+
+const tauriRpc: BukuRpc = {
+  async list(args) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<BukuListResult>('buku_list', { args });
+  },
+  async get(id) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<BukuDetail>('buku_get', { id });
+  },
+  async create(input) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<Buku>('buku_create', { input });
+  },
+  async update(id, input) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<Buku>('buku_update', { id, input });
+  },
+  async remove(id) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('buku_delete', { id });
+  },
+  async importBatch(items) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<BukuImportResult>('buku_import', { items });
+  },
+  async eksemplarCreate(bukuId, kode) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<Eksemplar>('eksemplar_create', { bukuId, kode });
+  },
+  async eksemplarRemove(id) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('eksemplar_delete', { id });
+  },
+  __resetMock() {
+    /* no-op for tauri */
+  },
+};
+
+const browserRpc: BukuRpc = {
+  async list(args) {
+    let items = readMock();
+    const q = args.query?.trim().toLowerCase();
+    if (q) {
+      items = items.filter(
+        (it) =>
+          it.judul.toLowerCase().includes(q) ||
+          it.kodeBuku.toLowerCase().includes(q) ||
+          (it.pengarang ?? '').toLowerCase().includes(q) ||
+          (it.isbn ?? '').toLowerCase().includes(q),
+      );
+    }
+    if (args.kategori) items = items.filter((it) => it.kategori === args.kategori);
+    if (args.bahasa) items = items.filter((it) => it.bahasa === args.bahasa);
+    if (args.kodeDdc) items = items.filter((it) => (it.kodeDdc ?? '').startsWith(args.kodeDdc!));
+    const total = items.length;
+    const sortBy = args.sortBy ?? 'judul';
+    const dir = args.sortDir === 'desc' ? -1 : 1;
+    items = [...items].sort((a, b) => {
+      const av = String((a as unknown as Record<string, unknown>)[sortBy] ?? '');
+      const bv = String((b as unknown as Record<string, unknown>)[sortBy] ?? '');
+      return av.localeCompare(bv) * dir;
+    });
+    const offset = args.offset ?? 0;
+    const limit = args.limit ?? 100;
+    return { items: items.slice(offset, offset + limit), total };
+  },
+  async get(id) {
+    const all = readMock();
+    const buku = all.find((it) => it.id === id);
+    if (!buku) throw new Error(`buku id=${id} not found`);
+    // Mock eksemplar derived from jumlahEksemplar
+    const eksemplar: Eksemplar[] = Array.from({ length: buku.jumlahEksemplar }, (_, i) => ({
+      id: id * 100 + i + 1,
+      bukuId: id,
+      kodeEksemplar: `${buku.kodeBuku}-${String(i + 1).padStart(2, '0')}`,
+      status: i < buku.jumlahTersedia ? 'tersedia' : 'dipinjam',
+      catatan: null,
+      createdAt: buku.createdAt,
+      updatedAt: buku.updatedAt,
+    }));
+    return { buku, eksemplar };
+  },
+  async create(input) {
+    if (!input.kodeBuku.trim()) throw new Error('validation: kodeBuku required');
+    if (!input.judul.trim()) throw new Error('validation: judul required');
+    const all = readMock();
+    if (all.some((it) => it.kodeBuku === input.kodeBuku.trim())) {
+      throw new Error(`validation: kodeBuku '${input.kodeBuku}' sudah dipakai`);
+    }
+    const jumlah = Math.max(0, input.jumlahEksemplar ?? 1);
+    const created: Buku = {
+      id: nextId(all),
+      kodeBuku: input.kodeBuku.trim(),
+      judul: input.judul.trim(),
+      pengarang: input.pengarang ?? null,
+      penerbit: input.penerbit ?? null,
+      tahunTerbit: input.tahunTerbit ?? null,
+      kodeDdc: input.kodeDdc ?? null,
+      kategori: input.kategori ?? null,
+      isbn: input.isbn ?? null,
+      jumlahEksemplar: jumlah,
+      jumlahTersedia: jumlah,
+      sumber: input.sumber ?? null,
+      harga: Math.max(0, input.harga ?? 0),
+      coverPath: input.coverPath ?? null,
+      bahasa: input.bahasa ?? null,
+      deskripsi: input.deskripsi ?? null,
+      rak: input.rak ?? null,
+      tanggalInput: input.tanggalInput ?? new Date().toISOString().slice(0, 10),
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    writeMock([...all, created]);
+    return created;
+  },
+  async update(id, input) {
+    const all = readMock();
+    const existing = all.find((it) => it.id === id);
+    if (!existing) throw new Error('not_found');
+    if (all.some((it) => it.id !== id && it.kodeBuku === input.kodeBuku.trim())) {
+      throw new Error(`validation: kodeBuku '${input.kodeBuku}' sudah dipakai buku lain`);
+    }
+    const updated: Buku = {
+      ...existing,
+      kodeBuku: input.kodeBuku.trim(),
+      judul: input.judul.trim(),
+      pengarang: input.pengarang ?? null,
+      penerbit: input.penerbit ?? null,
+      tahunTerbit: input.tahunTerbit ?? null,
+      kodeDdc: input.kodeDdc ?? null,
+      kategori: input.kategori ?? null,
+      isbn: input.isbn ?? null,
+      jumlahEksemplar: input.jumlahEksemplar ?? existing.jumlahEksemplar,
+      sumber: input.sumber ?? null,
+      harga: input.harga ?? existing.harga,
+      coverPath: input.coverPath ?? existing.coverPath,
+      bahasa: input.bahasa ?? null,
+      deskripsi: input.deskripsi ?? null,
+      rak: input.rak ?? null,
+      updatedAt: nowIso(),
+    };
+    writeMock(all.map((it) => (it.id === id ? updated : it)));
+    return updated;
+  },
+  async remove(id) {
+    const all = readMock();
+    if (!all.some((it) => it.id === id)) throw new Error('not_found');
+    writeMock(all.filter((it) => it.id !== id));
+  },
+  async importBatch(items) {
+    const all = readMock();
+    let inserted = 0;
+    let skipped = 0;
+    const errors: BukuImportError[] = [];
+    const next: Buku[] = [...all];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]!;
+      if (!item.kodeBuku.trim() || !item.judul.trim()) {
+        errors.push({ row: i + 1, message: 'kode_buku and judul are required' });
+        skipped += 1;
+        continue;
+      }
+      if (next.some((it) => it.kodeBuku === item.kodeBuku.trim())) {
+        errors.push({ row: i + 1, message: `kode_buku '${item.kodeBuku}' sudah ada` });
+        skipped += 1;
+        continue;
+      }
+      const jumlah = Math.max(0, item.jumlahEksemplar ?? 1);
+      next.push({
+        id: nextId(next),
+        kodeBuku: item.kodeBuku.trim(),
+        judul: item.judul.trim(),
+        pengarang: item.pengarang ?? null,
+        penerbit: item.penerbit ?? null,
+        tahunTerbit: item.tahunTerbit ?? null,
+        kodeDdc: item.kodeDdc ?? null,
+        kategori: item.kategori ?? null,
+        isbn: item.isbn ?? null,
+        jumlahEksemplar: jumlah,
+        jumlahTersedia: jumlah,
+        sumber: null,
+        harga: 0,
+        coverPath: null,
+        bahasa: item.bahasa ?? null,
+        deskripsi: null,
+        rak: null,
+        tanggalInput: new Date().toISOString().slice(0, 10),
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+      inserted += 1;
+    }
+    writeMock(next);
+    return { inserted, skipped, errors };
+  },
+  async eksemplarCreate(bukuId, kode) {
+    if (!kode.trim()) throw new Error('validation: kodeEksemplar required');
+    const all = readMock();
+    const buku = all.find((it) => it.id === bukuId);
+    if (!buku) throw new Error('not_found');
+    const updated: Buku = {
+      ...buku,
+      jumlahEksemplar: buku.jumlahEksemplar + 1,
+      jumlahTersedia: buku.jumlahTersedia + 1,
+      updatedAt: nowIso(),
+    };
+    writeMock(all.map((it) => (it.id === bukuId ? updated : it)));
+    return {
+      id: bukuId * 100 + buku.jumlahEksemplar + 1,
+      bukuId,
+      kodeEksemplar: kode.trim(),
+      status: 'tersedia',
+      catatan: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+  },
+  async eksemplarRemove() {
+    /* mock: ignore for now */
+  },
+  __resetMock() {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  },
+};
+
+export const bukuApi: BukuRpc = isTauri() ? tauriRpc : browserRpc;

--- a/apps/desktop/src/lib/masterData.ts
+++ b/apps/desktop/src/lib/masterData.ts
@@ -1,0 +1,246 @@
+import { isTauri } from '@/lib/auth';
+
+export type MasterTable = 'kategori' | 'bahasa' | 'jurusan' | 'agama' | 'kelas' | 'ddc';
+
+export interface MasterItem {
+  id?: number | null;
+  kode?: string | null;
+  nama: string;
+  deskripsi?: string | null;
+  urutan?: number | null;
+}
+
+export interface MasterInput {
+  kode?: string | null;
+  nama: string;
+  deskripsi?: string | null;
+  urutan?: number | null;
+}
+
+interface MasterRpc {
+  list(table: MasterTable, query?: string): Promise<MasterItem[]>;
+  create(table: MasterTable, input: MasterInput): Promise<MasterItem>;
+  update(table: MasterTable, key: string, input: MasterInput): Promise<MasterItem>;
+  remove(table: MasterTable, key: string): Promise<void>;
+  __resetMock(): void;
+}
+
+const STORAGE_KEY = 'po:master-mock';
+
+interface MockState {
+  kategori: MasterItem[];
+  bahasa: MasterItem[];
+  jurusan: MasterItem[];
+  agama: MasterItem[];
+  kelas: MasterItem[];
+  ddc: MasterItem[];
+}
+
+const SEED: MockState = {
+  kategori: [
+    { id: 1, nama: 'Fiksi', urutan: 0 },
+    { id: 2, nama: 'Non-fiksi', urutan: 1 },
+    { id: 3, nama: 'Referensi', urutan: 2 },
+    { id: 4, nama: 'Buku Pelajaran', urutan: 3 },
+    { id: 5, nama: 'Karya Ilmiah', urutan: 4 },
+    { id: 6, nama: 'Majalah', urutan: 5 },
+    { id: 7, nama: 'Komik', urutan: 6 },
+    { id: 8, nama: 'Biografi', urutan: 7 },
+  ],
+  bahasa: [
+    { kode: 'id', nama: 'Indonesia' },
+    { kode: 'en', nama: 'Inggris' },
+    { kode: 'ar', nama: 'Arab' },
+    { kode: 'jw', nama: 'Jawa' },
+    { kode: 'su', nama: 'Sunda' },
+    { kode: 'zh', nama: 'Mandarin' },
+    { kode: 'ja', nama: 'Jepang' },
+    { kode: 'fr', nama: 'Prancis' },
+    { kode: 'de', nama: 'Jerman' },
+    { kode: 'ms', nama: 'Melayu' },
+  ],
+  jurusan: [
+    { id: 1, nama: 'IPA', urutan: 0 },
+    { id: 2, nama: 'IPS', urutan: 1 },
+    { id: 3, nama: 'Bahasa', urutan: 2 },
+    { id: 4, nama: 'TKJ', urutan: 3 },
+    { id: 5, nama: 'RPL', urutan: 4 },
+    { id: 6, nama: 'Multimedia', urutan: 5 },
+  ],
+  agama: [
+    { id: 1, nama: 'Islam', urutan: 0 },
+    { id: 2, nama: 'Kristen', urutan: 1 },
+    { id: 3, nama: 'Katolik', urutan: 2 },
+    { id: 4, nama: 'Hindu', urutan: 3 },
+    { id: 5, nama: 'Buddha', urutan: 4 },
+    { id: 6, nama: 'Konghucu', urutan: 5 },
+  ],
+  kelas: [
+    { id: 1, nama: '7A', urutan: 0 },
+    { id: 2, nama: '7B', urutan: 1 },
+    { id: 3, nama: '8A', urutan: 2 },
+    { id: 4, nama: '8B', urutan: 3 },
+    { id: 5, nama: '9A', urutan: 4 },
+    { id: 6, nama: '10 IPA 1', urutan: 5 },
+    { id: 7, nama: '11 IPS 1', urutan: 6 },
+    { id: 8, nama: '12 IPA 3', urutan: 7 },
+  ],
+  ddc: [
+    { kode: '000', nama: 'Karya Umum' },
+    { kode: '100', nama: 'Filsafat & Psikologi' },
+    { kode: '200', nama: 'Agama' },
+    { kode: '300', nama: 'Ilmu Sosial' },
+    { kode: '400', nama: 'Bahasa' },
+    { kode: '500', nama: 'Sains' },
+    { kode: '600', nama: 'Teknologi' },
+    { kode: '700', nama: 'Seni & Olahraga' },
+    { kode: '800', nama: 'Sastra' },
+    { kode: '813', nama: 'Sastra Indonesia' },
+    { kode: '900', nama: 'Geografi & Sejarah' },
+    { kode: '909', nama: 'Sejarah Dunia' },
+  ],
+};
+
+function readMock(): MockState {
+  if (typeof window === 'undefined') return JSON.parse(JSON.stringify(SEED));
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(SEED));
+    return JSON.parse(JSON.stringify(SEED));
+  }
+  try {
+    return JSON.parse(raw) as MockState;
+  } catch {
+    return JSON.parse(JSON.stringify(SEED));
+  }
+}
+
+function writeMock(state: MockState): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function keyForRow(table: MasterTable, item: MasterItem): string {
+  if (table === 'bahasa' || table === 'ddc') return item.kode ?? '';
+  return String(item.id ?? '');
+}
+
+function nextNumericId(items: MasterItem[]): number {
+  return items.reduce((max, it) => Math.max(max, it.id ?? 0), 0) + 1;
+}
+
+const tauriRpc: MasterRpc = {
+  async list(table, query) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<MasterItem[]>('master_list', { table, query: query ?? null });
+  },
+  async create(table, input) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<MasterItem>('master_create', { table, input });
+  },
+  async update(table, key, input) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<MasterItem>('master_update', { table, key, input });
+  },
+  async remove(table, key) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('master_delete', { table, key });
+  },
+  __resetMock() {
+    /* no-op */
+  },
+};
+
+const browserRpc: MasterRpc = {
+  async list(table, query) {
+    const state = readMock();
+    let rows = [...state[table]];
+    const q = query?.trim().toLowerCase();
+    if (q) {
+      rows = rows.filter(
+        (r) =>
+          r.nama.toLowerCase().includes(q) ||
+          (r.kode ?? '').toLowerCase().includes(q),
+      );
+    }
+    rows.sort((a, b) => {
+      const ord = (a.urutan ?? 0) - (b.urutan ?? 0);
+      if (ord !== 0) return ord;
+      return a.nama.localeCompare(b.nama);
+    });
+    return rows;
+  },
+  async create(table, input) {
+    if (!input.nama.trim()) throw new Error('validation: nama required');
+    const state = readMock();
+    const rows = state[table];
+    if (table === 'bahasa') {
+      const kode = input.kode?.trim();
+      if (!kode) throw new Error('validation: kode required for bahasa');
+      if (rows.some((r) => r.kode === kode || r.nama === input.nama.trim())) {
+        throw new Error(`validation: bahasa '${kode}' / '${input.nama}' sudah ada`);
+      }
+      const created: MasterItem = { kode, nama: input.nama.trim() };
+      writeMock({ ...state, [table]: [...rows, created] });
+      return created;
+    }
+    if (table === 'ddc') {
+      const kode = input.kode?.trim();
+      if (!kode) throw new Error('validation: kode required for ddc');
+      if (rows.some((r) => r.kode === kode)) {
+        throw new Error(`validation: ddc '${kode}' sudah ada`);
+      }
+      const created: MasterItem = { kode, nama: input.nama.trim() };
+      writeMock({ ...state, [table]: [...rows, created] });
+      return created;
+    }
+    const namaLc = input.nama.trim().toLowerCase();
+    if (rows.some((r) => r.nama.toLowerCase() === namaLc)) {
+      throw new Error(`validation: ${table} '${input.nama}' sudah ada`);
+    }
+    const created: MasterItem = {
+      id: nextNumericId(rows),
+      nama: input.nama.trim(),
+      deskripsi: input.deskripsi ?? null,
+      kode: input.kode ?? null,
+      urutan: input.urutan ?? rows.length,
+    };
+    writeMock({ ...state, [table]: [...rows, created] });
+    return created;
+  },
+  async update(table, key, input) {
+    if (!input.nama.trim()) throw new Error('validation: nama required');
+    const state = readMock();
+    const rows = state[table];
+    const idx = rows.findIndex((r) => keyForRow(table, r) === key);
+    if (idx < 0) throw new Error('not_found');
+    const existing = rows[idx]!;
+    const updated: MasterItem = {
+      ...existing,
+      nama: input.nama.trim(),
+      deskripsi: input.deskripsi ?? existing.deskripsi ?? null,
+      kode: input.kode ?? existing.kode ?? null,
+      urutan: input.urutan ?? existing.urutan ?? 0,
+    };
+    const nextRows = [...rows];
+    nextRows[idx] = updated;
+    writeMock({ ...state, [table]: nextRows });
+    return updated;
+  },
+  async remove(table, key) {
+    const state = readMock();
+    const rows = state[table];
+    if (!rows.some((r) => keyForRow(table, r) === key)) throw new Error('not_found');
+    writeMock({
+      ...state,
+      [table]: rows.filter((r) => keyForRow(table, r) !== key),
+    });
+  },
+  __resetMock() {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  },
+};
+
+export const masterDataApi: MasterRpc = isTauri() ? tauriRpc : browserRpc;

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -13,7 +13,11 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard'
+import { Route as AuthedBukuIndexRouteImport } from './routes/_authed/buku/index'
 import { Route as AuthedAnggotaIndexRouteImport } from './routes/_authed/anggota/index'
+import { Route as AuthedSettingsMasterDataRouteImport } from './routes/_authed/settings/master-data'
+import { Route as AuthedBukuNewRouteImport } from './routes/_authed/buku/new'
+import { Route as AuthedBukuIdRouteImport } from './routes/_authed/buku/$id'
 import { Route as AuthedAnggotaNewRouteImport } from './routes/_authed/anggota/new'
 import { Route as AuthedAnggotaIdRouteImport } from './routes/_authed/anggota/$id'
 
@@ -36,9 +40,30 @@ const AuthedDashboardRoute = AuthedDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedBukuIndexRoute = AuthedBukuIndexRouteImport.update({
+  id: '/buku/',
+  path: '/buku/',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedAnggotaIndexRoute = AuthedAnggotaIndexRouteImport.update({
   id: '/anggota/',
   path: '/anggota/',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedSettingsMasterDataRoute =
+  AuthedSettingsMasterDataRouteImport.update({
+    id: '/settings/master-data',
+    path: '/settings/master-data',
+    getParentRoute: () => AuthedRoute,
+  } as any)
+const AuthedBukuNewRoute = AuthedBukuNewRouteImport.update({
+  id: '/buku/new',
+  path: '/buku/new',
+  getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedBukuIdRoute = AuthedBukuIdRouteImport.update({
+  id: '/buku/$id',
+  path: '/buku/$id',
   getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedAnggotaNewRoute = AuthedAnggotaNewRouteImport.update({
@@ -58,7 +83,11 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof AuthedDashboardRoute
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
+  '/buku/$id': typeof AuthedBukuIdRoute
+  '/buku/new': typeof AuthedBukuNewRoute
+  '/settings/master-data': typeof AuthedSettingsMasterDataRoute
   '/anggota/': typeof AuthedAnggotaIndexRoute
+  '/buku/': typeof AuthedBukuIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -66,7 +95,11 @@ export interface FileRoutesByTo {
   '/dashboard': typeof AuthedDashboardRoute
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
+  '/buku/$id': typeof AuthedBukuIdRoute
+  '/buku/new': typeof AuthedBukuNewRoute
+  '/settings/master-data': typeof AuthedSettingsMasterDataRoute
   '/anggota': typeof AuthedAnggotaIndexRoute
+  '/buku': typeof AuthedBukuIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -76,7 +109,11 @@ export interface FileRoutesById {
   '/_authed/dashboard': typeof AuthedDashboardRoute
   '/_authed/anggota/$id': typeof AuthedAnggotaIdRoute
   '/_authed/anggota/new': typeof AuthedAnggotaNewRoute
+  '/_authed/buku/$id': typeof AuthedBukuIdRoute
+  '/_authed/buku/new': typeof AuthedBukuNewRoute
+  '/_authed/settings/master-data': typeof AuthedSettingsMasterDataRoute
   '/_authed/anggota/': typeof AuthedAnggotaIndexRoute
+  '/_authed/buku/': typeof AuthedBukuIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -86,7 +123,11 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/anggota/$id'
     | '/anggota/new'
+    | '/buku/$id'
+    | '/buku/new'
+    | '/settings/master-data'
     | '/anggota/'
+    | '/buku/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -94,7 +135,11 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/anggota/$id'
     | '/anggota/new'
+    | '/buku/$id'
+    | '/buku/new'
+    | '/settings/master-data'
     | '/anggota'
+    | '/buku'
   id:
     | '__root__'
     | '/'
@@ -103,7 +148,11 @@ export interface FileRouteTypes {
     | '/_authed/dashboard'
     | '/_authed/anggota/$id'
     | '/_authed/anggota/new'
+    | '/_authed/buku/$id'
+    | '/_authed/buku/new'
+    | '/_authed/settings/master-data'
     | '/_authed/anggota/'
+    | '/_authed/buku/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -142,11 +191,39 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedDashboardRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/buku/': {
+      id: '/_authed/buku/'
+      path: '/buku'
+      fullPath: '/buku/'
+      preLoaderRoute: typeof AuthedBukuIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/anggota/': {
       id: '/_authed/anggota/'
       path: '/anggota'
       fullPath: '/anggota/'
       preLoaderRoute: typeof AuthedAnggotaIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/settings/master-data': {
+      id: '/_authed/settings/master-data'
+      path: '/settings/master-data'
+      fullPath: '/settings/master-data'
+      preLoaderRoute: typeof AuthedSettingsMasterDataRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/buku/new': {
+      id: '/_authed/buku/new'
+      path: '/buku/new'
+      fullPath: '/buku/new'
+      preLoaderRoute: typeof AuthedBukuNewRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/buku/$id': {
+      id: '/_authed/buku/$id'
+      path: '/buku/$id'
+      fullPath: '/buku/$id'
+      preLoaderRoute: typeof AuthedBukuIdRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/anggota/new': {
@@ -170,14 +247,22 @@ interface AuthedRouteChildren {
   AuthedDashboardRoute: typeof AuthedDashboardRoute
   AuthedAnggotaIdRoute: typeof AuthedAnggotaIdRoute
   AuthedAnggotaNewRoute: typeof AuthedAnggotaNewRoute
+  AuthedBukuIdRoute: typeof AuthedBukuIdRoute
+  AuthedBukuNewRoute: typeof AuthedBukuNewRoute
+  AuthedSettingsMasterDataRoute: typeof AuthedSettingsMasterDataRoute
   AuthedAnggotaIndexRoute: typeof AuthedAnggotaIndexRoute
+  AuthedBukuIndexRoute: typeof AuthedBukuIndexRoute
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedDashboardRoute: AuthedDashboardRoute,
   AuthedAnggotaIdRoute: AuthedAnggotaIdRoute,
   AuthedAnggotaNewRoute: AuthedAnggotaNewRoute,
+  AuthedBukuIdRoute: AuthedBukuIdRoute,
+  AuthedBukuNewRoute: AuthedBukuNewRoute,
+  AuthedSettingsMasterDataRoute: AuthedSettingsMasterDataRoute,
   AuthedAnggotaIndexRoute: AuthedAnggotaIndexRoute,
+  AuthedBukuIndexRoute: AuthedBukuIndexRoute,
 }
 
 const AuthedRouteWithChildren =

--- a/apps/desktop/src/routes/_authed/buku/$id.tsx
+++ b/apps/desktop/src/routes/_authed/buku/$id.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import { createFileRoute, Link, useNavigate, useParams } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { BukuForm } from '@/features/buku/BukuForm';
+import { bukuApi, type Buku } from '@/lib/buku';
+import { masterDataApi, type MasterItem } from '@/lib/masterData';
+import { toBukuInput } from '@/features/buku/schema';
+import { useToast } from '@/components/ui/toast-manager';
+
+export const Route = createFileRoute('/_authed/buku/$id')({
+  component: EditBukuRoute,
+});
+
+function EditBukuRoute() {
+  const { t } = useTranslation(['buku', 'common']);
+  const params = useParams({ from: '/_authed/buku/$id' });
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  const id = Number(params.id);
+  const [item, setItem] = useState<Buku | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [ddc, setDdc] = useState<MasterItem[]>([]);
+  const [kategori, setKategori] = useState<MasterItem[]>([]);
+  const [bahasa, setBahasa] = useState<MasterItem[]>([]);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([
+      bukuApi.get(id),
+      masterDataApi.list('ddc'),
+      masterDataApi.list('kategori'),
+      masterDataApi.list('bahasa'),
+    ])
+      .then(([detail, d, k, b]) => {
+        if (cancelled) return;
+        setItem(detail.buku);
+        setDdc(d);
+        setKategori(k);
+        setBahasa(b);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        showToast({
+          variant: 'destructive',
+          title: t('buku:feedback.loadError'),
+          description: err instanceof Error ? err.message : String(err),
+        });
+        void navigate({ to: '/buku' });
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, navigate, showToast, t]);
+
+  return (
+    <div className="container mx-auto max-w-3xl p-6 md:p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/buku">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {t('common:actions.back')}
+          </Link>
+        </Button>
+      </div>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold tracking-tight">{t('buku:form.editTitle')}</h1>
+        <p className="text-sm text-muted-foreground">{t('buku:form.editSubtitle')}</p>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">{t('common:states.loading')}</p>
+      ) : (
+        item && (
+          <BukuForm
+            initial={item}
+            ddcOptions={ddc}
+            kategoriOptions={kategori}
+            bahasaOptions={bahasa}
+            submitLabel={t('buku:form.submitUpdate')}
+            onCancel={() => void navigate({ to: '/buku' })}
+            onDelete={() => setConfirmOpen(true)}
+            onSubmit={async (values) => {
+              try {
+                await bukuApi.update(id, toBukuInput(values));
+                showToast({ title: t('buku:feedback.updateSuccess') });
+                void navigate({ to: '/buku' });
+              } catch (err) {
+                showToast({
+                  variant: 'destructive',
+                  title: t('buku:feedback.updateError', {
+                    message: err instanceof Error ? err.message : String(err),
+                  }),
+                });
+              }
+            }}
+          />
+        )
+      )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={t('buku:delete.title', { name: item?.judul ?? '' })}
+        description={t('buku:delete.description')}
+        confirmText={t('common:actions.delete')}
+        destructive
+        onConfirm={async () => {
+          try {
+            await bukuApi.remove(id);
+            showToast({ title: t('buku:feedback.deleteSuccess') });
+            void navigate({ to: '/buku' });
+          } catch (err) {
+            showToast({
+              variant: 'destructive',
+              title: t('buku:feedback.deleteError'),
+              description: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/routes/_authed/buku/index.tsx
+++ b/apps/desktop/src/routes/_authed/buku/index.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import { BukuList, useBukuListSearchSync } from '@/features/buku/BukuList';
+
+const searchSchema = z.object({
+  q: z.string().optional(),
+  kategori: z.string().optional(),
+  bahasa: z.string().optional(),
+  page: z.coerce.number().int().positive().optional(),
+  selected: z.coerce.number().int().positive().optional(),
+});
+
+export const Route = createFileRoute('/_authed/buku/')({
+  validateSearch: (s) => searchSchema.parse(s),
+  component: BukuIndexRoute,
+});
+
+function BukuIndexRoute() {
+  const { search, patch } = useBukuListSearchSync();
+  return <BukuList search={search} onSearchChange={patch} />;
+}

--- a/apps/desktop/src/routes/_authed/buku/new.tsx
+++ b/apps/desktop/src/routes/_authed/buku/new.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { BukuForm } from '@/features/buku/BukuForm';
+import { bukuApi } from '@/lib/buku';
+import { masterDataApi, type MasterItem } from '@/lib/masterData';
+import { toBukuInput } from '@/features/buku/schema';
+import { useToast } from '@/components/ui/toast-manager';
+
+export const Route = createFileRoute('/_authed/buku/new')({
+  component: NewBukuRoute,
+});
+
+function NewBukuRoute() {
+  const { t } = useTranslation(['buku', 'common']);
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const [ddc, setDdc] = useState<MasterItem[]>([]);
+  const [kategori, setKategori] = useState<MasterItem[]>([]);
+  const [bahasa, setBahasa] = useState<MasterItem[]>([]);
+
+  useEffect(() => {
+    void Promise.all([
+      masterDataApi.list('ddc').then(setDdc).catch(() => undefined),
+      masterDataApi.list('kategori').then(setKategori).catch(() => undefined),
+      masterDataApi.list('bahasa').then(setBahasa).catch(() => undefined),
+    ]);
+  }, []);
+
+  return (
+    <div className="container mx-auto max-w-3xl p-6 md:p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/buku">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {t('common:actions.back')}
+          </Link>
+        </Button>
+      </div>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold tracking-tight">{t('buku:form.newTitle')}</h1>
+        <p className="text-sm text-muted-foreground">{t('buku:form.newSubtitle')}</p>
+      </div>
+
+      <BukuForm
+        ddcOptions={ddc}
+        kategoriOptions={kategori}
+        bahasaOptions={bahasa}
+        submitLabel={t('buku:form.submitCreate')}
+        onCancel={() => void navigate({ to: '/buku' })}
+        onSubmit={async (values) => {
+          try {
+            await bukuApi.create(toBukuInput(values));
+            showToast({ title: t('buku:feedback.createSuccess') });
+            void navigate({ to: '/buku' });
+          } catch (err) {
+            showToast({
+              variant: 'destructive',
+              title: t('buku:feedback.createError', {
+                message: err instanceof Error ? err.message : String(err),
+              }),
+            });
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/routes/_authed/settings/master-data.tsx
+++ b/apps/desktop/src/routes/_authed/settings/master-data.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MasterDataPage } from '@/features/master-data/MasterDataPage';
+
+export const Route = createFileRoute('/_authed/settings/master-data')({
+  component: MasterDataPage,
+});

--- a/apps/desktop/tests/e2e/buku.spec.ts
+++ b/apps/desktop/tests/e2e/buku.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test';
+
+async function login(page: import('@playwright/test').Page) {
+  await page.goto('/login');
+  await page.evaluate(() => {
+    localStorage.removeItem('po:auth');
+    localStorage.removeItem('po:buku-mock');
+    localStorage.removeItem('po:master-mock');
+  });
+  await page.reload();
+  await page.getByLabel(/Nama Pengguna|Username/).fill('admin');
+  await page.getByLabel(/Kata Sandi|Password/).fill('admin123');
+  await page.getByRole('button', { name: /Masuk|Sign in/ }).click();
+  await expect(page).toHaveURL(/\/dashboard/);
+}
+
+test.describe('buku CRUD (browser dev mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await login(page);
+    await page.goto('/buku');
+    await expect(page.getByTestId('buku-table')).toBeVisible();
+  });
+
+  test('renders the seed list with default rows', async ({ page }) => {
+    const table = page.getByTestId('buku-table');
+    await expect(table.getByText('Bumi Manusia')).toBeVisible();
+    await expect(table.getByText('Sapiens')).toBeVisible();
+  });
+
+  test('debounced search filters books live', async ({ page }) => {
+    await page.getByTestId('buku-search').fill('sapiens');
+    const table = page.getByTestId('buku-table');
+    await expect(table.getByText('Sapiens')).toBeVisible();
+    await expect(table.getByText('Bumi Manusia')).toHaveCount(0);
+  });
+
+  test('selecting a row populates the detail panel', async ({ page }) => {
+    await page.getByTestId('buku-table').getByText('Bumi Manusia').click();
+    const detail = page.getByTestId('buku-detail');
+    await expect(detail).toBeVisible();
+    await expect(detail.getByText('Bumi Manusia')).toBeVisible();
+    await expect(page.getByTestId('buku-eksemplar-list')).toBeVisible();
+  });
+
+  test('creates a new book end-to-end', async ({ page }) => {
+    await page.getByTestId('buku-add').click();
+    await expect(page).toHaveURL(/\/buku\/new/);
+    await page.getByTestId('field-kodeBuku').fill('E2EBK1');
+    await page.getByTestId('field-judul').fill('Playwright Buku E2E');
+    await page.getByTestId('field-pengarang').fill('Devin AI');
+    await page.getByTestId('field-jumlahEksemplar').fill('2');
+    await page.getByTestId('form-submit').click();
+    await expect(page).toHaveURL(/\/buku$|\/buku\?/);
+    await page.getByTestId('buku-search').fill('E2EBK1');
+    await expect(
+      page.getByTestId('buku-table').getByText('Playwright Buku E2E'),
+    ).toBeVisible();
+  });
+
+  test('blocks submission when required fields are missing', async ({ page }) => {
+    await page.getByTestId('buku-add').click();
+    await page.getByTestId('form-submit').click();
+    await expect(page).toHaveURL(/\/buku\/new/);
+  });
+
+  test('edits and deletes an existing book', async ({ page }) => {
+    await page.getByTestId('buku-table').getByText('Bumi Manusia').click();
+    await page.getByTestId('buku-detail-edit').click();
+    await expect(page).toHaveURL(/\/buku\/\d+/);
+    await page.getByTestId('field-judul').fill('Bumi Manusia (edited)');
+    await page.getByTestId('form-submit').click();
+    await expect(page).toHaveURL(/\/buku$|\/buku\?/);
+    await expect(
+      page.getByTestId('buku-table').getByText('Bumi Manusia (edited)'),
+    ).toBeVisible();
+
+    await page.getByTestId('buku-table').getByText('Bumi Manusia (edited)').click();
+    await page.getByTestId('buku-detail-edit').click();
+    await page.getByTestId('form-delete').click();
+    await page.getByTestId('confirm-dialog-confirm').click();
+    await expect(page).toHaveURL(/\/buku$|\/buku\?/);
+    await expect(page.getByText('Bumi Manusia (edited)')).toHaveCount(0);
+  });
+});

--- a/apps/desktop/tests/e2e/master-data.spec.ts
+++ b/apps/desktop/tests/e2e/master-data.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+async function login(page: import('@playwright/test').Page) {
+  await page.goto('/login');
+  await page.evaluate(() => {
+    localStorage.removeItem('po:auth');
+    localStorage.removeItem('po:master-mock');
+  });
+  await page.reload();
+  await page.getByLabel(/Nama Pengguna|Username/).fill('admin');
+  await page.getByLabel(/Kata Sandi|Password/).fill('admin123');
+  await page.getByRole('button', { name: /Masuk|Sign in/ }).click();
+  await expect(page).toHaveURL(/\/dashboard/);
+}
+
+test.describe('master-data CRUD (browser dev mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await login(page);
+    await page.goto('/settings/master-data');
+    await expect(page.getByTestId('master-tabs')).toBeVisible();
+  });
+
+  test('renders DDC tab seed entries by default', async ({ page }) => {
+    const table = page.getByTestId('master-table');
+    await expect(table.getByText('000', { exact: true }).first()).toBeVisible();
+  });
+
+  test('switches between tabs', async ({ page }) => {
+    await page.getByTestId('master-tab-bahasa').click();
+    const table = page.getByTestId('master-table');
+    await expect(table.getByText('Indonesia').first()).toBeVisible();
+    await expect(table.getByText('Inggris').first()).toBeVisible();
+
+    await page.getByTestId('master-tab-jurusan').click();
+    await expect(table.getByText('IPA').first()).toBeVisible();
+  });
+
+  test('creates a new kategori entry via dialog', async ({ page }) => {
+    await page.getByTestId('master-tab-kategori').click();
+    await page.getByTestId('master-add').click();
+    await page.getByTestId('master-form-nama').fill('E2E Test Kategori');
+    await page.getByTestId('master-form-submit').click();
+    await page.getByTestId('master-search').fill('E2E Test');
+    await expect(page.getByTestId('master-table').getByText('E2E Test Kategori')).toBeVisible();
+  });
+
+  test('search filters within active tab', async ({ page }) => {
+    await page.getByTestId('master-tab-kategori').click();
+    await page.getByTestId('master-search').fill('fiksi');
+    const table = page.getByTestId('master-table');
+    await expect(table.getByText(/Fiksi|Non-fiksi/).first()).toBeVisible();
+  });
+});

--- a/apps/desktop/tests/unit/bukuApi.test.ts
+++ b/apps/desktop/tests/unit/bukuApi.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { bukuApi } from '@/lib/buku';
+
+describe('bukuApi (browser mock)', () => {
+  beforeEach(() => {
+    bukuApi.__resetMock();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    bukuApi.__resetMock();
+  });
+
+  it('seeds initial data on first list call', async () => {
+    const res = await bukuApi.list({});
+    expect(res.total).toBeGreaterThan(0);
+    expect(res.items[0]).toHaveProperty('kodeBuku');
+    expect(res.items[0]).toHaveProperty('judul');
+  });
+
+  it('filters by query across judul, kode, pengarang, isbn', async () => {
+    const res = await bukuApi.list({ query: 'sapiens' });
+    expect(res.items.length).toBeGreaterThan(0);
+    expect(res.items.every((it) => /sapiens/i.test(it.judul))).toBe(true);
+  });
+
+  it('filters by kategori', async () => {
+    const res = await bukuApi.list({ kategori: 'Fiksi' });
+    expect(res.items.every((it) => it.kategori === 'Fiksi')).toBe(true);
+  });
+
+  it('creates a buku with correct eksemplar count', async () => {
+    const created = await bukuApi.create({
+      kodeBuku: 'B9999',
+      judul: 'Test Book',
+      jumlahEksemplar: 3,
+    });
+    expect(created.id).toBeDefined();
+    expect(created.jumlahEksemplar).toBe(3);
+    expect(created.jumlahTersedia).toBe(3);
+  });
+
+  it('rejects duplicate kodeBuku on create', async () => {
+    await bukuApi.create({ kodeBuku: 'DUP', judul: 'First' });
+    await expect(bukuApi.create({ kodeBuku: 'DUP', judul: 'Second' })).rejects.toThrow();
+  });
+
+  it('rejects empty kodeBuku or judul', async () => {
+    await expect(bukuApi.create({ kodeBuku: '', judul: 'No Code' })).rejects.toThrow();
+    await expect(bukuApi.create({ kodeBuku: 'X', judul: '' })).rejects.toThrow();
+  });
+
+  it('updates and deletes a buku', async () => {
+    const created = await bukuApi.create({ kodeBuku: 'UPD1', judul: 'Original' });
+    const updated = await bukuApi.update(created.id, {
+      kodeBuku: 'UPD1',
+      judul: 'Updated Title',
+    });
+    expect(updated.judul).toBe('Updated Title');
+
+    await bukuApi.remove(created.id);
+    await expect(bukuApi.get(created.id)).rejects.toThrow();
+  });
+
+  it('returns detail with eksemplar list', async () => {
+    const created = await bukuApi.create({
+      kodeBuku: 'EKS1',
+      judul: 'With Eksemplar',
+      jumlahEksemplar: 2,
+    });
+    const detail = await bukuApi.get(created.id);
+    expect(detail.buku.id).toBe(created.id);
+    expect(Array.isArray(detail.eksemplar)).toBe(true);
+    expect(detail.eksemplar.length).toBe(2);
+  });
+
+  it('imports a batch and reports per-row errors', async () => {
+    const result = await bukuApi.importBatch([
+      { kodeBuku: 'IMP1', judul: 'Imported 1' },
+      { kodeBuku: '', judul: 'Missing kode' },
+      { kodeBuku: 'IMP1', judul: 'Duplicate within batch' },
+    ]);
+    expect(result.inserted).toBe(1);
+    expect(result.errors.length + result.skipped).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/desktop/tests/unit/masterDataApi.test.ts
+++ b/apps/desktop/tests/unit/masterDataApi.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { masterDataApi } from '@/lib/masterData';
+
+describe('masterDataApi (browser mock)', () => {
+  beforeEach(() => {
+    masterDataApi.__resetMock();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    masterDataApi.__resetMock();
+  });
+
+  it('seeds default DDC entries on first list', async () => {
+    const items = await masterDataApi.list('ddc');
+    expect(items.length).toBeGreaterThan(0);
+    const ratusan = items.find((it) => it.kode === '000');
+    expect(ratusan).toBeDefined();
+  });
+
+  it('seeds bahasa with ISO 639 codes', async () => {
+    const items = await masterDataApi.list('bahasa');
+    expect(items.find((it) => it.kode === 'id')).toBeDefined();
+    expect(items.find((it) => it.kode === 'en')).toBeDefined();
+  });
+
+  it('filters list by query (LIKE nama or kode)', async () => {
+    const all = await masterDataApi.list('kategori');
+    const filtered = await masterDataApi.list('kategori', 'fiksi');
+    expect(filtered.length).toBeGreaterThan(0);
+    expect(filtered.length).toBeLessThanOrEqual(all.length);
+    expect(filtered.every((it) => /fiksi/i.test(it.nama))).toBe(true);
+  });
+
+  it('creates a kategori entry (numeric id auto-assigned)', async () => {
+    const created = await masterDataApi.create('kategori', {
+      nama: 'TestKategori',
+      deskripsi: 'desc',
+    });
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.nama).toBe('TestKategori');
+  });
+
+  it('creates a bahasa entry with kode as primary key', async () => {
+    const created = await masterDataApi.create('bahasa', {
+      kode: 'xx',
+      nama: 'Xtra',
+    });
+    expect(created.kode).toBe('xx');
+  });
+
+  it('rejects duplicate nama on create (case-insensitive)', async () => {
+    await masterDataApi.create('jurusan', { nama: 'UniqueOne' });
+    await expect(
+      masterDataApi.create('jurusan', { nama: 'uniqueone' }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects bahasa create without kode', async () => {
+    await expect(
+      masterDataApi.create('bahasa', { nama: 'NoCode' }),
+    ).rejects.toThrow();
+  });
+
+  it('updates and deletes a kategori', async () => {
+    const created = await masterDataApi.create('kategori', { nama: 'WillUpdate' });
+    const updated = await masterDataApi.update('kategori', String(created.id), {
+      nama: 'WasUpdated',
+    });
+    expect(updated.nama).toBe('WasUpdated');
+
+    await masterDataApi.remove('kategori', String(created.id));
+    const list = await masterDataApi.list('kategori');
+    expect(list.find((it) => it.id === created.id)).toBeUndefined();
+  });
+
+  it('updates and deletes a bahasa by kode', async () => {
+    const created = await masterDataApi.create('bahasa', {
+      kode: 'zz',
+      nama: 'Zoolang',
+    });
+    const updated = await masterDataApi.update('bahasa', created.kode!, {
+      nama: 'ZoolangUpdated',
+    });
+    expect(updated.nama).toBe('ZoolangUpdated');
+
+    await masterDataApi.remove('bahasa', 'zz');
+    const list = await masterDataApi.list('bahasa');
+    expect(list.find((it) => it.kode === 'zz')).toBeUndefined();
+  });
+});

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -21,7 +21,7 @@ project: perpustakaan-offline
 migration: v1 (python+customtkinter) -> v2 (tauri 2.0 + react 18 + ts + tailwind 3 + shadcn + zustand)
 total_sessions: 12
 schema_version: 1
-last_updated: 2026-05-03 (session 04)
+last_updated: 2026-05-03 (session 05)
 ```
 
 ## Sessions
@@ -54,15 +54,15 @@ sessions:
   - id: 4
     title: Data Anggota CRUD + autocomplete + live search + dropdown styled
     status: COMPLETED
-    pr: PENDING
+    pr: https://github.com/alviarts/perpustakaan-offline/pull/39
     completed_at: 2026-05-03
     dependencies: [3]
 
   - id: 5
     title: Data Buku CRUD + Master Data komplit (DDC/Kategori/Bahasa/Jurusan/Kelas/Agama)
-    status: PENDING
+    status: COMPLETED
     pr: PENDING
-    completed_at: null
+    completed_at: 2026-05-03
     dependencies: [4]
 
   - id: 6
@@ -122,8 +122,8 @@ sessions:
 | 1 | Bootstrap migration plan | COMPLETED | [#35](https://github.com/alviarts/perpustakaan-offline/pull/35) | 2026-05-03 | — |
 | 2 | Scaffolding + login + theme + i18n | COMPLETED | [#36](https://github.com/alviarts/perpustakaan-offline/pull/36) | 2026-05-03 | 1 |
 | 3 | Layout shell (sidebar + header + responsive) | COMPLETED | [#37](https://github.com/alviarts/perpustakaan-offline/pull/37) | 2026-05-03 | 2 |
-| 4 | Data Anggota CRUD + search/autocomplete | COMPLETED | PENDING | 2026-05-03 | 3 |
-| 5 | Data Buku CRUD + Master Data | PENDING | PENDING | — | 4 |
+| 4 | Data Anggota CRUD + search/autocomplete | COMPLETED | [#39](https://github.com/alviarts/perpustakaan-offline/pull/39) | 2026-05-03 | 3 |
+| 5 | Data Buku CRUD + Master Data | COMPLETED | PENDING | 2026-05-03 | 4 |
 | 6 | Peminjaman + Pengembalian | PENDING | PENDING | — | 4, 5 |
 | 7 | Kunjungan redesign | PENDING | PENDING | — | 3, 4 |
 | 8 | Dashboard modern + charts | PENDING | PENDING | — | 4, 5, 6 |


### PR DESCRIPTION
## Summary

Devin **session 5/12** dari roadmap migrasi v2. Implementasi penuh CRUD buku perpustakaan dengan layout master/detail dan halaman Settings → Master Data dengan tab CRUD untuk DDC, Kategori, Bahasa, Jurusan, Kelas, Agama.

> **Note**: PR ini di-stack di atas branch session 4 (PR #39). Diff sementara mencakup commit session 4; setelah #39 merge, GitHub auto-rebase dan diff murni session 5.

**Revisi tercover**:
- **#16** Fix layout Data Buku (master/detail panel, fix bounce_book empty state)
- **#17** Dropdown master data DDC/Kategori/Bahasa/Jurusan/Kelas/Agama dengan CRUD di Settings, seed online (Dewey, ISO 639)

### Backend (Rust / Tauri)
- `commands/buku.rs` — 8 IPC commands: `buku_list` / `buku_get` / `buku_create` / `buku_update` / `buku_delete` / `buku_import` / `eksemplar_create` / `eksemplar_delete` (auto-sync `jumlahEksemplar` + `jumlahTersedia`).
- `commands/master_data.rs` — 4 generic commands untuk 6 tabel: `master_list` / `master_create` / `master_update` / `master_delete`.
- `db/mod.rs` — migrasi idempotent untuk 4 tabel baru (kategori, bahasa, jurusan, agama) + `seed_master_data()` lengkap (DDC: 14 entries, Bahasa: 10 ISO codes, Agama: 6, Kelas: 18, Jurusan: 6, Kategori: 8).

### Frontend (React + TS + shadcn/ui)
- `lib/buku.ts` + `lib/masterData.ts` — IPC dual-mode (Tauri vs localStorage mock) dengan seed lengkap.
- `features/buku/`:
  - `BukuList` — master/detail layout: kiri DataTable + filter + search debounced 200ms, kanan panel detail dengan eksemplar badge list (revisi #16).
  - `BukuForm` — RHF + Zod, autocomplete ddc/kategori/bahasa pakai master data.
  - `ImportBukuDialog` — XLSX parse + flexible header mapping + preview 50 row + per-row error report.
- `features/master-data/MasterDataPage` — tabs untuk 6 tabel + DataTable + search + dialog tambah/edit/hapus.
- Routes baru: `/buku`, `/buku/new`, `/buku/$id`, `/settings/master-data`.
- Sidebar: `/buku` di-unlock (was `pending: true`).
- i18n: namespace `buku` dan `masterData` lengkap (id + en).

### Tests
- **Vitest** (47 pass total, 18 baru): `bukuApi.test.ts` (9 cases), `masterDataApi.test.ts` (9 cases).
- **Playwright** (25 pass total, 10 baru): `buku.spec.ts` (6 cases), `master-data.spec.ts` (4 cases).
- **Cargo**: `cargo check` + `cargo clippy --all-targets -- -D warnings` clean.
- **Frontend**: `pnpm lint` (0 warning), `pnpm typecheck` (0 error).

### Docs
- `docs/migration-v2/PROGRESS.md` — sesi 5 PENDING → COMPLETED (2026-05-03), sesi 4 PR URL diisi #39.

## Review & Testing Checklist for Human

- [ ] **Buku CRUD**: Login → buka **Buku** dari sidebar; klik salah satu baris (mis. Bumi Manusia) → konfirmasi panel kanan menampilkan detail + eksemplar badge list (revisi #16). Coba search "sapiens" → list filter live.
- [ ] **Buku create**: klik **+ Tambah Buku** → isi minimal `kode_buku` + `judul` + jumlah eksemplar → submit; konfirmasi muncul di list dengan badge tersedia.
- [ ] **Buku autocomplete**: di form, klik field DDC / Kategori / Bahasa → konfirmasi popup autocomplete tampil dengan width sama persis dengan trigger, dan options sourced dari master data.
- [ ] **Buku import**: klik **Import Excel**, upload `.xlsx` dengan header `kode_buku, judul, pengarang, kategori, bahasa, ddc, jumlah` → konfirmasi preview muncul, batch insert sukses, error per-row dilaporkan untuk row yang invalid.
- [ ] **Master Data Settings**: navigate ke `/settings/master-data` → konfirmasi tabs untuk 6 master tables. Klik tab **Bahasa** → konfirmasi 10 ISO codes seed (id, en, ar, jw, ...). Tambah entry baru di tab **Kategori**, edit, hapus → konfirmasi persist.
- [ ] **Buku filter sync**: filter Kategori atau Bahasa di list buku → konfirmasi options dropdown ter-source dari master data tables.

### Notes

- Browser dev mode pakai mock localStorage (`po:buku-mock`, `po:master-mock`) — Tauri runtime full delegates ke Rust IPC.
- Skema DB tetap kompatibel dengan v1 (idempotent migration). Tabel baru tidak menyentuh data existing.
- Master Data nama uniqueness sekarang case-insensitive (`LOWER(nama) = LOWER(?1)`) supaya konsisten antara backend SQL dan browser mock.
- PR ini stacked di atas PR #39 (session 4); base auto-rebase setelah #39 merge.

Devin session 5/12
