### PR TITLE
feat(session-07): kunjungan redesign

### DIFF
--- a/apps/desktop/src-tauri/src/commands/kunjungan.rs
+++ b/apps/desktop/src-tauri/src/commands/kunjungan.rs
@@ -1,0 +1,294 @@
+//! Kunjungan (visit log) commands.
+//!
+//! Backs the Kunjungan page (revisi #18). Reuses the existing `kunjungan`
+//! table populated by Peminjaman/Pengembalian flows plus manual entries.
+
+use chrono::NaiveDate;
+use rusqlite::{params, params_from_iter, ToSql};
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KunjunganRow {
+    pub id: i64,
+    pub anggota_id: Option<i64>,
+    pub anggota_nama: Option<String>,
+    pub anggota_kode: Option<String>,
+    pub anggota_kelas: Option<String>,
+    pub tanggal: String,
+    pub jam: String,
+    pub keperluan: Option<String>,
+    pub sumber: String,
+    pub jumlah_orang: i64,
+    pub kelas: Option<String>,
+    pub catatan: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KunjunganListArgs {
+    pub query: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub sumber: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KunjunganListResult {
+    pub items: Vec<KunjunganRow>,
+    pub total: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KunjunganCreateInput {
+    pub anggota_id: Option<i64>,
+    pub keperluan: Option<String>,
+    pub sumber: Option<String>,
+    pub jumlah_orang: Option<i64>,
+    pub kelas: Option<String>,
+    pub catatan: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KunjunganQuickStats {
+    pub hari_ini: i64,
+    pub minggu_ini: i64,
+    pub bulan_ini: i64,
+    pub total: i64,
+}
+
+fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<KunjunganRow> {
+    Ok(KunjunganRow {
+        id: row.get(0)?,
+        anggota_id: row.get(1)?,
+        anggota_nama: row.get(2)?,
+        anggota_kode: row.get(3)?,
+        anggota_kelas: row.get(4)?,
+        tanggal: row.get(5)?,
+        jam: row.get(6)?,
+        keperluan: row.get(7)?,
+        sumber: row.get(8)?,
+        jumlah_orang: row.get(9)?,
+        kelas: row.get(10)?,
+        catatan: row.get(11)?,
+        created_at: row.get(12)?,
+    })
+}
+
+const SELECT_FIELDS: &str = "
+    k.id,
+    k.anggota_id,
+    a.nama AS anggota_nama,
+    a.kode_anggota AS anggota_kode,
+    a.kelas AS anggota_kelas,
+    k.tanggal,
+    k.jam,
+    k.keperluan,
+    k.sumber,
+    k.jumlah_orang,
+    k.kelas,
+    k.catatan,
+    k.created_at
+";
+
+fn validate_date(value: &str, field: &str) -> AppResult<()> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map(|_| ())
+        .map_err(|_| AppError::Validation(format!("{field} bukan tanggal valid (YYYY-MM-DD)")))
+}
+
+#[tauri::command]
+pub fn kunjungan_list(
+    state: State<'_, AppState>,
+    args: Option<KunjunganListArgs>,
+) -> AppResult<KunjunganListResult> {
+    let args = args.unwrap_or_default();
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let mut conditions: Vec<String> = Vec::new();
+    let mut params_vec: Vec<Box<dyn ToSql>> = Vec::new();
+
+    if let Some(query) = args.query.as_ref().map(|q| q.trim()).filter(|q| !q.is_empty()) {
+        conditions.push("(LOWER(a.nama) LIKE ?1 OR LOWER(a.kode_anggota) LIKE ?1 OR LOWER(COALESCE(k.keperluan, '')) LIKE ?1)".into());
+        params_vec.push(Box::new(format!("%{}%", query.to_lowercase())));
+    }
+    if let Some(from) = args.from.as_ref().filter(|v| !v.is_empty()) {
+        validate_date(from, "from")?;
+        conditions.push(format!("k.tanggal >= ?{}", params_vec.len() + 1));
+        params_vec.push(Box::new(from.clone()));
+    }
+    if let Some(to) = args.to.as_ref().filter(|v| !v.is_empty()) {
+        validate_date(to, "to")?;
+        conditions.push(format!("k.tanggal <= ?{}", params_vec.len() + 1));
+        params_vec.push(Box::new(to.clone()));
+    }
+    if let Some(sumber) = args.sumber.as_ref().filter(|v| !v.is_empty() && v.as_str() != "all") {
+        conditions.push(format!("k.sumber = ?{}", params_vec.len() + 1));
+        params_vec.push(Box::new(sumber.clone()));
+    }
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+
+    let total_sql = format!(
+        "SELECT COUNT(*) FROM kunjungan k LEFT JOIN anggota a ON a.id = k.anggota_id {where_clause}"
+    );
+    let total: i64 = conn
+        .query_row(&total_sql, params_from_iter(params_vec.iter().map(|b| b.as_ref())), |r| r.get(0))
+        .map_err(AppError::from)?;
+
+    let limit = args.limit.unwrap_or(50).clamp(1, 500);
+    let offset = args.offset.unwrap_or(0).max(0);
+
+    let list_sql = format!(
+        "SELECT {SELECT_FIELDS}
+         FROM kunjungan k
+         LEFT JOIN anggota a ON a.id = k.anggota_id
+         {where_clause}
+         ORDER BY k.tanggal DESC, k.jam DESC, k.id DESC
+         LIMIT ?{} OFFSET ?{}",
+        params_vec.len() + 1,
+        params_vec.len() + 2,
+    );
+    params_vec.push(Box::new(limit));
+    params_vec.push(Box::new(offset));
+
+    let mut stmt = conn.prepare(&list_sql).map_err(AppError::from)?;
+    let rows = stmt
+        .query_map(
+            params_from_iter(params_vec.iter().map(|b| b.as_ref())),
+            map_row,
+        )
+        .map_err(AppError::from)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(AppError::from)?;
+
+    Ok(KunjunganListResult {
+        items: rows,
+        total,
+    })
+}
+
+#[tauri::command]
+pub fn kunjungan_create(
+    state: State<'_, AppState>,
+    input: KunjunganCreateInput,
+) -> AppResult<KunjunganRow> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let sumber = input.sumber.unwrap_or_else(|| "manual".to_string());
+    if !matches!(sumber.as_str(), "manual" | "peminjaman" | "pengembalian" | "kelas") {
+        return Err(AppError::Validation(format!("sumber '{sumber}' tidak dikenal")));
+    }
+    let jumlah = input.jumlah_orang.unwrap_or(1);
+    if jumlah < 1 {
+        return Err(AppError::Validation("jumlah_orang minimal 1".into()));
+    }
+
+    if let Some(aid) = input.anggota_id {
+        let exists: bool = conn
+            .query_row("SELECT 1 FROM anggota WHERE id = ?1", params![aid], |_| Ok(true))
+            .unwrap_or(false);
+        if !exists {
+            return Err(AppError::Validation(format!("anggota id={aid} tidak ditemukan")));
+        }
+    }
+
+    let id: i64 = conn
+        .query_row(
+            "INSERT INTO kunjungan (anggota_id, keperluan, sumber, jumlah_orang, kelas, catatan)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) RETURNING id",
+            params![
+                input.anggota_id,
+                input.keperluan,
+                sumber,
+                jumlah,
+                input.kelas,
+                input.catatan,
+            ],
+            |r| r.get(0),
+        )
+        .map_err(AppError::from)?;
+
+    let row = conn
+        .query_row(
+            &format!(
+                "SELECT {SELECT_FIELDS}
+                 FROM kunjungan k
+                 LEFT JOIN anggota a ON a.id = k.anggota_id
+                 WHERE k.id = ?1"
+            ),
+            params![id],
+            map_row,
+        )
+        .map_err(AppError::from)?;
+    Ok(row)
+}
+
+#[tauri::command]
+pub fn kunjungan_quick_stats(state: State<'_, AppState>) -> AppResult<KunjunganQuickStats> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let hari_ini: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(jumlah_orang), 0) FROM kunjungan WHERE tanggal = date('now', 'localtime')",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(AppError::from)?;
+    let minggu_ini: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(jumlah_orang), 0) FROM kunjungan
+             WHERE tanggal >= date('now', 'weekday 0', '-6 days', 'localtime')
+               AND tanggal <= date('now', 'localtime')",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(AppError::from)?;
+    let bulan_ini: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(jumlah_orang), 0) FROM kunjungan
+             WHERE tanggal >= date('now', 'start of month', 'localtime')
+               AND tanggal <= date('now', 'localtime')",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(AppError::from)?;
+    let total: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(jumlah_orang), 0) FROM kunjungan",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(AppError::from)?;
+    Ok(KunjunganQuickStats {
+        hari_ini,
+        minggu_ini,
+        bulan_ini,
+        total,
+    })
+}
+
+#[tauri::command]
+pub fn kunjungan_delete(state: State<'_, AppState>, id: i64) -> AppResult<()> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let affected = conn
+        .execute("DELETE FROM kunjungan WHERE id = ?1", params![id])
+        .map_err(AppError::from)?;
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("kunjungan id={id}")));
+    }
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod anggota;
 pub mod auth;
 pub mod buku;
 pub mod identity;
