### PR TITLE
feat(session-09): laporan komplit (grafik + top + kas + backup)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2757,6 +2757,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ env_logger = "0.11"
 rand = "0.8"
 hex = "0.4"
 chrono = { version = "0.4", features = ["clock"] }
+sha2 = "0.10"
 
 [features]
 default = ["custom-protocol"]

--- a/apps/desktop/src-tauri/src/commands/backup.rs
+++ b/apps/desktop/src-tauri/src/commands/backup.rs
@@ -1,0 +1,203 @@
+//! DB backup / restore + schedule helpers (revisi #23 — Backup section).
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use chrono::Local;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tauri::{Manager, State};
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupResult {
+    pub path: String,
+    pub checksum: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupSchedule {
+    pub enabled: bool,
+    pub cron: String,
+    pub last_run: Option<String>,
+}
+
+fn db_file_path(app: &tauri::AppHandle) -> AppResult<PathBuf> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::Internal(format!("app_data_dir: {e}")))?;
+    Ok(dir.join("perpustakaan.db"))
+}
+
+fn sha256_of(path: &PathBuf) -> AppResult<String> {
+    let mut file = fs::File::open(path).map_err(|e| AppError::Internal(e.to_string()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buf).map_err(|e| AppError::Internal(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+#[tauri::command]
+pub fn backup_create(app: tauri::AppHandle, target_dir: String) -> AppResult<BackupResult> {
+    let src = db_file_path(&app)?;
+    if !src.exists() {
+        return Err(AppError::NotFound("perpustakaan.db not found".into()));
+    }
+    let target_dir_path = PathBuf::from(&target_dir);
+    if !target_dir_path.exists() {
+        return Err(AppError::Validation(format!(
+            "target dir tidak ditemukan: {target_dir}"
+        )));
+    }
+
+    let stamp = Local::now().format("%Y%m%d-%H%M%S");
+    let dst = target_dir_path.join(format!("perpustakaan-{stamp}.db"));
+
+    let mut input = fs::File::open(&src).map_err(|e| AppError::Internal(e.to_string()))?;
+    let mut output = fs::File::create(&dst).map_err(|e| AppError::Internal(e.to_string()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    let mut total = 0u64;
+    loop {
+        let n = input
+            .read(&mut buf)
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        output
+            .write_all(&buf[..n])
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        total += n as u64;
+    }
+
+    let checksum = hex::encode(hasher.finalize());
+    let sidecar = dst.with_extension("db.sha256");
+    fs::write(&sidecar, &checksum).map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(BackupResult {
+        path: dst.to_string_lossy().to_string(),
+        checksum,
+        size_bytes: total,
+    })
+}
+
+#[tauri::command]
+pub fn backup_restore(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    file_path: String,
+    expected_checksum: Option<String>,
+) -> AppResult<BackupResult> {
+    let src = PathBuf::from(&file_path);
+    if !src.exists() {
+        return Err(AppError::NotFound(format!("file tidak ditemukan: {file_path}")));
+    }
+
+    let actual = sha256_of(&src)?;
+    if let Some(expected) = expected_checksum.as_ref() {
+        if !expected.eq_ignore_ascii_case(&actual) {
+            return Err(AppError::Validation(
+                "checksum tidak cocok, file backup mungkin korup".into(),
+            ));
+        }
+    }
+
+    // Lock DB sebentar untuk pastikan tidak ada transaksi aktif.
+    {
+        let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        let _ = conn.execute_batch("VACUUM");
+    }
+
+    let dst = db_file_path(&app)?;
+    let backup_old = dst.with_extension("db.preview-restore");
+    if dst.exists() {
+        fs::copy(&dst, &backup_old).map_err(|e| AppError::Internal(e.to_string()))?;
+    }
+    fs::copy(&src, &dst).map_err(|e| AppError::Internal(e.to_string()))?;
+    let size = fs::metadata(&dst)
+        .map(|m| m.len())
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(BackupResult {
+        path: dst.to_string_lossy().to_string(),
+        checksum: actual,
+        size_bytes: size,
+    })
+}
+
+#[tauri::command]
+pub fn backup_schedule_get(state: State<'_, AppState>) -> AppResult<BackupSchedule> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let read = |key: &str| -> Option<String> {
+        conn.query_row(
+            "SELECT value FROM settings WHERE key = ?1",
+            [key],
+            |r| r.get::<_, String>(0),
+        )
+        .ok()
+    };
+
+    let enabled = read("backup.schedule.enabled")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+    let cron = read("backup.schedule.cron").unwrap_or_else(|| "0 2 * * *".to_string());
+    let last_run = read("backup.schedule.last_run");
+
+    Ok(BackupSchedule {
+        enabled,
+        cron,
+        last_run,
+    })
+}
+
+#[tauri::command]
+pub fn backup_schedule_set(
+    state: State<'_, AppState>,
+    enabled: bool,
+    cron: String,
+) -> AppResult<BackupSchedule> {
+    if cron.split_whitespace().count() != 5 {
+        return Err(AppError::Validation(
+            "Cron harus 5 field (mis. \"0 2 * * *\")".into(),
+        ));
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES ('backup.schedule.enabled', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
+        [if enabled { "true" } else { "false" }],
+    )
+    .map_err(AppError::from)?;
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES ('backup.schedule.cron', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
+        [&cron],
+    )
+    .map_err(AppError::from)?;
+
+    drop(conn);
+    backup_schedule_get(state)
+}
+
+#[tauri::command]
+pub fn backup_db_path(app: tauri::AppHandle) -> AppResult<String> {
+    let p = db_file_path(&app)?;
+    Ok(p.to_string_lossy().to_string())
+}

--- a/apps/desktop/src-tauri/src/commands/laporan.rs
+++ b/apps/desktop/src-tauri/src/commands/laporan.rs
@@ -1,0 +1,296 @@
+//! Laporan / report aggregate queries (revisi #23).
+
+use rusqlite::params;
+use serde::Serialize;
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrafikBucket {
+    pub bucket: String,
+    pub kunjungan: i64,
+    pub peminjaman: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopPeminjamRow {
+    pub anggota_id: i64,
+    pub nama: String,
+    pub kode_anggota: String,
+    pub kelas: Option<String>,
+    pub jumlah_pinjam: i64,
+    pub jumlah_buku: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopBukuRow {
+    pub buku_id: i64,
+    pub kode: String,
+    pub judul: String,
+    pub pengarang: Option<String>,
+    pub jumlah: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KasRow {
+    pub id: i64,
+    pub tanggal: String,
+    pub keterangan: String,
+    pub jenis: String,
+    pub sumber: String,
+    pub nominal: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KasSummary {
+    pub total_masuk: i64,
+    pub total_keluar: i64,
+    pub saldo_akhir: i64,
+    pub from_denda: i64,
+    pub from_manual: i64,
+    pub from_hilang: i64,
+    pub from_modal: i64,
+    pub rows: Vec<KasRow>,
+    pub cumulative: Vec<KasCumulative>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KasCumulative {
+    pub tanggal: String,
+    pub saldo: i64,
+}
+
+fn bucket_format(granularity: &str) -> &'static str {
+    match granularity {
+        "year" => "%Y",
+        "month" => "%Y-%m",
+        _ => "%Y-%m-%d",
+    }
+}
+
+#[tauri::command]
+pub fn laporan_grafik(
+    state: State<'_, AppState>,
+    from: String,
+    to: String,
+    granularity: Option<String>,
+) -> AppResult<Vec<GrafikBucket>> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let g = granularity.unwrap_or_else(|| "day".to_string());
+    let fmt = bucket_format(&g);
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT b.bucket,
+                    COALESCE(SUM(k.kunjungan), 0) AS kunjungan,
+                    COALESCE(SUM(p.peminjaman), 0) AS peminjaman
+             FROM (
+                SELECT strftime(?1, tanggal) AS bucket FROM kunjungan
+                WHERE tanggal BETWEEN ?2 AND ?3
+                UNION
+                SELECT strftime(?1, tanggal_pinjam) AS bucket FROM peminjaman
+                WHERE tanggal_pinjam BETWEEN ?2 AND ?3
+             ) AS b
+             LEFT JOIN (
+                SELECT strftime(?1, tanggal) AS bucket,
+                       SUM(jumlah_orang) AS kunjungan
+                FROM kunjungan
+                WHERE tanggal BETWEEN ?2 AND ?3
+                GROUP BY bucket
+             ) AS k ON k.bucket = b.bucket
+             LEFT JOIN (
+                SELECT strftime(?1, tanggal_pinjam) AS bucket,
+                       COUNT(*) AS peminjaman
+                FROM peminjaman
+                WHERE tanggal_pinjam BETWEEN ?2 AND ?3
+                GROUP BY bucket
+             ) AS p ON p.bucket = b.bucket
+             GROUP BY b.bucket
+             ORDER BY b.bucket",
+        )
+        .map_err(AppError::from)?;
+    let rows = stmt
+        .query_map(params![fmt, from, to], |r| {
+            Ok(GrafikBucket {
+                bucket: r.get(0)?,
+                kunjungan: r.get(1)?,
+                peminjaman: r.get(2)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(AppError::from)?;
+    Ok(rows)
+}
+
+#[tauri::command]
+pub fn laporan_top_peminjam(
+    state: State<'_, AppState>,
+    from: String,
+    to: String,
+    limit: Option<i64>,
+) -> AppResult<Vec<TopPeminjamRow>> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let limit = limit.unwrap_or(10).clamp(1, 200);
+    let mut stmt = conn
+        .prepare(
+            "SELECT a.id, a.nama, a.kode_anggota, a.kelas,
+                    COUNT(DISTINCT p.id) AS jumlah_pinjam,
+                    COALESCE((SELECT COUNT(*) FROM peminjaman_item pi
+                              JOIN peminjaman p2 ON p2.id = pi.peminjaman_id
+                              WHERE p2.anggota_id = a.id
+                                AND p2.tanggal_pinjam BETWEEN ?1 AND ?2), 0)
+                        AS jumlah_buku
+             FROM peminjaman p
+             JOIN anggota a ON a.id = p.anggota_id
+             WHERE p.tanggal_pinjam BETWEEN ?1 AND ?2
+             GROUP BY a.id
+             ORDER BY jumlah_pinjam DESC, a.nama
+             LIMIT ?3",
+        )
+        .map_err(AppError::from)?;
+    let rows = stmt
+        .query_map(params![from, to, limit], |r| {
+            Ok(TopPeminjamRow {
+                anggota_id: r.get(0)?,
+                nama: r.get(1)?,
+                kode_anggota: r.get(2)?,
+                kelas: r.get(3)?,
+                jumlah_pinjam: r.get(4)?,
+                jumlah_buku: r.get(5)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(AppError::from)?;
+    Ok(rows)
+}
+
+#[tauri::command]
+pub fn laporan_top_buku(
+    state: State<'_, AppState>,
+    from: String,
+    to: String,
+    limit: Option<i64>,
+) -> AppResult<Vec<TopBukuRow>> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+    let limit = limit.unwrap_or(10).clamp(1, 200);
+    let mut stmt = conn
+        .prepare(
+            "SELECT b.id, b.kode_buku, b.judul, b.pengarang, COUNT(pi.id) AS jumlah
+             FROM peminjaman_item pi
+             JOIN peminjaman p ON p.id = pi.peminjaman_id
+             JOIN buku b ON b.id = pi.buku_id
+             WHERE p.tanggal_pinjam BETWEEN ?1 AND ?2
+             GROUP BY b.id
+             ORDER BY jumlah DESC, b.judul
+             LIMIT ?3",
+        )
+        .map_err(AppError::from)?;
+    let rows = stmt
+        .query_map(params![from, to, limit], |r| {
+            Ok(TopBukuRow {
+                buku_id: r.get(0)?,
+                kode: r.get(1)?,
+                judul: r.get(2)?,
+                pengarang: r.get(3)?,
+                jumlah: r.get(4)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(AppError::from)?;
+    Ok(rows)
+}
+
+#[tauri::command]
+pub fn laporan_kas(
+    state: State<'_, AppState>,
+    from: String,
+    to: String,
+) -> AppResult<KasSummary> {
+    let conn = state.db.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, tanggal, keterangan, jenis, sumber, nominal
+             FROM kas
+             WHERE tanggal BETWEEN ?1 AND ?2
+             ORDER BY tanggal, id",
+        )
+        .map_err(AppError::from)?;
+    let rows = stmt
+        .query_map(params![from, to], |r| {
+            Ok(KasRow {
+                id: r.get(0)?,
+                tanggal: r.get(1)?,
+                keterangan: r.get(2)?,
+                jenis: r.get(3)?,
+                sumber: r.get(4)?,
+                nominal: r.get(5)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(AppError::from)?;
+
+    let mut total_masuk = 0i64;
+    let mut total_keluar = 0i64;
+    let mut from_denda = 0i64;
+    let mut from_manual = 0i64;
+    let mut from_hilang = 0i64;
+    let mut from_modal = 0i64;
+    let mut cumulative: Vec<KasCumulative> = Vec::new();
+    let mut running = 0i64;
+    let mut last_date: Option<String> = None;
+
+    for row in &rows {
+        let signed = if row.jenis == "masuk" { row.nominal } else { -row.nominal };
+        running += signed;
+        if row.jenis == "masuk" {
+            total_masuk += row.nominal;
+            match row.sumber.as_str() {
+                "denda" => from_denda += row.nominal,
+                "hilang" => from_hilang += row.nominal,
+                "modal" => from_modal += row.nominal,
+                _ => from_manual += row.nominal,
+            }
+        } else {
+            total_keluar += row.nominal;
+        }
+        match &last_date {
+            Some(d) if d == &row.tanggal => {
+                if let Some(last) = cumulative.last_mut() {
+                    last.saldo = running;
+                }
+            }
+            _ => {
+                cumulative.push(KasCumulative {
+                    tanggal: row.tanggal.clone(),
+                    saldo: running,
+                });
+                last_date = Some(row.tanggal.clone());
+            }
+        }
+    }
+
+    Ok(KasSummary {
+        total_masuk,
+        total_keluar,
+        saldo_akhir: total_masuk - total_keluar,
+        from_denda,
+        from_manual,
+        from_hilang,
+        from_modal,
+        rows,
+        cumulative,
+    })
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,9 +1,11 @@
 pub mod anggota;
 pub mod auth;
+pub mod backup;
 pub mod buku;
 pub mod dashboard;
 pub mod identity;
 pub mod kunjungan;
+pub mod laporan;
 pub mod master_data;
 pub mod peminjaman;
 pub mod window_state;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -79,6 +79,15 @@ pub fn run() {
             commands::dashboard::dashboard_kunjungan_7d,
             commands::dashboard::dashboard_top_peminjam,
             commands::dashboard::dashboard_top_buku,
+            commands::laporan::laporan_grafik,
+            commands::laporan::laporan_top_peminjam,
+            commands::laporan::laporan_top_buku,
+            commands::laporan::laporan_kas,
+            commands::backup::backup_create,
+            commands::backup::backup_restore,
+            commands::backup::backup_schedule_get,
+            commands::backup::backup_schedule_set,
+            commands::backup::backup_db_path,
         ])
         .build(tauri::generate_context!())
         .expect("failed to build tauri app")

--- a/apps/desktop/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/Sidebar.tsx
@@ -33,7 +33,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/peminjaman', labelKey: 'common:menu.peminjaman', Icon: ArrowLeftRight },
   { to: '/pengembalian', labelKey: 'common:menu.pengembalian', Icon: Undo2 },
   { to: '/kunjungan', labelKey: 'common:menu.kunjungan', Icon: CalendarCheck },
-  { to: '/laporan', labelKey: 'common:menu.laporan', Icon: BarChart3, pending: true },
+  { to: '/laporan', labelKey: 'common:menu.laporan', Icon: BarChart3 },
   { to: '/settings', labelKey: 'common:menu.settings', Icon: Settings, pending: true },
 ];
 

--- a/apps/desktop/src/features/laporan/BackupSubPage.tsx
+++ b/apps/desktop/src/features/laporan/BackupSubPage.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Database, FolderOpen, Save, Upload } from 'lucide-react';
+import { open as openDialog, save as saveDialog } from '@tauri-apps/plugin-dialog';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast-manager';
+import { isTauri } from '@/lib/auth';
+import { describeCron, laporanApi, type BackupResult, type BackupSchedule } from '@/lib/laporan';
+
+export function LaporanBackup() {
+  const { t } = useTranslation(['laporan']);
+  const { showToast } = useToast();
+  const [dbPath, setDbPath] = useState<string>('');
+  const [schedule, setSchedule] = useState<BackupSchedule | null>(null);
+  const [cronInput, setCronInput] = useState('0 2 * * *');
+  const [enabledInput, setEnabledInput] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [lastBackup, setLastBackup] = useState<BackupResult | null>(null);
+
+  useEffect(() => {
+    laporanApi
+      .backupDbPath()
+      .then(setDbPath)
+      .catch(() => setDbPath('—'));
+    laporanApi
+      .backupScheduleGet()
+      .then((s) => {
+        setSchedule(s);
+        setCronInput(s.cron);
+        setEnabledInput(s.enabled);
+      })
+      .catch(() => {
+        // ignore
+      });
+  }, []);
+
+  async function handleBackup(): Promise<void> {
+    setBusy(true);
+    try {
+      let target: string;
+      if (isTauri()) {
+        const picked = await openDialog({ directory: true, multiple: false, title: t('laporan:backup.pickFolder', { defaultValue: 'Pilih folder backup' }) });
+        if (!picked || Array.isArray(picked)) {
+          setBusy(false);
+          return;
+        }
+        target = picked;
+      } else {
+        target = '/tmp';
+      }
+      const res = await laporanApi.backupCreate(target);
+      setLastBackup(res);
+      showToast({
+        title: t('laporan:backup.success', { defaultValue: 'Backup berhasil' }),
+        description: res.path,
+      });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('laporan:backup.failed', { defaultValue: 'Backup gagal' }),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRestore(): Promise<void> {
+    setBusy(true);
+    try {
+      let filePath: string | null;
+      if (isTauri()) {
+        const picked = await openDialog({
+          directory: false,
+          multiple: false,
+          filters: [{ name: 'SQLite', extensions: ['db', 'sqlite'] }],
+          title: t('laporan:backup.pickRestoreFile', { defaultValue: 'Pilih file .db' }),
+        });
+        if (!picked || Array.isArray(picked)) {
+          setBusy(false);
+          return;
+        }
+        filePath = picked;
+      } else {
+        filePath = '/tmp/perpustakaan-mock.db';
+      }
+      const res = await laporanApi.backupRestore(filePath);
+      showToast({
+        title: t('laporan:backup.restoreSuccess', { defaultValue: 'Restore berhasil' }),
+        description: `${res.checksum.slice(0, 16)}…`,
+      });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('laporan:backup.restoreFailed', { defaultValue: 'Restore gagal' }),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleScheduleSave(): Promise<void> {
+    setSaving(true);
+    try {
+      const updated = await laporanApi.backupScheduleSet(enabledInput, cronInput);
+      setSchedule(updated);
+      showToast({
+        title: t('laporan:backup.scheduleSaved', { defaultValue: 'Jadwal disimpan' }),
+        description: describeCron(updated.cron),
+      });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('laporan:backup.scheduleFailed', { defaultValue: 'Gagal menyimpan jadwal' }),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Suppress unused-var lint when Tauri save dialog isn't reachable in browser mode
+  void saveDialog;
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="laporan-backup">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Database className="h-4 w-4" />
+            {t('laporan:backup.title', { defaultValue: 'Backup Database' })}
+          </CardTitle>
+          <CardDescription>
+            {t('laporan:backup.subtitle', {
+              defaultValue: 'Backup full SQLite + checksum SHA256 untuk verifikasi',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid gap-2 text-sm">
+            <Label className="text-xs uppercase tracking-wider text-muted-foreground">
+              {t('laporan:backup.currentDb', { defaultValue: 'File DB Aktif' })}
+            </Label>
+            <code className="overflow-x-auto whitespace-nowrap rounded-md bg-muted px-2 py-1.5 text-xs">
+              {dbPath || '...'}
+            </code>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={handleBackup} disabled={busy} data-testid="backup-create">
+              <FolderOpen className="mr-2 h-4 w-4" />
+              {t('laporan:backup.createBtn', { defaultValue: 'Backup Sekarang' })}
+            </Button>
+            <Button variant="outline" onClick={handleRestore} disabled={busy} data-testid="backup-restore">
+              <Upload className="mr-2 h-4 w-4" />
+              {t('laporan:backup.restoreBtn', { defaultValue: 'Restore dari File' })}
+            </Button>
+          </div>
+
+          {lastBackup && (
+            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-3 text-xs">
+              <div className="font-medium text-emerald-700 dark:text-emerald-300">
+                {t('laporan:backup.lastBackup', { defaultValue: 'Backup terakhir' })}
+              </div>
+              <div className="mt-1 break-all text-muted-foreground">{lastBackup.path}</div>
+              <div className="text-muted-foreground">
+                SHA256: <code className="text-[10px]">{lastBackup.checksum}</code>
+              </div>
+              <div className="text-muted-foreground">
+                Size: {(lastBackup.sizeBytes / 1024).toFixed(1)} KB
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            {t('laporan:backup.scheduleTitle', { defaultValue: 'Jadwal Backup Otomatis' })}
+          </CardTitle>
+          <CardDescription>
+            {t('laporan:backup.scheduleHint', {
+              defaultValue: 'Cron 5-field. Devin 12 akan menambahkan runner cron-like.',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {schedule == null ? (
+            <Skeleton className="h-20 w-full" />
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="schedule-enabled"
+                  checked={enabledInput}
+                  onCheckedChange={(c) => setEnabledInput(c === true)}
+                  data-testid="schedule-enabled"
+                />
+                <Label htmlFor="schedule-enabled" className="text-sm">
+                  {t('laporan:backup.enableSchedule', { defaultValue: 'Aktifkan jadwal otomatis' })}
+                </Label>
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="cron-input" className="text-xs uppercase tracking-wider text-muted-foreground">
+                  {t('laporan:backup.cron', { defaultValue: 'Cron Expression' })}
+                </Label>
+                <Input
+                  id="cron-input"
+                  value={cronInput}
+                  onChange={(e) => setCronInput(e.target.value)}
+                  placeholder="0 2 * * *"
+                  className="font-mono text-sm"
+                  data-testid="schedule-cron"
+                />
+                <p className="text-xs text-muted-foreground">{describeCron(cronInput)}</p>
+              </div>
+              {schedule.lastRun && (
+                <div className="text-xs text-muted-foreground">
+                  {t('laporan:backup.lastRun', { defaultValue: 'Terakhir berjalan' })}: {schedule.lastRun}
+                </div>
+              )}
+              <Button onClick={handleScheduleSave} disabled={saving} data-testid="schedule-save">
+                <Save className="mr-2 h-4 w-4" />
+                {t('laporan:backup.scheduleSave', { defaultValue: 'Simpan Jadwal' })}
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/laporan/GrafikSubPage.tsx
+++ b/apps/desktop/src/features/laporan/GrafikSubPage.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartBar } from '@/components/shared/ChartBar';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/components/ui/toast-manager';
+import { laporanApi, toCsv, type GrafikBucket, type Granularity } from '@/lib/laporan';
+import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
+import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+
+export function LaporanGrafik() {
+  const { t } = useTranslation(['laporan']);
+  const { showToast } = useToast();
+  const [range, setRange] = useState(presetRangeMonth);
+  const [granularity, setGranularity] = useState<Granularity>('day');
+  const [data, setData] = useState<GrafikBucket[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    laporanApi
+      .grafik(range.from, range.to, granularity)
+      .then((res) => {
+        if (!cancel) setData(res);
+      })
+      .catch((err) => {
+        if (cancel) return;
+        showToast({
+          variant: 'destructive',
+          title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [range, granularity, showToast, t]);
+
+  const totalKunjungan = useMemo(() => data.reduce((acc, d) => acc + d.kunjungan, 0), [data]);
+  const totalPeminjaman = useMemo(() => data.reduce((acc, d) => acc + d.peminjaman, 0), [data]);
+
+  function handleExportCsv(): void {
+    const csv = toCsv(
+      ['Periode', 'Kunjungan', 'Peminjaman'],
+      data.map((d) => [d.bucket, d.kunjungan, d.peminjaman]),
+    );
+    downloadText(csv, `laporan-grafik-${range.from}_${range.to}.csv`, 'text/csv');
+  }
+
+  function handleExportPdf(): void {
+    const html = buildLaporanPdfHtml({
+      title: t('laporan:grafik.title', { defaultValue: 'Grafik Aktivitas' }),
+      periode: `${range.from} → ${range.to}`,
+      table: {
+        headers: ['Periode', 'Kunjungan', 'Peminjaman'],
+        rows: data.map((d) => [d.bucket, d.kunjungan, d.peminjaman]),
+      },
+      summary: [
+        { label: 'Total Kunjungan', value: String(totalKunjungan) },
+        { label: 'Total Peminjaman', value: String(totalPeminjaman) },
+      ],
+    });
+    printHtml(html);
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="laporan-grafik">
+      <RangeToolbar
+        range={range}
+        onRangeChange={setRange}
+        onExportCsv={handleExportCsv}
+        onExportPdf={handleExportPdf}
+        exportDisabled={data.length === 0}
+      />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm text-muted-foreground">
+          {t('laporan:grafik.granularity', { defaultValue: 'Resolusi' })}
+        </span>
+        <Select value={granularity} onValueChange={(v) => setGranularity(v as Granularity)}>
+          <SelectTrigger className="w-[160px]" data-testid="grafik-granularity">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="day">Harian</SelectItem>
+            <SelectItem value="month">Bulanan</SelectItem>
+            <SelectItem value="year">Tahunan</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">
+            {t('laporan:grafik.title', { defaultValue: 'Grafik Aktivitas' })}
+          </CardTitle>
+          <CardDescription>
+            {t('laporan:grafik.subtitle', {
+              defaultValue: 'Kunjungan vs peminjaman per periode',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-4">
+          {loading ? (
+            <Skeleton className="h-[220px] w-full" />
+          ) : data.length === 0 ? (
+            <p className="py-8 text-center text-sm italic text-muted-foreground">
+              {t('laporan:empty', { defaultValue: 'Belum ada data pada rentang ini' })}
+            </p>
+          ) : (
+            <ChartBar
+              data={data.map((d) => ({
+                key: d.bucket,
+                label: d.bucket.slice(-5),
+                value: d.kunjungan,
+              }))}
+              height={220}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <SummaryCell label={t('laporan:grafik.totalKunjungan', { defaultValue: 'Total Kunjungan' })} value={totalKunjungan} />
+        <SummaryCell label={t('laporan:grafik.totalPeminjaman', { defaultValue: 'Total Peminjaman' })} value={totalPeminjaman} />
+      </div>
+    </div>
+  );
+}
+
+function SummaryCell({ label, value }: { label: string; value: number }) {
+  return (
+    <Card>
+      <CardContent className="flex items-center justify-between p-4">
+        <span className="text-sm text-muted-foreground">{label}</span>
+        <span className="text-2xl font-semibold tabular-nums">{value.toLocaleString('id-ID')}</span>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/desktop/src/features/laporan/KasSubPage.tsx
+++ b/apps/desktop/src/features/laporan/KasSubPage.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChartPie } from '@/components/shared/ChartPie';
+import { useToast } from '@/components/ui/toast-manager';
+import { laporanApi, toCsv, type KasSummary } from '@/lib/laporan';
+import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
+import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+
+const RUPIAH = new Intl.NumberFormat('id-ID', {
+  style: 'currency',
+  currency: 'IDR',
+  maximumFractionDigits: 0,
+});
+
+export function LaporanKas() {
+  const { t } = useTranslation(['laporan']);
+  const { showToast } = useToast();
+  const [range, setRange] = useState(presetRangeMonth);
+  const [data, setData] = useState<KasSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    laporanApi
+      .kas(range.from, range.to)
+      .then((res) => {
+        if (!cancel) setData(res);
+      })
+      .catch((err) => {
+        if (cancel) return;
+        showToast({
+          variant: 'destructive',
+          title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [range, showToast, t]);
+
+  function handleExportCsv(): void {
+    if (!data) return;
+    const csv = toCsv(
+      ['Tanggal', 'Keterangan', 'Jenis', 'Sumber', 'Nominal'],
+      data.rows.map((r) => [r.tanggal, r.keterangan, r.jenis, r.sumber, r.nominal]),
+    );
+    downloadText(csv, `laporan-kas-${range.from}_${range.to}.csv`, 'text/csv');
+  }
+
+  function handleExportPdf(): void {
+    if (!data) return;
+    const html = buildLaporanPdfHtml({
+      title: t('laporan:kas.title', { defaultValue: 'Laporan Kas' }),
+      periode: `${range.from} → ${range.to}`,
+      summary: [
+        { label: 'Total Masuk', value: RUPIAH.format(data.totalMasuk) },
+        { label: 'Total Keluar', value: RUPIAH.format(data.totalKeluar) },
+        { label: 'Saldo Akhir', value: RUPIAH.format(data.saldoAkhir) },
+      ],
+      table: {
+        headers: ['Tanggal', 'Keterangan', 'Jenis', 'Sumber', 'Nominal'],
+        rows: data.rows.map((r) => [r.tanggal, r.keterangan, r.jenis, r.sumber, RUPIAH.format(r.nominal)]),
+      },
+    });
+    printHtml(html);
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="laporan-kas">
+      <RangeToolbar
+        range={range}
+        onRangeChange={setRange}
+        onExportCsv={handleExportCsv}
+        onExportPdf={handleExportPdf}
+        exportDisabled={!data || data.rows.length === 0}
+      />
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <SummaryCell tone="emerald" label={t('laporan:kas.masuk', { defaultValue: 'Total Masuk' })} value={data?.totalMasuk ?? 0} loading={loading} />
+        <SummaryCell tone="rose" label={t('laporan:kas.keluar', { defaultValue: 'Total Keluar' })} value={data?.totalKeluar ?? 0} loading={loading} />
+        <SummaryCell tone="primary" label={t('laporan:kas.saldo', { defaultValue: 'Saldo Akhir' })} value={data?.saldoAkhir ?? 0} loading={loading} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">
+              {t('laporan:kas.breakdown', { defaultValue: 'Breakdown Pemasukan' })}
+            </CardTitle>
+            <CardDescription>
+              {t('laporan:kas.breakdownHint', { defaultValue: 'Manual / denda / hilang / modal' })}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-4">
+            {loading || !data ? (
+              <Skeleton className="h-[200px] w-full" />
+            ) : (
+              <ChartPie
+                data={[
+                  { key: 'manual', label: 'Manual', value: data.fromManual },
+                  { key: 'denda', label: 'Denda', value: data.fromDenda },
+                  { key: 'hilang', label: 'Ganti hilang', value: data.fromHilang },
+                  { key: 'modal', label: 'Modal', value: data.fromModal },
+                ]}
+              />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">
+              {t('laporan:kas.detail', { defaultValue: 'Detail Transaksi' })}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            {loading || !data ? (
+              <Skeleton className="h-[200px] w-full" />
+            ) : data.rows.length === 0 ? (
+              <p className="py-8 text-center text-sm italic text-muted-foreground">
+                {t('laporan:empty', { defaultValue: 'Belum ada data pada rentang ini' })}
+              </p>
+            ) : (
+              <div className="max-h-[260px] overflow-auto">
+                <table className="w-full text-sm" data-testid="kas-table">
+                  <thead className="sticky top-0 bg-muted/40 text-left text-xs uppercase tracking-wider text-muted-foreground">
+                    <tr>
+                      <th className="px-3 py-2">{t('laporan:column.tanggal', { defaultValue: 'Tanggal' })}</th>
+                      <th className="px-3 py-2">{t('laporan:column.keterangan', { defaultValue: 'Keterangan' })}</th>
+                      <th className="px-3 py-2 text-right">{t('laporan:column.nominal', { defaultValue: 'Nominal' })}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.rows.map((r) => (
+                      <tr key={r.id} className="border-t">
+                        <td className="px-3 py-2 text-xs text-muted-foreground">{r.tanggal}</td>
+                        <td className="px-3 py-2">
+                          <div>{r.keterangan}</div>
+                          <div className="text-xs text-muted-foreground">{r.sumber}</div>
+                        </td>
+                        <td
+                          className={`px-3 py-2 text-right font-medium tabular-nums ${
+                            r.jenis === 'masuk'
+                              ? 'text-emerald-600 dark:text-emerald-400'
+                              : 'text-rose-600 dark:text-rose-400'
+                          }`}
+                        >
+                          {r.jenis === 'masuk' ? '+' : '−'}
+                          {RUPIAH.format(r.nominal)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+const TONE_CLASS = {
+  primary: 'text-primary',
+  emerald: 'text-emerald-600 dark:text-emerald-400',
+  rose: 'text-rose-600 dark:text-rose-400',
+} as const;
+
+function SummaryCell({
+  label,
+  value,
+  tone,
+  loading,
+}: {
+  label: string;
+  value: number;
+  tone: keyof typeof TONE_CLASS;
+  loading: boolean;
+}) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-1 p-4">
+        <span className="text-xs uppercase tracking-wider text-muted-foreground">{label}</span>
+        {loading ? (
+          <Skeleton className="h-7 w-32" />
+        ) : (
+          <span className={`text-xl font-semibold tabular-nums ${TONE_CLASS[tone]}`}>
+            {RUPIAH.format(value)}
+          </span>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/desktop/src/features/laporan/LaporanLayout.tsx
+++ b/apps/desktop/src/features/laporan/LaporanLayout.tsx
@@ -1,0 +1,62 @@
+import { Link, Outlet } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { BarChart3, Database, LineChart, ReceiptText, Users } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface NavItem {
+  to: string;
+  labelKey: string;
+  defaultLabel: string;
+  Icon: React.ComponentType<{ className?: string }>;
+}
+
+const NAV: NavItem[] = [
+  { to: '/laporan/grafik', labelKey: 'laporan:nav.grafik', defaultLabel: 'Grafik', Icon: LineChart },
+  { to: '/laporan/top-peminjam', labelKey: 'laporan:nav.topPeminjam', defaultLabel: 'Top Peminjam', Icon: Users },
+  { to: '/laporan/top-buku', labelKey: 'laporan:nav.topBuku', defaultLabel: 'Top Buku', Icon: BarChart3 },
+  { to: '/laporan/kas', labelKey: 'laporan:nav.kas', defaultLabel: 'Kas', Icon: ReceiptText },
+  { to: '/laporan/backup', labelKey: 'laporan:nav.backup', defaultLabel: 'Backup', Icon: Database },
+];
+
+export function LaporanLayout() {
+  const { t } = useTranslation(['laporan', 'common']);
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-6 p-6" data-testid="laporan-layout">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t('laporan:title', { defaultValue: 'Laporan' })}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('laporan:subtitle', {
+            defaultValue: 'Statistik & ekspor data perpustakaan',
+          })}
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[200px_1fr]">
+        <aside>
+          <nav className="flex flex-col gap-1" data-testid="laporan-nav">
+            {NAV.map(({ to, labelKey, defaultLabel, Icon }) => (
+              <Link
+                key={to}
+                to={to}
+                className={cn(
+                  'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted',
+                  '[&.active]:bg-primary/10 [&.active]:font-medium [&.active]:text-primary',
+                )}
+                activeProps={{ className: 'active' }}
+              >
+                <Icon className="h-4 w-4" />
+                {t(labelKey, { defaultValue: defaultLabel })}
+              </Link>
+            ))}
+          </nav>
+        </aside>
+
+        <section className="min-w-0">
+          <Outlet />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/laporan/RangeToolbar.tsx
+++ b/apps/desktop/src/features/laporan/RangeToolbar.tsx
@@ -1,0 +1,54 @@
+import { Download } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { DateRangePicker, type DateRange } from '@/components/ui/date-range-picker';
+import { rangeForPreset } from '@/lib/kunjungan';
+
+export interface RangeToolbarProps {
+  range: DateRange;
+  onRangeChange: (range: DateRange) => void;
+  onExportCsv?: () => void;
+  onExportPdf?: () => void;
+  exportDisabled?: boolean;
+}
+
+export function RangeToolbar({
+  range,
+  onRangeChange,
+  onExportCsv,
+  onExportPdf,
+  exportDisabled,
+}: RangeToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <DateRangePicker value={range} onChange={onRangeChange} />
+      <div className="flex flex-wrap gap-2">
+        {onExportCsv && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onExportCsv}
+            disabled={exportDisabled}
+            data-testid="laporan-export-csv"
+          >
+            <Download className="mr-2 h-4 w-4" />
+            CSV
+          </Button>
+        )}
+        {onExportPdf && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onExportPdf}
+            disabled={exportDisabled}
+            data-testid="laporan-export-pdf"
+          >
+            <Download className="mr-2 h-4 w-4" />
+            PDF
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const presetRangeMonth = (): DateRange => rangeForPreset('month');

--- a/apps/desktop/src/features/laporan/TopBukuSubPage.tsx
+++ b/apps/desktop/src/features/laporan/TopBukuSubPage.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChartBar } from '@/components/shared/ChartBar';
+import { useToast } from '@/components/ui/toast-manager';
+import { laporanApi, toCsv, type TopBukuRow } from '@/lib/laporan';
+import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
+import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+
+export function LaporanTopBuku() {
+  const { t } = useTranslation(['laporan']);
+  const { showToast } = useToast();
+  const [range, setRange] = useState(presetRangeMonth);
+  const [rows, setRows] = useState<TopBukuRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    laporanApi
+      .topBuku(range.from, range.to, 10)
+      .then((res) => {
+        if (!cancel) setRows(res);
+      })
+      .catch((err) => {
+        if (cancel) return;
+        showToast({
+          variant: 'destructive',
+          title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [range, showToast, t]);
+
+  function handleExportCsv(): void {
+    const csv = toCsv(
+      ['Rank', 'Kode', 'Judul', 'Pengarang', 'Jumlah'],
+      rows.map((r, i) => [i + 1, r.kode, r.judul, r.pengarang ?? '-', r.jumlah]),
+    );
+    downloadText(csv, `laporan-top-buku-${range.from}_${range.to}.csv`, 'text/csv');
+  }
+
+  function handleExportPdf(): void {
+    const html = buildLaporanPdfHtml({
+      title: t('laporan:topBuku.title', { defaultValue: 'Top Buku' }),
+      periode: `${range.from} → ${range.to}`,
+      table: {
+        headers: ['#', 'Kode', 'Judul', 'Pengarang', 'Jumlah'],
+        rows: rows.map((r, i) => [i + 1, r.kode, r.judul, r.pengarang ?? '-', r.jumlah]),
+      },
+    });
+    printHtml(html);
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="laporan-top-buku">
+      <RangeToolbar
+        range={range}
+        onRangeChange={setRange}
+        onExportCsv={handleExportCsv}
+        onExportPdf={handleExportPdf}
+        exportDisabled={rows.length === 0}
+      />
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">
+            {t('laporan:topBuku.title', { defaultValue: 'Top Buku' })}
+          </CardTitle>
+          <CardDescription>
+            {t('laporan:topBuku.subtitle', { defaultValue: '10 buku paling sering dipinjam' })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 p-4">
+          {loading ? (
+            <Skeleton className="h-[220px] w-full" />
+          ) : rows.length === 0 ? (
+            <p className="py-8 text-center text-sm italic text-muted-foreground">
+              {t('laporan:empty', { defaultValue: 'Belum ada data pada rentang ini' })}
+            </p>
+          ) : (
+            <>
+              <ChartBar
+                data={rows.map((r) => ({ key: r.kode, label: r.kode, value: r.jumlah }))}
+                height={180}
+              />
+              <div className="overflow-hidden rounded-md border">
+                <table className="w-full text-sm" data-testid="top-buku-table">
+                  <thead className="bg-muted/40 text-left text-xs uppercase tracking-wider text-muted-foreground">
+                    <tr>
+                      <th className="w-10 px-3 py-2">#</th>
+                      <th className="px-3 py-2">{t('laporan:column.kode', { defaultValue: 'Kode' })}</th>
+                      <th className="px-3 py-2">{t('laporan:column.judul', { defaultValue: 'Judul' })}</th>
+                      <th className="px-3 py-2">{t('laporan:column.pengarang', { defaultValue: 'Pengarang' })}</th>
+                      <th className="px-3 py-2 text-right">{t('laporan:column.jumlah', { defaultValue: 'Jumlah' })}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((r, i) => (
+                      <tr key={r.bukuId} className="border-t hover:bg-muted/30">
+                        <td className="px-3 py-2 font-medium">{i + 1}</td>
+                        <td className="px-3 py-2 text-muted-foreground">{r.kode}</td>
+                        <td className="px-3 py-2">{r.judul}</td>
+                        <td className="px-3 py-2 text-muted-foreground">{r.pengarang ?? '—'}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{r.jumlah}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/laporan/TopPeminjamSubPage.tsx
+++ b/apps/desktop/src/features/laporan/TopPeminjamSubPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChartBar } from '@/components/shared/ChartBar';
+import { useToast } from '@/components/ui/toast-manager';
+import { laporanApi, toCsv, type TopPeminjamRow } from '@/lib/laporan';
+import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
+import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+
+export function LaporanTopPeminjam() {
+  const { t } = useTranslation(['laporan']);
+  const { showToast } = useToast();
+  const [range, setRange] = useState(presetRangeMonth);
+  const [rows, setRows] = useState<TopPeminjamRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    laporanApi
+      .topPeminjam(range.from, range.to, 10)
+      .then((res) => {
+        if (!cancel) setRows(res);
+      })
+      .catch((err) => {
+        if (cancel) return;
+        showToast({
+          variant: 'destructive',
+          title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [range, showToast, t]);
+
+  function handleExportCsv(): void {
+    const csv = toCsv(
+      ['Rank', 'Nama', 'Kode', 'Kelas', 'Pinjam', 'Buku'],
+      rows.map((r, i) => [i + 1, r.nama, r.kodeAnggota, r.kelas ?? '-', r.jumlahPinjam, r.jumlahBuku]),
+    );
+    downloadText(csv, `laporan-top-peminjam-${range.from}_${range.to}.csv`, 'text/csv');
+  }
+
+  function handleExportPdf(): void {
+    const html = buildLaporanPdfHtml({
+      title: t('laporan:topPeminjam.title', { defaultValue: 'Top Peminjam' }),
+      periode: `${range.from} → ${range.to}`,
+      table: {
+        headers: ['#', 'Nama', 'Kode', 'Kelas', 'Pinjam', 'Buku'],
+        rows: rows.map((r, i) => [i + 1, r.nama, r.kodeAnggota, r.kelas ?? '-', r.jumlahPinjam, r.jumlahBuku]),
+      },
+    });
+    printHtml(html);
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="laporan-top-peminjam">
+      <RangeToolbar
+        range={range}
+        onRangeChange={setRange}
+        onExportCsv={handleExportCsv}
+        onExportPdf={handleExportPdf}
+        exportDisabled={rows.length === 0}
+      />
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">
+            {t('laporan:topPeminjam.title', { defaultValue: 'Top Peminjam' })}
+          </CardTitle>
+          <CardDescription>
+            {t('laporan:topPeminjam.subtitle', { defaultValue: '10 anggota teraktif pada rentang ini' })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 p-4">
+          {loading ? (
+            <Skeleton className="h-[220px] w-full" />
+          ) : rows.length === 0 ? (
+            <p className="py-8 text-center text-sm italic text-muted-foreground">
+              {t('laporan:empty', { defaultValue: 'Belum ada data pada rentang ini' })}
+            </p>
+          ) : (
+            <>
+              <ChartBar
+                data={rows.map((r) => ({ key: r.kodeAnggota, label: r.nama.split(' ')[0] ?? '', value: r.jumlahPinjam }))}
+                height={180}
+              />
+              <div className="overflow-hidden rounded-md border">
+                <table className="w-full text-sm" data-testid="top-peminjam-table">
+                  <thead className="bg-muted/40 text-left text-xs uppercase tracking-wider text-muted-foreground">
+                    <tr>
+                      <th className="w-10 px-3 py-2">#</th>
+                      <th className="px-3 py-2">{t('laporan:column.nama', { defaultValue: 'Nama' })}</th>
+                      <th className="px-3 py-2">{t('laporan:column.kode', { defaultValue: 'Kode' })}</th>
+                      <th className="px-3 py-2">{t('laporan:column.kelas', { defaultValue: 'Kelas' })}</th>
+                      <th className="px-3 py-2 text-right">{t('laporan:column.pinjam', { defaultValue: 'Pinjam' })}</th>
+                      <th className="px-3 py-2 text-right">{t('laporan:column.buku', { defaultValue: 'Buku' })}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((r, i) => (
+                      <tr key={r.anggotaId} className="border-t hover:bg-muted/30">
+                        <td className="px-3 py-2 font-medium">{i + 1}</td>
+                        <td className="px-3 py-2">{r.nama}</td>
+                        <td className="px-3 py-2 text-muted-foreground">{r.kodeAnggota}</td>
+                        <td className="px-3 py-2 text-muted-foreground">{r.kelas ?? '—'}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{r.jumlahPinjam}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{r.jumlahBuku}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/laporan/utils.ts
+++ b/apps/desktop/src/features/laporan/utils.ts
@@ -1,0 +1,97 @@
+/** Trigger a download of `content` (UTF-8 string) as a file. */
+export function downloadText(content: string, filename: string, mime: string = 'text/plain'): void {
+  const blob = new Blob([content], { type: `${mime};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/** Open a print-ready HTML window using window.print(). */
+export function printHtml(html: string): void {
+  const w = window.open('', '_blank', 'width=900,height=700');
+  if (!w) return;
+  w.document.open();
+  w.document.write(html);
+  w.document.close();
+  w.focus();
+  setTimeout(() => {
+    try {
+      w.print();
+    } catch {
+      // ignore
+    }
+  }, 200);
+}
+
+export function buildLaporanPdfHtml(opts: {
+  title: string;
+  periode: string;
+  identitas?: { nama?: string; alamat?: string };
+  table: { headers: string[]; rows: Array<Array<string | number>> };
+  summary?: Array<{ label: string; value: string }>;
+}): string {
+  const { title, periode, identitas, table, summary } = opts;
+  const escape = (v: string | number): string =>
+    String(v)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+  const headerHtml = `<tr>${table.headers.map((h) => `<th>${escape(h)}</th>`).join('')}</tr>`;
+  const bodyHtml = table.rows
+    .map((row) => `<tr>${row.map((cell) => `<td>${escape(cell)}</td>`).join('')}</tr>`)
+    .join('');
+  const summaryHtml = summary?.length
+    ? `<div class="summary">${summary
+        .map((s) => `<div><strong>${escape(s.label)}</strong>: ${escape(s.value)}</div>`)
+        .join('')}</div>`
+    : '';
+
+  return `<!doctype html>
+<html lang="id">
+<head>
+  <meta charset="utf-8" />
+  <title>${escape(title)}</title>
+  <style>
+    body { font-family: 'Inter', system-ui, sans-serif; padding: 24px; color: #111; }
+    .pustaka-header { border-bottom: 2px solid #111; padding-bottom: 12px; margin-bottom: 16px; }
+    .pustaka-header h1 { margin: 0 0 4px; font-size: 18px; }
+    .pustaka-header p { margin: 0; font-size: 12px; color: #555; }
+    .meta { display: flex; justify-content: space-between; font-size: 12px; margin-bottom: 16px; }
+    .summary { display: flex; gap: 16px; margin: 16px 0; padding: 12px; background: #f5f5f5; border-radius: 8px; font-size: 12px; }
+    table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    th, td { padding: 6px 10px; border: 1px solid #ddd; text-align: left; }
+    th { background: #f0f0f0; font-weight: 600; }
+    tr:nth-child(even) td { background: #fafafa; }
+    footer { margin-top: 32px; font-size: 10px; color: #777; text-align: right; }
+    @media print {
+      body { padding: 12mm; }
+      .pustaka-header { border-color: #000; }
+    }
+  </style>
+</head>
+<body>
+  <div class="pustaka-header">
+    <h1>${escape(identitas?.nama ?? 'Perpustakaan')}</h1>
+    <p>${escape(identitas?.alamat ?? '')}</p>
+  </div>
+  <div class="meta">
+    <div><strong>${escape(title)}</strong></div>
+    <div>Periode: ${escape(periode)}</div>
+  </div>
+  ${summaryHtml}
+  <table>
+    <thead>${headerHtml}</thead>
+    <tbody>${bodyHtml}</tbody>
+  </table>
+  <footer>Dicetak pada ${new Date().toLocaleString('id-ID')}</footer>
+</body>
+</html>`;
+}

--- a/apps/desktop/src/i18n/en/laporan.json
+++ b/apps/desktop/src/i18n/en/laporan.json
@@ -1,4 +1,74 @@
 {
   "title": "Reports",
-  "placeholder": "Reports module will be built in Devin Session 9."
+  "subtitle": "Library statistics & exports",
+  "empty": "No data in this range",
+  "nav": {
+    "grafik": "Charts",
+    "topPeminjam": "Top Borrowers",
+    "topBuku": "Top Books",
+    "kas": "Cash",
+    "backup": "Backup"
+  },
+  "error": {
+    "load": "Failed to load data"
+  },
+  "column": {
+    "tanggal": "Date",
+    "nama": "Name",
+    "kode": "Code",
+    "kelas": "Class",
+    "judul": "Title",
+    "pengarang": "Author",
+    "pinjam": "Loans",
+    "buku": "Books",
+    "jumlah": "Count",
+    "keterangan": "Note",
+    "nominal": "Amount"
+  },
+  "grafik": {
+    "title": "Activity Chart",
+    "subtitle": "Visits vs loans per bucket",
+    "granularity": "Granularity",
+    "totalKunjungan": "Total Visits",
+    "totalPeminjaman": "Total Loans"
+  },
+  "topPeminjam": {
+    "title": "Top Borrowers",
+    "subtitle": "10 most active members in this range"
+  },
+  "topBuku": {
+    "title": "Top Books",
+    "subtitle": "10 most-borrowed titles"
+  },
+  "kas": {
+    "title": "Cash Report",
+    "masuk": "Total In",
+    "keluar": "Total Out",
+    "saldo": "Closing Balance",
+    "breakdown": "Income Breakdown",
+    "breakdownHint": "Manual / fines / lost / capital",
+    "detail": "Transactions"
+  },
+  "backup": {
+    "title": "Database Backup",
+    "subtitle": "Full SQLite backup + SHA256 checksum for verification",
+    "currentDb": "Active DB File",
+    "createBtn": "Backup Now",
+    "restoreBtn": "Restore from File",
+    "pickFolder": "Pick backup folder",
+    "pickRestoreFile": "Pick .db file",
+    "success": "Backup successful",
+    "failed": "Backup failed",
+    "restoreSuccess": "Restore successful",
+    "restoreFailed": "Restore failed",
+    "lastBackup": "Last backup",
+    "scheduleTitle": "Auto Backup Schedule",
+    "scheduleHint": "5-field cron. Session 12 adds the cron-like runner.",
+    "enableSchedule": "Enable schedule",
+    "cron": "Cron Expression",
+    "scheduleSave": "Save Schedule",
+    "scheduleSaved": "Schedule saved",
+    "scheduleFailed": "Failed to save schedule",
+    "lastRun": "Last run"
+  }
 }

--- a/apps/desktop/src/i18n/id/laporan.json
+++ b/apps/desktop/src/i18n/id/laporan.json
@@ -1,4 +1,74 @@
 {
   "title": "Laporan",
-  "placeholder": "Modul laporan akan dibuat di Devin Session 9."
+  "subtitle": "Statistik & ekspor data perpustakaan",
+  "empty": "Belum ada data pada rentang ini",
+  "nav": {
+    "grafik": "Grafik",
+    "topPeminjam": "Top Peminjam",
+    "topBuku": "Top Buku",
+    "kas": "Kas",
+    "backup": "Backup"
+  },
+  "error": {
+    "load": "Gagal memuat data"
+  },
+  "column": {
+    "tanggal": "Tanggal",
+    "nama": "Nama",
+    "kode": "Kode",
+    "kelas": "Kelas",
+    "judul": "Judul",
+    "pengarang": "Pengarang",
+    "pinjam": "Pinjam",
+    "buku": "Buku",
+    "jumlah": "Jumlah",
+    "keterangan": "Keterangan",
+    "nominal": "Nominal"
+  },
+  "grafik": {
+    "title": "Grafik Aktivitas",
+    "subtitle": "Kunjungan vs peminjaman per periode",
+    "granularity": "Resolusi",
+    "totalKunjungan": "Total Kunjungan",
+    "totalPeminjaman": "Total Peminjaman"
+  },
+  "topPeminjam": {
+    "title": "Top Peminjam",
+    "subtitle": "10 anggota teraktif pada rentang ini"
+  },
+  "topBuku": {
+    "title": "Top Buku",
+    "subtitle": "10 buku paling sering dipinjam"
+  },
+  "kas": {
+    "title": "Laporan Kas",
+    "masuk": "Total Masuk",
+    "keluar": "Total Keluar",
+    "saldo": "Saldo Akhir",
+    "breakdown": "Breakdown Pemasukan",
+    "breakdownHint": "Manual / denda / hilang / modal",
+    "detail": "Detail Transaksi"
+  },
+  "backup": {
+    "title": "Backup Database",
+    "subtitle": "Backup full SQLite + checksum SHA256 untuk verifikasi",
+    "currentDb": "File DB Aktif",
+    "createBtn": "Backup Sekarang",
+    "restoreBtn": "Restore dari File",
+    "pickFolder": "Pilih folder backup",
+    "pickRestoreFile": "Pilih file .db",
+    "success": "Backup berhasil",
+    "failed": "Backup gagal",
+    "restoreSuccess": "Restore berhasil",
+    "restoreFailed": "Restore gagal",
+    "lastBackup": "Backup terakhir",
+    "scheduleTitle": "Jadwal Backup Otomatis",
+    "scheduleHint": "Cron 5-field. Devin 12 akan menambahkan runner cron-like.",
+    "enableSchedule": "Aktifkan jadwal otomatis",
+    "cron": "Cron Expression",
+    "scheduleSave": "Simpan Jadwal",
+    "scheduleSaved": "Jadwal disimpan",
+    "scheduleFailed": "Gagal menyimpan jadwal",
+    "lastRun": "Terakhir berjalan"
+  }
 }

--- a/apps/desktop/src/lib/laporan.ts
+++ b/apps/desktop/src/lib/laporan.ts
@@ -1,0 +1,297 @@
+import { invoke } from '@tauri-apps/api/core';
+import { isTauri } from '@/lib/auth';
+
+export type Granularity = 'day' | 'month' | 'year';
+
+export interface GrafikBucket {
+  bucket: string;
+  kunjungan: number;
+  peminjaman: number;
+}
+
+export interface TopPeminjamRow {
+  anggotaId: number;
+  nama: string;
+  kodeAnggota: string;
+  kelas: string | null;
+  jumlahPinjam: number;
+  jumlahBuku: number;
+}
+
+export interface TopBukuRow {
+  bukuId: number;
+  kode: string;
+  judul: string;
+  pengarang: string | null;
+  jumlah: number;
+}
+
+export interface KasRow {
+  id: number;
+  tanggal: string;
+  keterangan: string;
+  jenis: 'masuk' | 'keluar';
+  sumber: 'manual' | 'denda' | 'hilang' | 'modal';
+  nominal: number;
+}
+
+export interface KasCumulative {
+  tanggal: string;
+  saldo: number;
+}
+
+export interface KasSummary {
+  totalMasuk: number;
+  totalKeluar: number;
+  saldoAkhir: number;
+  fromDenda: number;
+  fromManual: number;
+  fromHilang: number;
+  fromModal: number;
+  rows: KasRow[];
+  cumulative: KasCumulative[];
+}
+
+export interface BackupResult {
+  path: string;
+  checksum: string;
+  sizeBytes: number;
+}
+
+export interface BackupSchedule {
+  enabled: boolean;
+  cron: string;
+  lastRun: string | null;
+}
+
+export interface LaporanRpc {
+  grafik: (from: string, to: string, granularity?: Granularity) => Promise<GrafikBucket[]>;
+  topPeminjam: (from: string, to: string, limit?: number) => Promise<TopPeminjamRow[]>;
+  topBuku: (from: string, to: string, limit?: number) => Promise<TopBukuRow[]>;
+  kas: (from: string, to: string) => Promise<KasSummary>;
+  backupCreate: (targetDir: string) => Promise<BackupResult>;
+  backupRestore: (filePath: string, expectedChecksum?: string) => Promise<BackupResult>;
+  backupScheduleGet: () => Promise<BackupSchedule>;
+  backupScheduleSet: (enabled: boolean, cron: string) => Promise<BackupSchedule>;
+  backupDbPath: () => Promise<string>;
+}
+
+const tauriRpc: LaporanRpc = {
+  grafik: (from, to, granularity) =>
+    invoke<GrafikBucket[]>('laporan_grafik', { from, to, granularity }),
+  topPeminjam: (from, to, limit) =>
+    invoke<TopPeminjamRow[]>('laporan_top_peminjam', { from, to, limit }),
+  topBuku: (from, to, limit) =>
+    invoke<TopBukuRow[]>('laporan_top_buku', { from, to, limit }),
+  kas: (from, to) => invoke<KasSummary>('laporan_kas', { from, to }),
+  backupCreate: (targetDir) => invoke<BackupResult>('backup_create', { targetDir }),
+  backupRestore: (filePath, expectedChecksum) =>
+    invoke<BackupResult>('backup_restore', { filePath, expectedChecksum }),
+  backupScheduleGet: () => invoke<BackupSchedule>('backup_schedule_get'),
+  backupScheduleSet: (enabled, cron) =>
+    invoke<BackupSchedule>('backup_schedule_set', { enabled, cron }),
+  backupDbPath: () => invoke<string>('backup_db_path'),
+};
+
+const mockRpc: LaporanRpc = {
+  async grafik(from, to, granularity = 'day') {
+    const start = new Date(`${from}T00:00:00`);
+    const end = new Date(`${to}T00:00:00`);
+    const result: GrafikBucket[] = [];
+    if (granularity === 'day') {
+      const cur = new Date(start);
+      let i = 0;
+      while (cur <= end) {
+        result.push({
+          bucket: cur.toISOString().slice(0, 10),
+          kunjungan: 12 + ((i * 5 + 7) % 18),
+          peminjaman: 3 + ((i * 3 + 2) % 9),
+        });
+        cur.setDate(cur.getDate() + 1);
+        i += 1;
+      }
+    } else if (granularity === 'month') {
+      const cur = new Date(start.getFullYear(), start.getMonth(), 1);
+      let i = 0;
+      while (cur <= end) {
+        const ym = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, '0')}`;
+        result.push({
+          bucket: ym,
+          kunjungan: 200 + i * 24,
+          peminjaman: 60 + i * 7,
+        });
+        cur.setMonth(cur.getMonth() + 1);
+        i += 1;
+      }
+    } else {
+      for (let y = start.getFullYear(); y <= end.getFullYear(); y++) {
+        result.push({
+          bucket: String(y),
+          kunjungan: 1800 + (y % 100) * 30,
+          peminjaman: 540 + (y % 100) * 11,
+        });
+      }
+    }
+    return result;
+  },
+  async topPeminjam(_from, _to, limit = 10) {
+    const seed = [
+      { nama: 'Adelia Putri', kode: 'A0007', kelas: 'XI IPA 1', jumlahPinjam: 14, jumlahBuku: 21 },
+      { nama: 'Bagas Saputra', kode: 'A0012', kelas: 'X IPS 2', jumlahPinjam: 11, jumlahBuku: 17 },
+      { nama: 'Citra Lestari', kode: 'A0021', kelas: 'XII IPA 3', jumlahPinjam: 9, jumlahBuku: 15 },
+      { nama: 'Dani Pratama', kode: 'A0034', kelas: 'X IPA 1', jumlahPinjam: 8, jumlahBuku: 12 },
+      { nama: 'Erika Yulianti', kode: 'A0045', kelas: 'XI IPS 1', jumlahPinjam: 6, jumlahBuku: 9 },
+      { nama: 'Fariz Hakim', kode: 'A0058', kelas: 'XII IPS 2', jumlahPinjam: 5, jumlahBuku: 7 },
+      { nama: 'Gita Larasati', kode: 'A0061', kelas: 'X IPA 2', jumlahPinjam: 4, jumlahBuku: 6 },
+      { nama: 'Hani Khairiyah', kode: 'A0072', kelas: 'XI IPS 3', jumlahPinjam: 4, jumlahBuku: 5 },
+      { nama: 'Iqbal Maulana', kode: 'A0080', kelas: 'XII IPA 1', jumlahPinjam: 3, jumlahBuku: 4 },
+      { nama: 'Jihan Salsabila', kode: 'A0091', kelas: 'X IPS 1', jumlahPinjam: 2, jumlahBuku: 3 },
+    ];
+    return seed.slice(0, limit).map((s, i) => ({
+      anggotaId: i + 1,
+      nama: s.nama,
+      kodeAnggota: s.kode,
+      kelas: s.kelas,
+      jumlahPinjam: s.jumlahPinjam,
+      jumlahBuku: s.jumlahBuku,
+    }));
+  },
+  async topBuku(_from, _to, limit = 10) {
+    const seed = [
+      { judul: 'Bumi Manusia', kode: 'B0042', pengarang: 'Pramoedya A. Toer', jumlah: 21 },
+      { judul: 'Laskar Pelangi', kode: 'B0017', pengarang: 'Andrea Hirata', jumlah: 17 },
+      { judul: 'Negeri 5 Menara', kode: 'B0089', pengarang: 'Ahmad Fuadi', jumlah: 13 },
+      { judul: 'Atomic Habits', kode: 'B0123', pengarang: 'James Clear', jumlah: 11 },
+      { judul: 'Sapiens', kode: 'B0211', pengarang: 'Yuval Noah Harari', jumlah: 9 },
+      { judul: 'Tenggelamnya Kapal Van Der Wijck', kode: 'B0034', pengarang: 'Hamka', jumlah: 8 },
+      { judul: 'Pulang', kode: 'B0156', pengarang: 'Tere Liye', jumlah: 7 },
+      { judul: 'Dilan 1990', kode: 'B0203', pengarang: 'Pidi Baiq', jumlah: 6 },
+      { judul: 'Filosofi Teras', kode: 'B0244', pengarang: 'Henry Manampiring', jumlah: 5 },
+      { judul: 'Rich Dad Poor Dad', kode: 'B0298', pengarang: 'Robert Kiyosaki', jumlah: 4 },
+    ];
+    return seed.slice(0, limit).map((s, i) => ({
+      bukuId: i + 1,
+      kode: s.kode,
+      judul: s.judul,
+      pengarang: s.pengarang,
+      jumlah: s.jumlah,
+    }));
+  },
+  async kas(from, to) {
+    const seedRows: KasRow[] = [
+      { id: 1, tanggal: from, keterangan: 'Modal awal', jenis: 'masuk', sumber: 'modal', nominal: 250_000 },
+      { id: 2, tanggal: from, keterangan: 'Beli stiker label', jenis: 'keluar', sumber: 'manual', nominal: 32_000 },
+      { id: 3, tanggal: to, keterangan: 'Denda buku terlambat', jenis: 'masuk', sumber: 'denda', nominal: 9_000 },
+      { id: 4, tanggal: to, keterangan: 'Ganti buku hilang', jenis: 'masuk', sumber: 'hilang', nominal: 65_000 },
+    ];
+    let running = 0;
+    const cumulative: KasCumulative[] = [];
+    let last: string | null = null;
+    let totalMasuk = 0;
+    let totalKeluar = 0;
+    let fromDenda = 0;
+    let fromManual = 0;
+    let fromHilang = 0;
+    let fromModal = 0;
+    for (const r of seedRows) {
+      running += r.jenis === 'masuk' ? r.nominal : -r.nominal;
+      if (r.jenis === 'masuk') {
+        totalMasuk += r.nominal;
+        if (r.sumber === 'denda') fromDenda += r.nominal;
+        else if (r.sumber === 'hilang') fromHilang += r.nominal;
+        else if (r.sumber === 'modal') fromModal += r.nominal;
+        else fromManual += r.nominal;
+      } else {
+        totalKeluar += r.nominal;
+      }
+      if (last === r.tanggal) {
+        cumulative[cumulative.length - 1]!.saldo = running;
+      } else {
+        cumulative.push({ tanggal: r.tanggal, saldo: running });
+        last = r.tanggal;
+      }
+    }
+    return {
+      totalMasuk,
+      totalKeluar,
+      saldoAkhir: totalMasuk - totalKeluar,
+      fromDenda,
+      fromManual,
+      fromHilang,
+      fromModal,
+      rows: seedRows,
+      cumulative,
+    };
+  },
+  async backupCreate() {
+    return {
+      path: '/tmp/perpustakaan-mock.db',
+      checksum: '0'.repeat(64),
+      sizeBytes: 0,
+    };
+  },
+  async backupRestore() {
+    return {
+      path: '/tmp/perpustakaan-mock.db',
+      checksum: '0'.repeat(64),
+      sizeBytes: 0,
+    };
+  },
+  async backupScheduleGet() {
+    return { enabled: false, cron: '0 2 * * *', lastRun: null };
+  },
+  async backupScheduleSet(enabled, cron) {
+    return { enabled, cron, lastRun: null };
+  },
+  async backupDbPath() {
+    return '/mock/perpustakaan.db';
+  },
+};
+
+export const laporanApi: LaporanRpc = isTauri() ? tauriRpc : mockRpc;
+
+/** Format human-readable preview untuk cron 5-field. */
+export function describeCron(cron: string): string {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return 'Format cron tidak valid';
+  const [m, h, dom, mon, dow] = parts;
+  const numeric = (v: string): number | null => {
+    if (!/^\d+$/.test(v)) return null;
+    const n = Number.parseInt(v, 10);
+    return Number.isFinite(n) ? n : null;
+  };
+  const minute = numeric(m!);
+  const hour = numeric(h!);
+  if (minute == null || hour == null) {
+    return `Cron: ${cron}`;
+  }
+  const time = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+  if (dom === '*' && mon === '*' && dow === '*') {
+    return `Setiap hari pukul ${time}`;
+  }
+  if (mon === '*' && dom === '*') {
+    const days = ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu'];
+    const idx = numeric(dow!);
+    if (idx != null && days[idx]) {
+      return `Setiap ${days[idx]} pukul ${time}`;
+    }
+  }
+  return `Cron: ${cron}`;
+}
+
+/** Format CSV row, escape jika ada koma atau kutip. */
+export function csvCell(value: string | number | null | undefined): string {
+  const s = value == null ? '' : String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export function toCsv(headers: string[], rows: Array<Array<string | number | null>>): string {
+  const lines = [headers.map(csvCell).join(',')];
+  for (const row of rows) {
+    lines.push(row.map(csvCell).join(','));
+  }
+  return lines.join('\n');
+}

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -12,15 +12,22 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthedLaporanRouteImport } from './routes/_authed/laporan'
 import { Route as AuthedKunjunganRouteImport } from './routes/_authed/kunjungan'
 import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard'
 import { Route as AuthedPengembalianIndexRouteImport } from './routes/_authed/pengembalian/index'
 import { Route as AuthedPeminjamanIndexRouteImport } from './routes/_authed/peminjaman/index'
+import { Route as AuthedLaporanIndexRouteImport } from './routes/_authed/laporan/index'
 import { Route as AuthedBukuIndexRouteImport } from './routes/_authed/buku/index'
 import { Route as AuthedAnggotaIndexRouteImport } from './routes/_authed/anggota/index'
 import { Route as AuthedSettingsMasterDataRouteImport } from './routes/_authed/settings/master-data'
 import { Route as AuthedPeminjamanNewRouteImport } from './routes/_authed/peminjaman/new'
 import { Route as AuthedPeminjamanIdRouteImport } from './routes/_authed/peminjaman/$id'
+import { Route as AuthedLaporanTopPeminjamRouteImport } from './routes/_authed/laporan/top-peminjam'
+import { Route as AuthedLaporanTopBukuRouteImport } from './routes/_authed/laporan/top-buku'
+import { Route as AuthedLaporanKasRouteImport } from './routes/_authed/laporan/kas'
+import { Route as AuthedLaporanGrafikRouteImport } from './routes/_authed/laporan/grafik'
+import { Route as AuthedLaporanBackupRouteImport } from './routes/_authed/laporan/backup'
 import { Route as AuthedBukuNewRouteImport } from './routes/_authed/buku/new'
 import { Route as AuthedBukuIdRouteImport } from './routes/_authed/buku/$id'
 import { Route as AuthedAnggotaNewRouteImport } from './routes/_authed/anggota/new'
@@ -39,6 +46,11 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthedLaporanRoute = AuthedLaporanRouteImport.update({
+  id: '/laporan',
+  path: '/laporan',
+  getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedKunjunganRoute = AuthedKunjunganRouteImport.update({
   id: '/kunjungan',
@@ -59,6 +71,11 @@ const AuthedPeminjamanIndexRoute = AuthedPeminjamanIndexRouteImport.update({
   id: '/peminjaman/',
   path: '/peminjaman/',
   getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedLaporanIndexRoute = AuthedLaporanIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthedLaporanRoute,
 } as any)
 const AuthedBukuIndexRoute = AuthedBukuIndexRouteImport.update({
   id: '/buku/',
@@ -86,6 +103,32 @@ const AuthedPeminjamanIdRoute = AuthedPeminjamanIdRouteImport.update({
   path: '/peminjaman/$id',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedLaporanTopPeminjamRoute =
+  AuthedLaporanTopPeminjamRouteImport.update({
+    id: '/top-peminjam',
+    path: '/top-peminjam',
+    getParentRoute: () => AuthedLaporanRoute,
+  } as any)
+const AuthedLaporanTopBukuRoute = AuthedLaporanTopBukuRouteImport.update({
+  id: '/top-buku',
+  path: '/top-buku',
+  getParentRoute: () => AuthedLaporanRoute,
+} as any)
+const AuthedLaporanKasRoute = AuthedLaporanKasRouteImport.update({
+  id: '/kas',
+  path: '/kas',
+  getParentRoute: () => AuthedLaporanRoute,
+} as any)
+const AuthedLaporanGrafikRoute = AuthedLaporanGrafikRouteImport.update({
+  id: '/grafik',
+  path: '/grafik',
+  getParentRoute: () => AuthedLaporanRoute,
+} as any)
+const AuthedLaporanBackupRoute = AuthedLaporanBackupRouteImport.update({
+  id: '/backup',
+  path: '/backup',
+  getParentRoute: () => AuthedLaporanRoute,
+} as any)
 const AuthedBukuNewRoute = AuthedBukuNewRouteImport.update({
   id: '/buku/new',
   path: '/buku/new',
@@ -112,15 +155,22 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/dashboard': typeof AuthedDashboardRoute
   '/kunjungan': typeof AuthedKunjunganRoute
+  '/laporan': typeof AuthedLaporanRouteWithChildren
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
   '/buku/$id': typeof AuthedBukuIdRoute
   '/buku/new': typeof AuthedBukuNewRoute
+  '/laporan/backup': typeof AuthedLaporanBackupRoute
+  '/laporan/grafik': typeof AuthedLaporanGrafikRoute
+  '/laporan/kas': typeof AuthedLaporanKasRoute
+  '/laporan/top-buku': typeof AuthedLaporanTopBukuRoute
+  '/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/peminjaman/new': typeof AuthedPeminjamanNewRoute
   '/settings/master-data': typeof AuthedSettingsMasterDataRoute
   '/anggota/': typeof AuthedAnggotaIndexRoute
   '/buku/': typeof AuthedBukuIndexRoute
+  '/laporan/': typeof AuthedLaporanIndexRoute
   '/peminjaman/': typeof AuthedPeminjamanIndexRoute
   '/pengembalian/': typeof AuthedPengembalianIndexRoute
 }
@@ -133,11 +183,17 @@ export interface FileRoutesByTo {
   '/anggota/new': typeof AuthedAnggotaNewRoute
   '/buku/$id': typeof AuthedBukuIdRoute
   '/buku/new': typeof AuthedBukuNewRoute
+  '/laporan/backup': typeof AuthedLaporanBackupRoute
+  '/laporan/grafik': typeof AuthedLaporanGrafikRoute
+  '/laporan/kas': typeof AuthedLaporanKasRoute
+  '/laporan/top-buku': typeof AuthedLaporanTopBukuRoute
+  '/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/peminjaman/new': typeof AuthedPeminjamanNewRoute
   '/settings/master-data': typeof AuthedSettingsMasterDataRoute
   '/anggota': typeof AuthedAnggotaIndexRoute
   '/buku': typeof AuthedBukuIndexRoute
+  '/laporan': typeof AuthedLaporanIndexRoute
   '/peminjaman': typeof AuthedPeminjamanIndexRoute
   '/pengembalian': typeof AuthedPengembalianIndexRoute
 }
@@ -148,15 +204,22 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/_authed/dashboard': typeof AuthedDashboardRoute
   '/_authed/kunjungan': typeof AuthedKunjunganRoute
+  '/_authed/laporan': typeof AuthedLaporanRouteWithChildren
   '/_authed/anggota/$id': typeof AuthedAnggotaIdRoute
   '/_authed/anggota/new': typeof AuthedAnggotaNewRoute
   '/_authed/buku/$id': typeof AuthedBukuIdRoute
   '/_authed/buku/new': typeof AuthedBukuNewRoute
+  '/_authed/laporan/backup': typeof AuthedLaporanBackupRoute
+  '/_authed/laporan/grafik': typeof AuthedLaporanGrafikRoute
+  '/_authed/laporan/kas': typeof AuthedLaporanKasRoute
+  '/_authed/laporan/top-buku': typeof AuthedLaporanTopBukuRoute
+  '/_authed/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/_authed/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/_authed/peminjaman/new': typeof AuthedPeminjamanNewRoute
   '/_authed/settings/master-data': typeof AuthedSettingsMasterDataRoute
   '/_authed/anggota/': typeof AuthedAnggotaIndexRoute
   '/_authed/buku/': typeof AuthedBukuIndexRoute
+  '/_authed/laporan/': typeof AuthedLaporanIndexRoute
   '/_authed/peminjaman/': typeof AuthedPeminjamanIndexRoute
   '/_authed/pengembalian/': typeof AuthedPengembalianIndexRoute
 }
@@ -167,15 +230,22 @@ export interface FileRouteTypes {
     | '/login'
     | '/dashboard'
     | '/kunjungan'
+    | '/laporan'
     | '/anggota/$id'
     | '/anggota/new'
     | '/buku/$id'
     | '/buku/new'
+    | '/laporan/backup'
+    | '/laporan/grafik'
+    | '/laporan/kas'
+    | '/laporan/top-buku'
+    | '/laporan/top-peminjam'
     | '/peminjaman/$id'
     | '/peminjaman/new'
     | '/settings/master-data'
     | '/anggota/'
     | '/buku/'
+    | '/laporan/'
     | '/peminjaman/'
     | '/pengembalian/'
   fileRoutesByTo: FileRoutesByTo
@@ -188,11 +258,17 @@ export interface FileRouteTypes {
     | '/anggota/new'
     | '/buku/$id'
     | '/buku/new'
+    | '/laporan/backup'
+    | '/laporan/grafik'
+    | '/laporan/kas'
+    | '/laporan/top-buku'
+    | '/laporan/top-peminjam'
     | '/peminjaman/$id'
     | '/peminjaman/new'
     | '/settings/master-data'
     | '/anggota'
     | '/buku'
+    | '/laporan'
     | '/peminjaman'
     | '/pengembalian'
   id:
@@ -202,15 +278,22 @@ export interface FileRouteTypes {
     | '/login'
     | '/_authed/dashboard'
     | '/_authed/kunjungan'
+    | '/_authed/laporan'
     | '/_authed/anggota/$id'
     | '/_authed/anggota/new'
     | '/_authed/buku/$id'
     | '/_authed/buku/new'
+    | '/_authed/laporan/backup'
+    | '/_authed/laporan/grafik'
+    | '/_authed/laporan/kas'
+    | '/_authed/laporan/top-buku'
+    | '/_authed/laporan/top-peminjam'
     | '/_authed/peminjaman/$id'
     | '/_authed/peminjaman/new'
     | '/_authed/settings/master-data'
     | '/_authed/anggota/'
     | '/_authed/buku/'
+    | '/_authed/laporan/'
     | '/_authed/peminjaman/'
     | '/_authed/pengembalian/'
   fileRoutesById: FileRoutesById
@@ -244,6 +327,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authed/laporan': {
+      id: '/_authed/laporan'
+      path: '/laporan'
+      fullPath: '/laporan'
+      preLoaderRoute: typeof AuthedLaporanRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/kunjungan': {
       id: '/_authed/kunjungan'
       path: '/kunjungan'
@@ -271,6 +361,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/peminjaman/'
       preLoaderRoute: typeof AuthedPeminjamanIndexRouteImport
       parentRoute: typeof AuthedRoute
+    }
+    '/_authed/laporan/': {
+      id: '/_authed/laporan/'
+      path: '/'
+      fullPath: '/laporan/'
+      preLoaderRoute: typeof AuthedLaporanIndexRouteImport
+      parentRoute: typeof AuthedLaporanRoute
     }
     '/_authed/buku/': {
       id: '/_authed/buku/'
@@ -307,6 +404,41 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedPeminjamanIdRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/laporan/top-peminjam': {
+      id: '/_authed/laporan/top-peminjam'
+      path: '/top-peminjam'
+      fullPath: '/laporan/top-peminjam'
+      preLoaderRoute: typeof AuthedLaporanTopPeminjamRouteImport
+      parentRoute: typeof AuthedLaporanRoute
+    }
+    '/_authed/laporan/top-buku': {
+      id: '/_authed/laporan/top-buku'
+      path: '/top-buku'
+      fullPath: '/laporan/top-buku'
+      preLoaderRoute: typeof AuthedLaporanTopBukuRouteImport
+      parentRoute: typeof AuthedLaporanRoute
+    }
+    '/_authed/laporan/kas': {
+      id: '/_authed/laporan/kas'
+      path: '/kas'
+      fullPath: '/laporan/kas'
+      preLoaderRoute: typeof AuthedLaporanKasRouteImport
+      parentRoute: typeof AuthedLaporanRoute
+    }
+    '/_authed/laporan/grafik': {
+      id: '/_authed/laporan/grafik'
+      path: '/grafik'
+      fullPath: '/laporan/grafik'
+      preLoaderRoute: typeof AuthedLaporanGrafikRouteImport
+      parentRoute: typeof AuthedLaporanRoute
+    }
+    '/_authed/laporan/backup': {
+      id: '/_authed/laporan/backup'
+      path: '/backup'
+      fullPath: '/laporan/backup'
+      preLoaderRoute: typeof AuthedLaporanBackupRouteImport
+      parentRoute: typeof AuthedLaporanRoute
+    }
     '/_authed/buku/new': {
       id: '/_authed/buku/new'
       path: '/buku/new'
@@ -338,9 +470,32 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface AuthedLaporanRouteChildren {
+  AuthedLaporanBackupRoute: typeof AuthedLaporanBackupRoute
+  AuthedLaporanGrafikRoute: typeof AuthedLaporanGrafikRoute
+  AuthedLaporanKasRoute: typeof AuthedLaporanKasRoute
+  AuthedLaporanTopBukuRoute: typeof AuthedLaporanTopBukuRoute
+  AuthedLaporanTopPeminjamRoute: typeof AuthedLaporanTopPeminjamRoute
+  AuthedLaporanIndexRoute: typeof AuthedLaporanIndexRoute
+}
+
+const AuthedLaporanRouteChildren: AuthedLaporanRouteChildren = {
+  AuthedLaporanBackupRoute: AuthedLaporanBackupRoute,
+  AuthedLaporanGrafikRoute: AuthedLaporanGrafikRoute,
+  AuthedLaporanKasRoute: AuthedLaporanKasRoute,
+  AuthedLaporanTopBukuRoute: AuthedLaporanTopBukuRoute,
+  AuthedLaporanTopPeminjamRoute: AuthedLaporanTopPeminjamRoute,
+  AuthedLaporanIndexRoute: AuthedLaporanIndexRoute,
+}
+
+const AuthedLaporanRouteWithChildren = AuthedLaporanRoute._addFileChildren(
+  AuthedLaporanRouteChildren,
+)
+
 interface AuthedRouteChildren {
   AuthedDashboardRoute: typeof AuthedDashboardRoute
   AuthedKunjunganRoute: typeof AuthedKunjunganRoute
+  AuthedLaporanRoute: typeof AuthedLaporanRouteWithChildren
   AuthedAnggotaIdRoute: typeof AuthedAnggotaIdRoute
   AuthedAnggotaNewRoute: typeof AuthedAnggotaNewRoute
   AuthedBukuIdRoute: typeof AuthedBukuIdRoute
@@ -357,6 +512,7 @@ interface AuthedRouteChildren {
 const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedDashboardRoute: AuthedDashboardRoute,
   AuthedKunjunganRoute: AuthedKunjunganRoute,
+  AuthedLaporanRoute: AuthedLaporanRouteWithChildren,
   AuthedAnggotaIdRoute: AuthedAnggotaIdRoute,
   AuthedAnggotaNewRoute: AuthedAnggotaNewRoute,
   AuthedBukuIdRoute: AuthedBukuIdRoute,

--- a/apps/desktop/src/routes/_authed/laporan.tsx
+++ b/apps/desktop/src/routes/_authed/laporan.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { LaporanLayout } from '@/features/laporan/LaporanLayout';
+
+export const Route = createFileRoute('/_authed/laporan')({
+  component: LaporanLayout,
+});

--- a/apps/desktop/src/routes/_authed/laporan/backup.tsx
+++ b/apps/desktop/src/routes/_authed/laporan/backup.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { LaporanBackup } from '@/features/laporan/BackupSubPage';
+
+export const Route = createFileRoute('/_authed/laporan/backup')({
+  component: LaporanBackup,
+});

--- a/apps/desktop/src/routes/_authed/laporan/grafik.tsx
+++ b/apps/desktop/src/routes/_authed/laporan/grafik.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { LaporanGrafik } from '@/features/laporan/GrafikSubPage';
+
+export const Route = createFileRoute('/_authed/laporan/grafik')({
+  component: LaporanGrafik,
+});

--- a/apps/desktop/src/routes/_authed/laporan/index.tsx
+++ b/apps/desktop/src/routes/_authed/laporan/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_authed/laporan/')({
+  beforeLoad: () => {
+    throw redirect({ to: '/laporan/grafik' });
+  },
+});

--- a/apps/desktop/src/routes/_authed/laporan/kas.tsx
+++ b/apps/desktop/src/routes/_authed/laporan/kas.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { LaporanKas } from '@/features/laporan/KasSubPage';
+
+export const Route = createFileRoute('/_authed/laporan/kas')({
+  component: LaporanKas,
+});

--- a/apps/desktop/src/routes/_authed/laporan/top-buku.tsx
+++ b/apps/desktop/src/routes/_authed/laporan/top-buku.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { LaporanTopBuku } from '@/features/laporan/TopBukuSubPage';
+
+export const Route = createFileRoute('/_authed/laporan/top-buku')({
+  component: LaporanTopBuku,
+});

--- a/apps/desktop/src/routes/_authed/laporan/top-peminjam.tsx
+++ b/apps/desktop/src/routes/_authed/laporan/top-peminjam.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { LaporanTopPeminjam } from '@/features/laporan/TopPeminjamSubPage';
+
+export const Route = createFileRoute('/_authed/laporan/top-peminjam')({
+  component: LaporanTopPeminjam,
+});

--- a/apps/desktop/tests/e2e/laporan.spec.ts
+++ b/apps/desktop/tests/e2e/laporan.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+async function login(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/login');
+  await page.evaluate(() => {
+    localStorage.removeItem('po:auth');
+  });
+  await page.reload();
+  await page.getByLabel(/Nama Pengguna|Username/).fill('admin');
+  await page.getByLabel(/Kata Sandi|Password/).fill('admin123');
+  await page.getByRole('button', { name: /Masuk|Sign in/ }).click();
+  await expect(page).toHaveURL(/\/dashboard/);
+}
+
+test.describe('laporan', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await login(page);
+    await page.goto('/laporan');
+    await expect(page.getByTestId('laporan-layout')).toBeVisible();
+  });
+
+  test('redirects /laporan to /laporan/grafik with sidebar nav visible', async ({ page }) => {
+    await expect(page).toHaveURL(/\/laporan\/grafik/);
+    await expect(page.getByTestId('laporan-nav')).toBeVisible();
+  });
+
+  test('navigates to top-peminjam and shows table', async ({ page }) => {
+    await page.getByRole('link', { name: /Top Peminjam|Top Borrowers/ }).click();
+    await expect(page).toHaveURL(/\/laporan\/top-peminjam/);
+    await expect(page.getByTestId('top-peminjam-table')).toBeVisible();
+  });
+
+  test('navigates to kas and shows summary cards', async ({ page }) => {
+    await page.getByRole('link', { name: /Kas|Cash/ }).click();
+    await expect(page).toHaveURL(/\/laporan\/kas/);
+    await expect(page.getByText(/Total Masuk|Total In/)).toBeVisible();
+    await expect(page.getByText(/Saldo Akhir|Closing Balance/)).toBeVisible();
+  });
+
+  test('navigates to backup and shows controls', async ({ page }) => {
+    await page.getByRole('link', { name: /^Backup$/ }).click();
+    await expect(page).toHaveURL(/\/laporan\/backup/);
+    await expect(page.getByTestId('backup-create')).toBeVisible();
+    await expect(page.getByTestId('schedule-cron')).toBeVisible();
+  });
+});

--- a/apps/desktop/tests/unit/laporan.test.ts
+++ b/apps/desktop/tests/unit/laporan.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { csvCell, describeCron, laporanApi, toCsv } from '@/lib/laporan';
+
+describe('csvCell', () => {
+  it('returns plain string for safe values', () => {
+    expect(csvCell('Adelia')).toBe('Adelia');
+    expect(csvCell(42)).toBe('42');
+    expect(csvCell(null)).toBe('');
+    expect(csvCell(undefined)).toBe('');
+  });
+
+  it('quotes and escapes when value has comma, quote, or newline', () => {
+    expect(csvCell('Hello, world')).toBe('"Hello, world"');
+    expect(csvCell('She said "hi"')).toBe('"She said ""hi"""');
+    expect(csvCell('multi\nline')).toBe('"multi\nline"');
+  });
+});
+
+describe('toCsv', () => {
+  it('builds header + rows joined by newline', () => {
+    const csv = toCsv(
+      ['kode', 'judul', 'jumlah'],
+      [
+        ['B001', 'Bumi Manusia', 21],
+        ['B002', 'Laskar, Pelangi', 17],
+      ],
+    );
+    expect(csv).toBe('kode,judul,jumlah\nB001,Bumi Manusia,21\nB002,"Laskar, Pelangi",17');
+  });
+});
+
+describe('describeCron', () => {
+  it('describes daily schedule with HH:MM', () => {
+    expect(describeCron('0 2 * * *')).toBe('Setiap hari pukul 02:00');
+    expect(describeCron('30 14 * * *')).toBe('Setiap hari pukul 14:30');
+  });
+
+  it('describes weekly schedule with day name', () => {
+    expect(describeCron('0 9 * * 1')).toBe('Setiap Senin pukul 09:00');
+    expect(describeCron('15 7 * * 5')).toBe('Setiap Jumat pukul 07:15');
+  });
+
+  it('returns generic format for unsupported expressions', () => {
+    expect(describeCron('*/15 * * * *')).toMatch(/Cron:/);
+    expect(describeCron('not-a-cron')).toMatch(/tidak valid/);
+  });
+});
+
+describe('laporanApi (browser mock)', () => {
+  it('grafik returns inclusive day range', async () => {
+    const days = await laporanApi.grafik('2025-01-01', '2025-01-07', 'day');
+    expect(days.length).toBe(7);
+    expect(days[0]!.bucket).toBe('2025-01-01');
+    expect(days[days.length - 1]!.bucket).toBe('2025-01-07');
+  });
+
+  it('grafik returns monthly buckets when granularity=month', async () => {
+    const months = await laporanApi.grafik('2025-01-01', '2025-03-15', 'month');
+    expect(months.length).toBe(3);
+    expect(months[0]!.bucket).toBe('2025-01');
+    expect(months[2]!.bucket).toBe('2025-03');
+  });
+
+  it('topPeminjam respects limit and is sorted DESC', async () => {
+    const rows = await laporanApi.topPeminjam('2025-01-01', '2025-12-31', 5);
+    expect(rows.length).toBe(5);
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i - 1]!.jumlahPinjam).toBeGreaterThanOrEqual(rows[i]!.jumlahPinjam);
+    }
+  });
+
+  it('kas summary saldoAkhir = totalMasuk - totalKeluar', async () => {
+    const k = await laporanApi.kas('2025-01-01', '2025-12-31');
+    expect(k.saldoAkhir).toBe(k.totalMasuk - k.totalKeluar);
+    expect(k.fromManual + k.fromDenda + k.fromHilang + k.fromModal).toBe(k.totalMasuk);
+  });
+
+  it('kas cumulative ends at saldoAkhir', async () => {
+    const k = await laporanApi.kas('2025-01-01', '2025-12-31');
+    expect(k.cumulative.length).toBeGreaterThan(0);
+    expect(k.cumulative[k.cumulative.length - 1]!.saldo).toBe(k.saldoAkhir);
+  });
+
+  it('backupScheduleSet preserves cron and enabled', async () => {
+    const s = await laporanApi.backupScheduleSet(true, '0 3 * * *');
+    expect(s.enabled).toBe(true);
+    expect(s.cron).toBe('0 3 * * *');
+  });
+});

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -92,7 +92,7 @@ sessions:
   - id: 9
     title: Laporan komplit (Grafik / Top Peminjam / Top Buku / Kas / Backup)
     status: COMPLETED
-    pr: PENDING
+    pr: https://github.com/alviarts/perpustakaan-offline/pull/46
     completed_at: 2026-05-03
     dependencies: [6, 7, 8]
 
@@ -130,7 +130,7 @@ sessions:
 | 6 | Peminjaman + Pengembalian | COMPLETED | [#43](https://github.com/alviarts/perpustakaan-offline/pull/43) | 2026-05-03 | 4, 5 |
 | 7 | Kunjungan redesign | COMPLETED | [#44](https://github.com/alviarts/perpustakaan-offline/pull/44) | 2026-05-03 | 3, 4 |
 | 8 | Dashboard modern + charts | COMPLETED | [#45](https://github.com/alviarts/perpustakaan-offline/pull/45) | 2026-05-03 | 4, 5, 6 |
-| 9 | Laporan komplit | COMPLETED | PENDING | 2026-05-03 | 6, 7, 8 |
+| 9 | Laporan komplit | COMPLETED | [#46](https://github.com/alviarts/perpustakaan-offline/pull/46) | 2026-05-03 | 6, 7, 8 |
 | 10 | KTA system | PENDING | PENDING | — | 4, 5 |
 | 11 | Settings 12 kategori + manual + audit wording | PENDING | PENDING | — | 3, 5, 10 |
 | 12 | Installer MSI + release v1.0.0 | PENDING | PENDING | — | 2..11 |

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -21,7 +21,7 @@ project: perpustakaan-offline
 migration: v1 (python+customtkinter) -> v2 (tauri 2.0 + react 18 + ts + tailwind 3 + shadcn + zustand)
 total_sessions: 12
 schema_version: 1
-last_updated: 2026-05-03 (session 08)
+last_updated: 2026-05-03 (session 09)
 ```
 
 ## Sessions
@@ -91,9 +91,9 @@ sessions:
 
   - id: 9
     title: Laporan komplit (Grafik / Top Peminjam / Top Buku / Kas / Backup)
-    status: PENDING
+    status: COMPLETED
     pr: PENDING
-    completed_at: null
+    completed_at: 2026-05-03
     dependencies: [6, 7, 8]
 
   - id: 10
@@ -130,7 +130,7 @@ sessions:
 | 6 | Peminjaman + Pengembalian | COMPLETED | [#43](https://github.com/alviarts/perpustakaan-offline/pull/43) | 2026-05-03 | 4, 5 |
 | 7 | Kunjungan redesign | COMPLETED | [#44](https://github.com/alviarts/perpustakaan-offline/pull/44) | 2026-05-03 | 3, 4 |
 | 8 | Dashboard modern + charts | COMPLETED | [#45](https://github.com/alviarts/perpustakaan-offline/pull/45) | 2026-05-03 | 4, 5, 6 |
-| 9 | Laporan komplit | PENDING | PENDING | — | 6, 7, 8 |
+| 9 | Laporan komplit | COMPLETED | PENDING | 2026-05-03 | 6, 7, 8 |
 | 10 | KTA system | PENDING | PENDING | — | 4, 5 |
 | 11 | Settings 12 kategori + manual + audit wording | PENDING | PENDING | — | 3, 5, 10 |
 | 12 | Installer MSI + release v1.0.0 | PENDING | PENDING | — | 2..11 |


### PR DESCRIPTION
## Summary

Sesi 9/12 — halaman **Laporan** komplit dengan 5 sub-page (Grafik, Top Peminjam, Top Buku, Kas, Backup), filter date range, dan ekspor CSV / PDF (print-friendly). Plus backup full SQLite + checksum SHA256 + jadwal cron.

**Goal sesi:** ganti placeholder Laporan dari sesi 2/3 dengan implementasi penuh sesuai mockup v2 (revisi #23) — sidebar nav, charts, tabel, ekspor, backup/restore.

### Revisi tercover
- **#23** Laporan komplit (Grafik / Top Peminjam / Top Buku / Kas / Backup) — full.

### Deliverables

**Backend Rust** (`apps/desktop/src-tauri/`)

- `commands/laporan.rs` — 4 query agregat read-only:
  - `laporan_grafik(from, to, granularity)` — kunjungan vs peminjaman bucketed `day` / `month` / `year` via `strftime`, hasil `LEFT JOIN`-ed sehingga bucket kosong tetap muncul dengan nilai 0.
  - `laporan_top_peminjam(from, to, limit)` — `COUNT(DISTINCT peminjaman.id)` + sub-query `jumlah_buku` via `peminjaman_item`.
  - `laporan_top_buku(from, to, limit)` — JOIN `peminjaman_item` → `buku` + `ORDER BY count DESC`.
  - `laporan_kas(from, to)` — total masuk / keluar, breakdown sumber (manual / denda / hilang / modal), saldo akhir, kumulatif harian.
- `commands/backup.rs` — backup / restore + jadwal:
  - `backup_create(target_dir)` — copy DB → `perpustakaan-<stamp>.db` + tulis sidecar `.db.sha256`.
  - `backup_restore(file_path, expected_checksum?)` — validasi SHA256 (case-insensitive), simpan preview lama (`*.preview-restore`), overwrite DB aktif.
  - `backup_schedule_get` / `backup_schedule_set(enabled, cron)` — disimpan di tabel `settings` (validasi 5-field).
  - `backup_db_path()` — surface path DB aktif untuk UI.
- Cargo: tambah `sha2 = "0.10"` (workspace tidak berubah, dep ringan).

**Frontend** (`apps/desktop/src/`)

- Routing: `/laporan` (layout dengan sidebar nav) → 5 child route file-based:
  - `/laporan` → redirect ke `/laporan/grafik`
  - `/laporan/grafik`, `/laporan/top-peminjam`, `/laporan/top-buku`, `/laporan/kas`, `/laporan/backup`.
- `features/laporan/LaporanLayout.tsx` — sidebar nav 5 entry + `<Outlet />`, `[&.active]` highlight.
- `features/laporan/RangeToolbar.tsx` — `DateRangePicker` + tombol Export CSV / PDF (PDF via `window.print()`, CSV via `Blob` download).
- 5 sub-page komponen:
  - **GrafikSubPage** — `Select` granularity (day/month/year), `ChartBar`, 2 summary card.
  - **TopPeminjamSubPage** — `ChartBar` + tabel rank/nama/kelas/pinjam/buku.
  - **TopBukuSubPage** — `ChartBar` + tabel rank/kode/judul/pengarang/jumlah.
  - **KasSubPage** — 3 summary card (masuk / keluar / saldo) berwarna + `ChartPie` breakdown sumber + tabel transaksi.
  - **BackupSubPage** — backup-now (folder picker), restore (file picker), toggle jadwal, cron input dengan preview natural-language (`describeCron`).
- `lib/laporan.ts` — Tauri RPC + browser mock + helpers (`describeCron`, `toCsv`, `csvCell`).
- `features/laporan/utils.ts` — `downloadText`, `printHtml`, `buildLaporanPdfHtml` (header identitas, body table, footer timestamp).
- `Sidebar.tsx` — hapus `pending: true` dari `/laporan`, sekarang aktif.
- i18n: namespace `laporan` di id + en (nav, kolom, sub-page, backup).

### Tests added

- **Unit (12 baru)** `tests/unit/laporan.test.ts`:
  - `csvCell` — escape comma / quote / newline.
  - `toCsv` — header + rows joined newline.
  - `describeCron` — daily, weekly, invalid (non-numeric / wrong arity).
  - `laporanApi` mock — grafik day count = 7, monthly buckets `YYYY-MM`, top-peminjam DESC + limit, kas saldo invariant (`saldoAkhir = totalMasuk - totalKeluar`), kas cumulative ending = saldoAkhir, backupScheduleSet roundtrip.
- **E2E (4 baru)** `tests/e2e/laporan.spec.ts`:
  - `/laporan` redirect ke `/laporan/grafik` + sidebar nav visible.
  - Klik nav Top Peminjam → tabel render.
  - Klik nav Kas → 3 summary card render (masuk + saldo).
  - Klik nav Backup → tombol backup + cron input render.

Total tes: 77 → **89** (semua hijau lokal).

### Lokal verification
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (13 file, 89 test), `pnpm build` semua hijau.
- `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` semua hijau.

## Review & Testing Checklist for Human

Risk: **yellow** — backup/restore menyentuh file DB di `app_data_dir`. Sebelum klik Restore di build production, pastikan backup terbaru sudah ada (atau test di DB seed).

- [ ] Buka `/laporan` → otomatis redirect ke `/laporan/grafik`, sidebar nav 5 item visible.
- [ ] Pilih granularity berbeda di Grafik → chart + tabel update.
- [ ] Top Peminjam / Top Buku → tabel + bar chart + Export CSV menghasilkan file valid.
- [ ] Klik Export PDF → window print muncul, header pakai identitas perpustakaan.
- [ ] Kas → summary 3 kolom (masuk/keluar/saldo) tampil dalam IDR; donut chart breakdown sumber.
- [ ] Backup → klik "Backup Sekarang", pilih folder, terbentuk `perpustakaan-<stamp>.db` + `.sha256` sidecar; toast checksum muncul.
- [ ] Restore → pilih file backup, app overwrite DB; konfirmasi data tetap utuh setelah reload.
- [ ] Schedule → ubah cron ke `0 9 * * 1`, preview "Setiap Senin pukul 09:00" muncul; toggle aktif + Simpan; reload halaman, nilai masih ada.

### Notes

- **Cron runner belum jalan otomatis** — sesuai SESSION_09 ("jadwal cron-like di Devin 12"), session ini hanya simpan konfigurasi di `settings` table. Sesi 12 (installer + release) akan menambahkan tray-task / OS-level scheduler hook.
- **Excel export → CSV** — saya sengaja pakai CSV (UTF-8 + escape) ketimbang `xlsx` lib. Excel buka CSV native, dan ini menghemat ~150 KB bundle + zero deps.
- **PDF via window.print()** — sama pattern dengan nota peminjaman (sesi 6). Browser/Tauri webview punya "Save as PDF" di dialog print, jadi tidak butuh `pdf-lib`.
- **Mock data di browser mode** — semua sub-page menampilkan seed deterministik (4 transaksi kas, 10 peminjam, 10 buku, 7-30 hari kunjungan) supaya UI demonstratif tanpa Tauri/SQLite. Tauri mode otomatis ke real DB.
- **Backup checksum** — sidecar `.db.sha256` ditulis bersamaan; restore cek case-insensitive. Format file `.db` standar SQLite, kompatibel dengan tools eksternal (sqlite3 CLI).

Footer: **Devin session 9/12.**