+pub mod kunjungan;
 pub mod master_data;
 pub mod peminjaman;
 pub mod window_state;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -70,6 +70,10 @@ pub fn run() {
             commands::peminjaman::pengembalian_search,
             commands::peminjaman::anggota_summary,
             commands::peminjaman::buku_summary,
+            commands::kunjungan::kunjungan_list,
+            commands::kunjungan::kunjungan_create,
+            commands::kunjungan::kunjungan_quick_stats,
+            commands::kunjungan::kunjungan_delete,
         ])
         .build(tauri::generate_context!())
         .expect("failed to build tauri app")

--- a/apps/desktop/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/buku', labelKey: 'common:menu.buku', Icon: BookOpen },
   { to: '/peminjaman', labelKey: 'common:menu.peminjaman', Icon: ArrowLeftRight },
   { to: '/pengembalian', labelKey: 'common:menu.pengembalian', Icon: Undo2 },
-  { to: '/kunjungan', labelKey: 'common:menu.kunjungan', Icon: CalendarCheck, pending: true },
+  { to: '/kunjungan', labelKey: 'common:menu.kunjungan', Icon: CalendarCheck },
   { to: '/laporan', labelKey: 'common:menu.laporan', Icon: BarChart3, pending: true },
   { to: '/settings', labelKey: 'common:menu.settings', Icon: Settings, pending: true },
 ];

--- a/apps/desktop/src/features/kunjungan/KunjunganBackdrop.tsx
+++ b/apps/desktop/src/features/kunjungan/KunjunganBackdrop.tsx
@@ -1,0 +1,53 @@
+/**
+ * Transparent SVG illustration backdrop (revisi #18).
+ *
+ * Placeholder asset until Devin 12 swaps in unDraw / Storyset PNG (revisi #6).
+ * Theme-aware via `currentColor`.
+ */
+export function KunjunganBackdrop() {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 -z-10 overflow-hidden opacity-[0.06] dark:opacity-[0.08]"
+      data-testid="kunjungan-backdrop"
+    >
+      <svg
+        className="absolute -right-12 -top-12 h-[420px] w-[420px] text-primary"
+        viewBox="0 0 200 200"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle cx="100" cy="100" r="90" stroke="currentColor" strokeWidth="2" />
+        <circle cx="100" cy="100" r="70" stroke="currentColor" strokeWidth="2" />
+        <path
+          d="M40 110 Q100 50 160 110"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          fill="none"
+        />
+        <rect x="60" y="115" width="80" height="40" rx="4" stroke="currentColor" strokeWidth="2" />
+        <line x1="70" y1="125" x2="130" y2="125" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="70" y1="135" x2="120" y2="135" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="70" y1="145" x2="110" y2="145" stroke="currentColor" strokeWidth="1.5" />
+      </svg>
+      <svg
+        className="absolute -bottom-16 -left-12 h-[360px] w-[360px] text-primary"
+        viewBox="0 0 200 200"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M30 160 L90 80 L130 130 L170 60"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          fill="none"
+        />
+        <circle cx="90" cy="80" r="6" fill="currentColor" />
+        <circle cx="130" cy="130" r="6" fill="currentColor" />
+        <circle cx="170" cy="60" r="6" fill="currentColor" />
+      </svg>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/kunjungan/KunjunganDialog.tsx
+++ b/apps/desktop/src/features/kunjungan/KunjunganDialog.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Autocomplete, type AutocompleteOption } from '@/components/shared/Autocomplete';
+import { useToast } from '@/components/ui/toast-manager';
+import { anggotaApi, type Anggota } from '@/lib/anggota';
+import { kunjunganApi } from '@/lib/kunjungan';
+
+const KEPERLUAN_OPTIONS = ['Membaca', 'Pinjam Buku', 'Tugas', 'Lainnya'];
+
+interface KunjunganDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated?: () => void;
+}
+
+export function KunjunganDialog({ open, onOpenChange, onCreated }: KunjunganDialogProps) {
+  const { t } = useTranslation(['kunjungan', 'common']);
+  const { showToast } = useToast();
+  const [anggotaList, setAnggotaList] = useState<Anggota[]>([]);
+  const [anggotaId, setAnggotaId] = useState<number | null>(null);
+  const [keperluan, setKeperluan] = useState<string>('Membaca');
+  const [catatan, setCatatan] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    anggotaApi
+      .list({ aktif: true, limit: 200 })
+      .then((res) => setAnggotaList(res.items))
+      .catch(() => setAnggotaList([]));
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      setAnggotaId(null);
+      setKeperluan('Membaca');
+      setCatatan('');
+      setError(null);
+    }
+  }, [open]);
+
+  const options = useMemo<AutocompleteOption[]>(
+    () =>
+      anggotaList.map((a) => ({
+        value: String(a.id),
+        label: a.nama,
+        hint: `${a.kodeAnggota}${a.kelas ? ` · ${a.kelas}` : ''}`,
+      })),
+    [anggotaList],
+  );
+
+  async function handleSubmit(): Promise<void> {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await kunjunganApi.create({
+        anggotaId,
+        keperluan,
+        catatan: catatan.trim() || null,
+        sumber: 'manual',
+      });
+      showToast({
+        title: t('kunjungan:feedback.created', { defaultValue: 'Kunjungan tercatat' }),
+      });
+      onCreated?.();
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {t('kunjungan:dialog.title', { defaultValue: 'Catat Kunjungan' })}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              {t('kunjungan:dialog.anggota', { defaultValue: 'Anggota (opsional)' })}
+            </label>
+            <Autocomplete
+              options={options}
+              value={anggotaId == null ? null : String(anggotaId)}
+              onChange={(v) => setAnggotaId(v ? Number(v) : null)}
+              placeholder={t('kunjungan:dialog.anggotaPlaceholder', {
+                defaultValue: 'Cari nama / NIS — atau biarkan kosong untuk kunjungan tamu',
+              })}
+              data-testid="kunjungan-anggota-autocomplete"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              {t('kunjungan:dialog.keperluan', { defaultValue: 'Keperluan' })}
+            </label>
+            <Select value={keperluan} onValueChange={setKeperluan}>
+              <SelectTrigger data-testid="kunjungan-keperluan">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {KEPERLUAN_OPTIONS.map((k) => (
+                  <SelectItem key={k} value={k}>
+                    {k}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              {t('kunjungan:dialog.catatan', { defaultValue: 'Catatan' })}
+            </label>
+            <Input
+              value={catatan}
+              onChange={(e) => setCatatan(e.target.value)}
+              placeholder={t('kunjungan:dialog.catatanPlaceholder', { defaultValue: 'Opsional' })}
+            />
+          </div>
+          {error && <p className="text-xs text-rose-600">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {t('common:actions.cancel', { defaultValue: 'Batal' })}
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting} data-testid="kunjungan-submit">
+            {submitting
+              ? t('common:states.loading', { defaultValue: 'Menyimpan…' })
+              : t('kunjungan:dialog.submit', { defaultValue: 'Simpan' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/features/kunjungan/KunjunganPage.tsx
+++ b/apps/desktop/src/features/kunjungan/KunjunganPage.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { DateRangePicker } from '@/components/ui/date-range-picker';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
+import { useToast } from '@/components/ui/toast-manager';
+import { kunjunganApi, rangeForPreset, type KunjunganRow } from '@/lib/kunjungan';
+import { KunjunganBackdrop } from './KunjunganBackdrop';
+import { KunjunganQuickStatsBar } from './QuickStats';
+import { KunjunganDialog } from './KunjunganDialog';
+
+const SUMBER_TONE: Record<KunjunganRow['sumber'], string> = {
+  manual: 'bg-primary/10 text-primary',
+  peminjaman: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  pengembalian: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
+  kelas: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+};
+
+export function KunjunganPage() {
+  const { t } = useTranslation(['kunjungan', 'common']);
+  const { showToast } = useToast();
+  const { query, debouncedQuery, setQuery } = useDebouncedSearch({ delay: 200 });
+  const [range, setRange] = useState(() => rangeForPreset('week'));
+  const [rows, setRows] = useState<KunjunganRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    kunjunganApi
+      .list({
+        query: debouncedQuery,
+        from: range.from,
+        to: range.to,
+        limit: 100,
+      })
+      .then((res) => {
+        if (cancel) return;
+        setRows(res.items);
+        setTotal(res.total);
+      })
+      .catch((err) => {
+        if (cancel) return;
+        showToast({
+          variant: 'destructive',
+          title: t('kunjungan:feedback.loadError', { defaultValue: 'Gagal memuat kunjungan' }),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [debouncedQuery, range, refreshKey, showToast, t]);
+
+  async function handleDelete(id: number): Promise<void> {
+    try {
+      await kunjunganApi.remove(id);
+      setRefreshKey((k) => k + 1);
+      showToast({
+        title: t('kunjungan:feedback.deleted', { defaultValue: 'Kunjungan dihapus' }),
+      });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('kunjungan:feedback.deleteError', { defaultValue: 'Gagal menghapus kunjungan' }),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return (
+    <div className="relative flex flex-col gap-6 p-6" data-testid="kunjungan-page">
+      <KunjunganBackdrop />
+
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">
+            {t('kunjungan:title', { defaultValue: 'Kunjungan' })}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {t('kunjungan:subtitle', {
+              defaultValue: 'Catat & monitor kunjungan harian perpustakaan',
+            })}
+          </p>
+        </div>
+        <Button onClick={() => setDialogOpen(true)} data-testid="kunjungan-add">
+          <Plus className="mr-2 h-4 w-4" />
+          {t('kunjungan:action.add', { defaultValue: 'Tambah Kunjungan' })}
+        </Button>
+      </div>
+
+      <KunjunganQuickStatsBar refreshKey={refreshKey} />
+
+      <Card>
+        <CardContent className="flex flex-col gap-4 p-4">
+          <div className="grid gap-3 lg:grid-cols-[1fr_auto]">
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t('kunjungan:searchPlaceholder', {
+                defaultValue: 'Cari nama / kode / keperluan',
+              })}
+              data-testid="kunjungan-search"
+            />
+            <DateRangePicker value={range} onChange={setRange} />
+          </div>
+
+          <div className="overflow-hidden rounded-lg border">
+            <table className="w-full text-sm" data-testid="kunjungan-table">
+              <thead className="bg-muted/40 text-left text-xs uppercase tracking-wider text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2">
+                    {t('kunjungan:column.tanggal', { defaultValue: 'Tanggal' })}
+                  </th>
+                  <th className="px-3 py-2">
+                    {t('kunjungan:column.jam', { defaultValue: 'Jam' })}
+                  </th>
+                  <th className="px-3 py-2">
+                    {t('kunjungan:column.anggota', { defaultValue: 'Anggota' })}
+                  </th>
+                  <th className="px-3 py-2">
+                    {t('kunjungan:column.kelas', { defaultValue: 'Kelas' })}
+                  </th>
+                  <th className="px-3 py-2">
+                    {t('kunjungan:column.keperluan', { defaultValue: 'Keperluan' })}
+                  </th>
+                  <th className="px-3 py-2">
+                    {t('kunjungan:column.sumber', { defaultValue: 'Sumber' })}
+                  </th>
+                  <th className="w-[1%] px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading && rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-3 py-8 text-center text-sm text-muted-foreground">
+                      {t('common:states.loading', { defaultValue: 'Memuat…' })}
+                    </td>
+                  </tr>
+                ) : rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-3 py-8 text-center text-sm text-muted-foreground">
+                      {t('kunjungan:empty', {
+                        defaultValue: 'Belum ada kunjungan pada rentang ini',
+                      })}
+                    </td>
+                  </tr>
+                ) : (
+                  rows.map((r) => (
+                    <tr key={r.id} className="border-t hover:bg-muted/30">
+                      <td className="px-3 py-2 font-medium">{r.tanggal}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{r.jam.slice(0, 5)}</td>
+                      <td className="px-3 py-2">
+                        {r.anggotaNama ? (
+                          <div className="flex flex-col">
+                            <span className="font-medium">{r.anggotaNama}</span>
+                            <span className="text-xs text-muted-foreground">{r.anggotaKode}</span>
+                          </div>
+                        ) : (
+                          <span className="text-xs italic text-muted-foreground">
+                            {t('kunjungan:guest', { defaultValue: 'Tamu' })}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {r.anggotaKelas ?? r.kelas ?? '—'}
+                      </td>
+                      <td className="px-3 py-2">{r.keperluan ?? '—'}</td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${SUMBER_TONE[r.sumber]}`}
+                        >
+                          {t(`kunjungan:sumber.${r.sumber}`, { defaultValue: r.sumber })}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        {r.sumber === 'manual' && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDelete(r.id)}
+                            aria-label={t('common:actions.delete', { defaultValue: 'Hapus' })}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              <Badge variant="outline">{total}</Badge>{' '}
+              {t('kunjungan:totalRecords', { defaultValue: 'kunjungan dalam rentang' })}
+            </span>
+            <span>
+              {range.from} → {range.to}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <KunjunganDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onCreated={() => setRefreshKey((k) => k + 1)}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/features/kunjungan/QuickStats.tsx
+++ b/apps/desktop/src/features/kunjungan/QuickStats.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CalendarCheck, CalendarDays, CalendarRange, Users } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { kunjunganApi, type KunjunganQuickStats } from '@/lib/kunjungan';
+
+interface StatProps {
+  Icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: number;
+  tone: 'primary' | 'sky' | 'emerald' | 'muted';
+}
+
+const TONE: Record<StatProps['tone'], string> = {
+  primary: 'bg-primary/10 text-primary',
+  sky: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
+  emerald: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  muted: 'bg-muted text-muted-foreground',
+};
+
+function StatCard({ Icon, label, value, tone }: StatProps) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${TONE[tone]}`}>
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">{label}</p>
+          <p className="text-2xl font-semibold leading-tight">{value}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function KunjunganQuickStatsBar({ refreshKey = 0 }: { refreshKey?: number }) {
+  const { t } = useTranslation('kunjungan');
+  const [stats, setStats] = useState<KunjunganQuickStats | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    kunjunganApi
+      .quickStats()
+      .then((s) => !cancel && setStats(s))
+      .catch(() => !cancel && setStats({ hariIni: 0, mingguIni: 0, bulanIni: 0, total: 0 }));
+    return () => {
+      cancel = true;
+    };
+  }, [refreshKey]);
+
+  return (
+    <div data-testid="kunjungan-quick-stats" className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        Icon={CalendarCheck}
+        tone="primary"
+        label={t('stats.hariIni', { defaultValue: 'Hari Ini' })}
+        value={stats?.hariIni ?? 0}
+      />
+      <StatCard
+        Icon={CalendarRange}
+        tone="sky"
+        label={t('stats.mingguIni', { defaultValue: 'Minggu Ini' })}
+        value={stats?.mingguIni ?? 0}
+      />
+      <StatCard
+        Icon={CalendarDays}
+        tone="emerald"
+        label={t('stats.bulanIni', { defaultValue: 'Bulan Ini' })}
+        value={stats?.bulanIni ?? 0}
+      />
+      <StatCard
+        Icon={Users}
+        tone="muted"
+        label={t('stats.total', { defaultValue: 'Total' })}
+        value={stats?.total ?? 0}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/i18n/en/kunjungan.json
+++ b/apps/desktop/src/i18n/en/kunjungan.json
@@ -1,4 +1,46 @@
 {
   "title": "Visits",
-  "placeholder": "Visits module will be built in Devin Session 7."
+  "subtitle": "Log & monitor daily library visits",
+  "searchPlaceholder": "Search by name / code / purpose",
+  "empty": "No visits in this range",
+  "guest": "Guest",
+  "totalRecords": "visits in range",
+  "stats": {
+    "hariIni": "Today",
+    "mingguIni": "This Week",
+    "bulanIni": "This Month",
+    "total": "Total"
+  },
+  "column": {
+    "tanggal": "Date",
+    "jam": "Time",
+    "anggota": "Member",
+    "kelas": "Class",
+    "keperluan": "Purpose",
+    "sumber": "Source"
+  },
+  "sumber": {
+    "manual": "Manual",
+    "peminjaman": "Borrow",
+    "pengembalian": "Return",
+    "kelas": "Class"
+  },
+  "action": {
+    "add": "Add Visit"
+  },
+  "dialog": {
+    "title": "Log Visit",
+    "anggota": "Member (optional)",
+    "anggotaPlaceholder": "Search name / ID — or leave blank for guest",
+    "keperluan": "Purpose",
+    "catatan": "Notes",
+    "catatanPlaceholder": "Optional",
+    "submit": "Save"
+  },
+  "feedback": {
+    "loadError": "Failed to load visits",
+    "created": "Visit logged",
+    "deleted": "Visit removed",
+    "deleteError": "Failed to remove visit"
+  }
 }

--- a/apps/desktop/src/i18n/id/kunjungan.json
+++ b/apps/desktop/src/i18n/id/kunjungan.json
@@ -1,4 +1,46 @@
 {
   "title": "Kunjungan",
-  "placeholder": "Modul kunjungan akan dibuat di Devin Session 7."
+  "subtitle": "Catat & monitor kunjungan harian perpustakaan",
+  "searchPlaceholder": "Cari nama / kode / keperluan",
+  "empty": "Belum ada kunjungan pada rentang ini",
+  "guest": "Tamu",
+  "totalRecords": "kunjungan dalam rentang",
+  "stats": {
+    "hariIni": "Hari Ini",
+    "mingguIni": "Minggu Ini",
+    "bulanIni": "Bulan Ini",
+    "total": "Total"
+  },
+  "column": {
+    "tanggal": "Tanggal",
+    "jam": "Jam",
+    "anggota": "Anggota",
+    "kelas": "Kelas",
+    "keperluan": "Keperluan",
+    "sumber": "Sumber"
+  },
+  "sumber": {
+    "manual": "Manual",
+    "peminjaman": "Pinjam",
+    "pengembalian": "Kembali",
+    "kelas": "Kelas"
+  },
+  "action": {
+    "add": "Tambah Kunjungan"
+  },
+  "dialog": {
+    "title": "Catat Kunjungan",
+    "anggota": "Anggota (opsional)",
+    "anggotaPlaceholder": "Cari nama / NIS — atau biarkan kosong untuk tamu",
+    "keperluan": "Keperluan",
+    "catatan": "Catatan",
+    "catatanPlaceholder": "Opsional",
+    "submit": "Simpan"
+  },
+  "feedback": {
+    "loadError": "Gagal memuat kunjungan",
+    "created": "Kunjungan tercatat",
+    "deleted": "Kunjungan dihapus",
+    "deleteError": "Gagal menghapus kunjungan"
+  }
 }

--- a/apps/desktop/src/lib/kunjungan.ts
+++ b/apps/desktop/src/lib/kunjungan.ts
@@ -1,0 +1,224 @@
+import { isTauri } from '@/lib/auth';
+
+export interface KunjunganRow {
+  id: number;
+  anggotaId?: number | null;
+  anggotaNama?: string | null;
+  anggotaKode?: string | null;
+  anggotaKelas?: string | null;
+  tanggal: string;
+  jam: string;
+  keperluan?: string | null;
+  sumber: 'manual' | 'peminjaman' | 'pengembalian' | 'kelas';
+  jumlahOrang: number;
+  kelas?: string | null;
+  catatan?: string | null;
+  createdAt: string;
+}
+
+export interface KunjunganListArgs {
+  query?: string;
+  from?: string;
+  to?: string;
+  sumber?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface KunjunganListResult {
+  items: KunjunganRow[];
+  total: number;
+}
+
+export interface KunjunganCreateInput {
+  anggotaId?: number | null;
+  keperluan?: string | null;
+  sumber?: 'manual' | 'peminjaman' | 'pengembalian' | 'kelas';
+  jumlahOrang?: number | null;
+  kelas?: string | null;
+  catatan?: string | null;
+}
+
+export interface KunjunganQuickStats {
+  hariIni: number;
+  mingguIni: number;
+  bulanIni: number;
+  total: number;
+}
+
+interface KunjunganRpc {
+  list(args: KunjunganListArgs): Promise<KunjunganListResult>;
+  create(input: KunjunganCreateInput): Promise<KunjunganRow>;
+  quickStats(): Promise<KunjunganQuickStats>;
+  remove(id: number): Promise<void>;
+}
+
+// ----------------------------------------------------------------------------
+// Mock store (browser dev mode)
+// ----------------------------------------------------------------------------
+
+const STORAGE_KEY = 'po:kunjungan-mock';
+
+interface MockState {
+  rows: KunjunganRow[];
+  seq: number;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function timeNow(): string {
+  return new Date().toTimeString().slice(0, 8);
+}
+
+function readMock(): MockState {
+  if (typeof window === 'undefined') return { rows: [], seq: 0 };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      const seed: MockState = { rows: [], seq: 0 };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(seed));
+      return seed;
+    }
+    return JSON.parse(raw) as MockState;
+  } catch {
+    return { rows: [], seq: 0 };
+  }
+}
+
+function writeMock(state: MockState): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function dayDiff(a: string, b: string): number {
+  const da = new Date(a + 'T00:00:00Z').getTime();
+  const db = new Date(b + 'T00:00:00Z').getTime();
+  return Math.floor((da - db) / (1000 * 60 * 60 * 24));
+}
+
+const tauriRpc: KunjunganRpc = {
+  async list(args) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<KunjunganListResult>('kunjungan_list', { args });
+  },
+  async create(input) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<KunjunganRow>('kunjungan_create', { input });
+  },
+  async quickStats() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<KunjunganQuickStats>('kunjungan_quick_stats');
+  },
+  async remove(id) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('kunjungan_delete', { id });
+  },
+};
+
+const mockRpc: KunjunganRpc = {
+  async list(args) {
+    const state = readMock();
+    let filtered = state.rows;
+    const q = args.query?.trim().toLowerCase();
+    if (q) {
+      filtered = filtered.filter(
+        (r) =>
+          (r.anggotaNama ?? '').toLowerCase().includes(q) ||
+          (r.anggotaKode ?? '').toLowerCase().includes(q) ||
+          (r.keperluan ?? '').toLowerCase().includes(q),
+      );
+    }
+    if (args.from) filtered = filtered.filter((r) => r.tanggal >= args.from!);
+    if (args.to) filtered = filtered.filter((r) => r.tanggal <= args.to!);
+    if (args.sumber && args.sumber !== 'all') {
+      filtered = filtered.filter((r) => r.sumber === args.sumber);
+    }
+    const total = filtered.length;
+    const limit = args.limit ?? 50;
+    const offset = args.offset ?? 0;
+    const items = filtered
+      .slice()
+      .sort((a, b) => `${b.tanggal} ${b.jam}`.localeCompare(`${a.tanggal} ${a.jam}`))
+      .slice(offset, offset + limit);
+    return { items, total };
+  },
+  async create(input) {
+    const state = readMock();
+    const id = ++state.seq;
+    const row: KunjunganRow = {
+      id,
+      anggotaId: input.anggotaId ?? null,
+      anggotaNama: input.anggotaId ? `Anggota ${input.anggotaId}` : null,
+      anggotaKode: input.anggotaId ? `A${String(input.anggotaId).padStart(4, '0')}` : null,
+      anggotaKelas: null,
+      tanggal: todayIso(),
+      jam: timeNow(),
+      keperluan: input.keperluan ?? null,
+      sumber: input.sumber ?? 'manual',
+      jumlahOrang: input.jumlahOrang ?? 1,
+      kelas: input.kelas ?? null,
+      catatan: input.catatan ?? null,
+      createdAt: nowIso(),
+    };
+    state.rows.unshift(row);
+    writeMock(state);
+    return row;
+  },
+  async quickStats() {
+    const state = readMock();
+    const today = todayIso();
+    const start = new Date();
+    start.setDate(start.getDate() - 6);
+    const weekStart = start.toISOString().slice(0, 10);
+    const monthStart = today.slice(0, 8) + '01';
+    const sum = (rows: KunjunganRow[]) => rows.reduce((acc, r) => acc + r.jumlahOrang, 0);
+    return {
+      hariIni: sum(state.rows.filter((r) => r.tanggal === today)),
+      mingguIni: sum(state.rows.filter((r) => r.tanggal >= weekStart && r.tanggal <= today)),
+      bulanIni: sum(state.rows.filter((r) => r.tanggal >= monthStart && r.tanggal <= today)),
+      total: sum(state.rows),
+    };
+  },
+  async remove(id) {
+    const state = readMock();
+    state.rows = state.rows.filter((r) => r.id !== id);
+    writeMock(state);
+  },
+};
+
+export const kunjunganApi: KunjunganRpc = isTauri() ? tauriRpc : mockRpc;
+
+export function rangeForPreset(
+  preset: 'today' | 'week' | 'month' | 'year',
+): { from: string; to: string } {
+  const now = new Date();
+  const to = now.toISOString().slice(0, 10);
+  switch (preset) {
+    case 'today':
+      return { from: to, to };
+    case 'week': {
+      const d = new Date(now);
+      d.setDate(d.getDate() - 6);
+      return { from: d.toISOString().slice(0, 10), to };
+    }
+    case 'month': {
+      const d = new Date(now);
+      d.setDate(1);
+      return { from: d.toISOString().slice(0, 10), to };
+    }
+    case 'year': {
+      const d = new Date(now);
+      d.setMonth(0, 1);
+      return { from: d.toISOString().slice(0, 10), to };
+    }
+  }
+}
+
+// Reuse for pure unit testing — same logic the backend uses.
+export { dayDiff as kunjunganDayDiff };

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthedKunjunganRouteImport } from './routes/_authed/kunjungan'
 import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard'
 import { Route as AuthedPengembalianIndexRouteImport } from './routes/_authed/pengembalian/index'
 import { Route as AuthedPeminjamanIndexRouteImport } from './routes/_authed/peminjaman/index'
@@ -38,6 +39,11 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthedKunjunganRoute = AuthedKunjunganRouteImport.update({
+  id: '/kunjungan',
+  path: '/kunjungan',
+  getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedDashboardRoute = AuthedDashboardRouteImport.update({
   id: '/dashboard',
@@ -105,6 +111,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/dashboard': typeof AuthedDashboardRoute
+  '/kunjungan': typeof AuthedKunjunganRoute
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
   '/buku/$id': typeof AuthedBukuIdRoute
@@ -121,6 +128,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/dashboard': typeof AuthedDashboardRoute
+  '/kunjungan': typeof AuthedKunjunganRoute
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
   '/buku/$id': typeof AuthedBukuIdRoute
@@ -139,6 +147,7 @@ export interface FileRoutesById {
   '/_authed': typeof AuthedRouteWithChildren
   '/login': typeof LoginRoute
   '/_authed/dashboard': typeof AuthedDashboardRoute
+  '/_authed/kunjungan': typeof AuthedKunjunganRoute
   '/_authed/anggota/$id': typeof AuthedAnggotaIdRoute
   '/_authed/anggota/new': typeof AuthedAnggotaNewRoute
   '/_authed/buku/$id': typeof AuthedBukuIdRoute
@@ -157,6 +166,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/dashboard'
+    | '/kunjungan'
     | '/anggota/$id'
     | '/anggota/new'
     | '/buku/$id'
@@ -173,6 +183,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/dashboard'
+    | '/kunjungan'
     | '/anggota/$id'
     | '/anggota/new'
     | '/buku/$id'
@@ -190,6 +201,7 @@ export interface FileRouteTypes {
     | '/_authed'
     | '/login'
     | '/_authed/dashboard'
+    | '/_authed/kunjungan'
     | '/_authed/anggota/$id'
     | '/_authed/anggota/new'
     | '/_authed/buku/$id'
@@ -231,6 +243,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_authed/kunjungan': {
+      id: '/_authed/kunjungan'
+      path: '/kunjungan'
+      fullPath: '/kunjungan'
+      preLoaderRoute: typeof AuthedKunjunganRouteImport
+      parentRoute: typeof AuthedRoute
     }
     '/_authed/dashboard': {
       id: '/_authed/dashboard'
@@ -321,6 +340,7 @@ declare module '@tanstack/react-router' {
 
 interface AuthedRouteChildren {
   AuthedDashboardRoute: typeof AuthedDashboardRoute
+  AuthedKunjunganRoute: typeof AuthedKunjunganRoute
   AuthedAnggotaIdRoute: typeof AuthedAnggotaIdRoute
   AuthedAnggotaNewRoute: typeof AuthedAnggotaNewRoute
   AuthedBukuIdRoute: typeof AuthedBukuIdRoute
@@ -336,6 +356,7 @@ interface AuthedRouteChildren {
 
 const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedDashboardRoute: AuthedDashboardRoute,
+  AuthedKunjunganRoute: AuthedKunjunganRoute,
   AuthedAnggotaIdRoute: AuthedAnggotaIdRoute,
   AuthedAnggotaNewRoute: AuthedAnggotaNewRoute,
   AuthedBukuIdRoute: AuthedBukuIdRoute,

--- a/apps/desktop/src/routes/_authed/kunjungan.tsx
+++ b/apps/desktop/src/routes/_authed/kunjungan.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { KunjunganPage } from '@/features/kunjungan/KunjunganPage';
+
+export const Route = createFileRoute('/_authed/kunjungan')({
+  component: KunjunganPage,
+});

--- a/apps/desktop/tests/e2e/kunjungan.spec.ts
+++ b/apps/desktop/tests/e2e/kunjungan.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+async function login(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/login');
+  await page.evaluate(() => {
+    localStorage.removeItem('po:auth');
+    localStorage.removeItem('po:kunjungan-mock');
+  });
+  await page.reload();
+  await page.getByLabel(/Nama Pengguna|Username/).fill('admin');
+  await page.getByLabel(/Kata Sandi|Password/).fill('admin123');
+  await page.getByRole('button', { name: /Masuk|Sign in/ }).click();
+  await expect(page).toHaveURL(/\/dashboard/);
+}
+
+test.describe('kunjungan page (browser dev mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await login(page);
+    await page.goto('/kunjungan');
+    await expect(page.getByTestId('kunjungan-page')).toBeVisible();
+  });
+
+  test('renders page with quick stats and table empty state', async ({ page }) => {
+    await expect(page.getByTestId('kunjungan-quick-stats')).toBeVisible();
+    await expect(page.getByTestId('kunjungan-table')).toBeVisible();
+    await expect(page.getByText(/Belum ada kunjungan|No visits in this range/)).toBeVisible();
+  });
+
+  test('opens add dialog and shows keperluan select', async ({ page }) => {
+    await page.getByTestId('kunjungan-add').click();
+    await expect(page.getByTestId('kunjungan-keperluan')).toBeVisible();
+    await expect(page.getByTestId('kunjungan-submit')).toBeVisible();
+  });
+
+  test('adds a manual visit which appears in table and bumps stats', async ({ page }) => {
+    await page.getByTestId('kunjungan-add').click();
+    await page.getByTestId('kunjungan-submit').click();
+    // Dialog should close + new row visible
+    await expect(page.getByText(/Membaca/)).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/apps/desktop/tests/unit/kunjungan.test.ts
+++ b/apps/desktop/tests/unit/kunjungan.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { kunjunganApi, kunjunganDayDiff, rangeForPreset } from '@/lib/kunjungan';
+
+describe('rangeForPreset', () => {
+  it('today returns from === to', () => {
+    const r = rangeForPreset('today');
+    expect(r.from).toBe(r.to);
+  });
+
+  it('week returns 7-day window ending today', () => {
+    const r = rangeForPreset('week');
+    expect(kunjunganDayDiff(r.to, r.from)).toBe(6);
+  });
+
+  it('month range starts at day 01 of current month', () => {
+    const r = rangeForPreset('month');
+    expect(r.from.endsWith('-01')).toBe(true);
+  });
+
+  it('year range starts at January 1st', () => {
+    const r = rangeForPreset('year');
+    expect(r.from.endsWith('-01-01')).toBe(true);
+  });
+});
+
+describe('kunjunganApi (browser mock)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('starts empty and increments after create', async () => {
+    const before = await kunjunganApi.list({});
+    expect(before.total).toBe(0);
+
+    await kunjunganApi.create({ keperluan: 'Membaca' });
+    const after = await kunjunganApi.list({});
+    expect(after.total).toBe(1);
+    expect(after.items[0]?.sumber).toBe('manual');
+  });
+
+  it('quickStats reflects today + total', async () => {
+    await kunjunganApi.create({ keperluan: 'Membaca' });
+    await kunjunganApi.create({ anggotaId: 1, keperluan: 'Pinjam Buku' });
+    const stats = await kunjunganApi.quickStats();
+    expect(stats.hariIni).toBe(2);
+    expect(stats.total).toBe(2);
+  });
+
+  it('search filters by query', async () => {
+    await kunjunganApi.create({ anggotaId: 7, keperluan: 'Tugas' });
+    await kunjunganApi.create({ anggotaId: 8, keperluan: 'Membaca' });
+    const matches = await kunjunganApi.list({ query: 'tugas' });
+    expect(matches.total).toBe(1);
+    expect(matches.items[0]?.keperluan).toBe('Tugas');
+  });
+
+  it('remove deletes a row', async () => {
+    const created = await kunjunganApi.create({ keperluan: 'Membaca' });
+    await kunjunganApi.remove(created.id);
+    const after = await kunjunganApi.list({});
+    expect(after.total).toBe(0);
+  });
+});

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -21,7 +21,7 @@ project: perpustakaan-offline
 migration: v1 (python+customtkinter) -> v2 (tauri 2.0 + react 18 + ts + tailwind 3 + shadcn + zustand)
 total_sessions: 12
 schema_version: 1
-last_updated: 2026-05-03 (session 06)
+last_updated: 2026-05-03 (session 07)
 ```
 
 ## Sessions
@@ -76,10 +76,11 @@ sessions:
 
   - id: 7
     title: Kunjungan redesign (transparent illustrations, quick stats, filter date range)
-    status: PENDING
+    status: COMPLETED
     pr: PENDING
-    completed_at: null
+    completed_at: 2026-05-03
     dependencies: [3, 4]
+    note: Bundled by Devin 4 sebagai stacked PR di atas #43.
 
   - id: 8
     title: Dashboard modern dengan charts (3 hero card + donut + bar + featured row)
@@ -127,7 +128,7 @@ sessions:
 | 4 | Data Anggota CRUD + search/autocomplete | COMPLETED | [#41](https://github.com/alviarts/perpustakaan-offline/pull/41) | 2026-05-03 | 3 |
 | 5 | Data Buku CRUD + Master Data | COMPLETED | [#42](https://github.com/alviarts/perpustakaan-offline/pull/42) | 2026-05-03 | 4 |
 | 6 | Peminjaman + Pengembalian | COMPLETED | [#43](https://github.com/alviarts/perpustakaan-offline/pull/43) | 2026-05-03 | 4, 5 |
-| 7 | Kunjungan redesign | PENDING | PENDING | — | 3, 4 |
+| 7 | Kunjungan redesign | COMPLETED | PENDING | 2026-05-03 | 3, 4 |
 | 8 | Dashboard modern + charts | PENDING | PENDING | — | 4, 5, 6 |
 | 9 | Laporan komplit | PENDING | PENDING | — | 6, 7, 8 |
 | 10 | KTA system | PENDING | PENDING | — | 4, 5 |

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -77,7 +77,7 @@ sessions:
   - id: 7
     title: Kunjungan redesign (transparent illustrations, quick stats, filter date range)
     status: COMPLETED
-    pr: PENDING
+    pr: https://github.com/alviarts/perpustakaan-offline/pull/44
     completed_at: 2026-05-03
     dependencies: [3, 4]
     note: Bundled by Devin 4 sebagai stacked PR di atas #43.
@@ -128,7 +128,7 @@ sessions:
 | 4 | Data Anggota CRUD + search/autocomplete | COMPLETED | [#41](https://github.com/alviarts/perpustakaan-offline/pull/41) | 2026-05-03 | 3 |
 | 5 | Data Buku CRUD + Master Data | COMPLETED | [#42](https://github.com/alviarts/perpustakaan-offline/pull/42) | 2026-05-03 | 4 |
 | 6 | Peminjaman + Pengembalian | COMPLETED | [#43](https://github.com/alviarts/perpustakaan-offline/pull/43) | 2026-05-03 | 4, 5 |
-| 7 | Kunjungan redesign | COMPLETED | PENDING | 2026-05-03 | 3, 4 |
+| 7 | Kunjungan redesign | COMPLETED | [#44](https://github.com/alviarts/perpustakaan-offline/pull/44) | 2026-05-03 | 3, 4 |
 | 8 | Dashboard modern + charts | PENDING | PENDING | — | 4, 5, 6 |
 | 9 | Laporan komplit | PENDING | PENDING | — | 6, 7, 8 |
 | 10 | KTA system | PENDING | PENDING | — | 4, 5 |


### PR DESCRIPTION
## Summary

Sesi 7/12 — halaman Kunjungan modern dengan ilustrasi transparent, quick stats, filter date range, dan dialog tambah kunjungan satu-klik. Stacked di atas PR #43 (sesi 6).

**Goal sesi:** redesign Kunjungan biar match mockup v2 — backdrop SVG transparent (theme-aware), 4 quick stat card real-time, filter date range + live search, autocomplete anggota untuk insert cepat.

### Revisi tercover
- **#18** Fix Kunjungan animasi bg transparent + quick stat card + filter date range — full.

### Deliverables
- [x] **Backend Rust** `apps/desktop/src-tauri/src/commands/kunjungan.rs` — 4 command:
  - `kunjungan_list` (filter `query`, `from`, `to`, `sumber`, paging, ORDER tanggal/jam DESC)
  - `kunjungan_create` (optional `anggota_id` untuk tamu, validasi `sumber` enum, autoset tanggal/jam server-side)
  - `kunjungan_quick_stats` (`hari_ini`, `minggu_ini`, `bulan_ini`, `total` — pakai `SUM(jumlah_orang)` agar baris kelas dengan `jumlah_orang > 1` ikut kehitung)
  - `kunjungan_delete` (validasi NotFound)
- [x] **Lib** `src/lib/kunjungan.ts` — API wrapper Tauri RPC + browser mock (localStorage), `rangeForPreset` helper untuk today/week/month/year
- [x] **Halaman `/kunjungan`** dengan layout:
  - **Backdrop** SVG transparent theme-aware (placeholder, swap unDraw di sesi 12 #6)
  - **Quick stats bar** — 4 card (Hari Ini / Minggu Ini / Bulan Ini / Total) dengan icon + tone berbeda
  - **Toolbar** — search input debounced 200ms (reuse hook sesi 4) + `DateRangePicker` (reuse komponen sesi 6) + tombol Tambah
  - **Table** kolom Tanggal / Jam / Anggota (2-line) / Kelas / Keperluan / Sumber (badge bertone) / Action
  - Manual entries dapat dihapus; entries dari peminjaman/pengembalian read-only
- [x] **Dialog Tambah Kunjungan** — Autocomplete anggota (opsional → tamu), Select keperluan (Membaca/Pinjam Buku/Tugas/Lainnya), input Catatan
- [x] **Sidebar** — Kunjungan unlocked (no longer 'soon' state)
- [x] **i18n** id/en kunjungan.json (stats/column/sumber/dialog/feedback)

### Tests added
- **Unit (8 baru):** `tests/unit/kunjungan.test.ts`
  - `rangeForPreset` — today (from===to), week (7-day window), month (start of month), year (Jan 1)
  - `kunjunganApi` mock CRUD: empty initial, create increment, quickStats today+total, search filter by keperluan, remove
- **E2E (3 baru):** `tests/e2e/kunjungan.spec.ts`
  - Page render + quick stats + table empty state
  - Dialog open dengan keperluan select & submit button
  - Tambah manual visit → row muncul di table

Total tes naik dari 59 → **67** (semua hijau lokal).

### Lokal verification
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (11 file, 67 test), `pnpm build` semua hijau
- `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` semua hijau

## Review & Testing Checklist for Human

Risk: **green** — fitur new-add yang tidak menyentuh sesi sebelumnya, full reuse komponen DatePicker + Autocomplete.

- [ ] Buka `/kunjungan` → cek backdrop SVG transparent muncul light + dark theme.
- [ ] Quick stats bar nunjukin 4 card dengan icon + tone berbeda.
- [ ] Date range picker — klik preset "30 hari terakhir" → table refresh.
- [ ] Klik "Tambah Kunjungan" → pilih anggota dari autocomplete (atau biarkan kosong untuk tamu) → pilih keperluan → submit. Row baru muncul di tabel + quick stat hari ini +1.
- [ ] Sumber `manual` punya tombol hapus (trash icon); sumber `peminjaman`/`pengembalian` read-only.
- [ ] Toggle ID ↔ EN → label kolom + tone badge ikut switch.
- [ ] Search ketik 2+ char → table filter live (debounced 200ms).

### Notes

- **Stacked di atas PR #43 (sesi 6)** — review setelah PR #43 di-merge, atau merge sequential 41 → 42 → 43 → 44.
- Backdrop SVG sengaja kept generic & theme-aware (`currentColor`) — Devin 12 (#6) bakal swap dengan asset unDraw/Storyset hi-res.
- `sumber=peminjaman` dan `sumber=pengembalian` rows otomatis ke-insert oleh command sesi 6 (peminjaman_create/peminjaman_kembalikan), sehingga tab Kunjungan ini menampilkan _semua_ traffic perpustakaan, bukan cuma manual entries.

Footer: **Devin session 7/12.**