### PR TITLE
feat(session-11): Settings 12 categories, manual book HTML, wording audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ src-tauri/gen/
 
 # Tauri auto-generated
 apps/desktop/src-tauri/gen/
+
+# Generated manual book HTML (built by `pnpm --filter @perpustakaan/manual build`)
+apps/desktop/public/manual/

--- a/apps/desktop/src-tauri/src/commands/manual.rs
+++ b/apps/desktop/src-tauri/src/commands/manual.rs
@@ -1,0 +1,32 @@
+//! Manual book opener (revisi #4).
+//!
+//! Opens the bundled HTML user manual in a separate Tauri webview window.
+//! The manual is built from `docs/manual.md` into `dist/manual/index.html` by
+//! the `apps/manual` workspace package and shipped as a regular frontend asset.
+
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+use crate::error::{AppError, AppResult};
+
+const MANUAL_WINDOW_LABEL: &str = "manual";
+const MANUAL_PATH: &str = "/manual/index.html";
+
+#[tauri::command]
+pub fn open_manual(app: AppHandle) -> AppResult<()> {
+    if let Some(existing) = app.get_webview_window(MANUAL_WINDOW_LABEL) {
+        existing.set_focus().ok();
+        return Ok(());
+    }
+    WebviewWindowBuilder::new(
+        &app,
+        MANUAL_WINDOW_LABEL,
+        WebviewUrl::App(MANUAL_PATH.trim_start_matches('/').into()),
+    )
+    .title("Buku Manual — Perpustakaan Offline")
+    .inner_size(960.0, 720.0)
+    .min_inner_size(640.0, 480.0)
+    .resizable(true)
+    .build()
+    .map_err(|e| AppError::Internal(format!("open_manual: {e}")))?;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -7,6 +7,8 @@ pub mod identity;
 pub mod kta;
 pub mod kunjungan;
 pub mod laporan;
+pub mod manual;
 pub mod master_data;
 pub mod peminjaman;
+pub mod settings;
 pub mod window_state;

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -1,0 +1,453 @@
+//! Settings commands (revisi #24).
+//!
+//! Bulk key/value access (`settings_get_many` / `settings_set_many`),
+//! account management (`settings_users_*`), permission matrix
+//! (`settings_permissions_*`), and audit-log query
+//! (`settings_audit_log_query`) — all back the in-app Settings page.
+
+use std::collections::BTreeMap;
+
+use rusqlite::{params, params_from_iter};
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+// ---------------------------------------------------------------------------
+// Generic key/value
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn settings_get_many(
+    state: State<'_, AppState>,
+    keys: Vec<String>,
+) -> AppResult<BTreeMap<String, String>> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let mut out: BTreeMap<String, String> = BTreeMap::new();
+    if keys.is_empty() {
+        return Ok(out);
+    }
+    let placeholders = keys.iter().map(|_| "?".to_string()).collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT key, value FROM settings WHERE key IN ({placeholders})",
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(
+        params_from_iter(keys.iter()),
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            ))
+        },
+    )?;
+    for r in rows {
+        let (k, v) = r?;
+        out.insert(k, v);
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+pub fn settings_set_many(
+    state: State<'_, AppState>,
+    entries: BTreeMap<String, String>,
+) -> AppResult<()> {
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let tx = conn.transaction()?;
+    for (k, v) in entries {
+        tx.execute(
+            "INSERT INTO settings (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![k, v],
+        )?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserRecord {
+    pub id: i64,
+    pub username: String,
+    pub full_name: String,
+    pub role: String,
+    pub aktif: bool,
+    pub last_login_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserInput {
+    pub username: String,
+    pub full_name: String,
+    pub role: String,
+    pub aktif: bool,
+    pub password: Option<String>,
+}
+
+fn validate_role(role: &str) -> AppResult<()> {
+    if role == "admin" || role == "pustakawan" {
+        Ok(())
+    } else {
+        Err(AppError::Validation(format!(
+            "role tidak dikenal: {role}"
+        )))
+    }
+}
+
+#[tauri::command]
+pub fn settings_users_list(state: State<'_, AppState>) -> AppResult<Vec<UserRecord>> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let mut stmt = conn.prepare(
+        "SELECT id, username, full_name, role, aktif, last_login_at, created_at
+         FROM users ORDER BY id ASC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(UserRecord {
+            id: row.get(0)?,
+            username: row.get(1)?,
+            full_name: row.get(2)?,
+            role: row.get(3)?,
+            aktif: row.get::<_, i64>(4)? != 0,
+            last_login_at: row.get(5)?,
+            created_at: row.get(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+pub fn settings_users_create(
+    state: State<'_, AppState>,
+    payload: UserInput,
+) -> AppResult<UserRecord> {
+    validate_role(&payload.role)?;
+    let username = payload.username.trim().to_string();
+    if username.is_empty() {
+        return Err(AppError::Validation("username wajib diisi".into()));
+    }
+    let password = payload
+        .password
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AppError::Validation("password wajib diisi".into()))?;
+    let hash = bcrypt::hash(password, bcrypt::DEFAULT_COST)
+        .map_err(|e| AppError::Internal(format!("bcrypt: {e}")))?;
+
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let id = {
+        let mut stmt = conn.prepare(
+            "INSERT INTO users (username, password_hash, full_name, role, aktif)
+             VALUES (?1, ?2, ?3, ?4, ?5) RETURNING id",
+        )?;
+        stmt.query_row(
+            params![
+                &username,
+                hash,
+                payload.full_name.trim(),
+                payload.role,
+                if payload.aktif { 1 } else { 0 }
+            ],
+            |row| row.get::<_, i64>(0),
+        )?
+    };
+    let mut stmt = conn.prepare(
+        "SELECT id, username, full_name, role, aktif, last_login_at, created_at
+         FROM users WHERE id = ?1",
+    )?;
+    let rec = stmt.query_row(params![id], |row| {
+        Ok(UserRecord {
+            id: row.get(0)?,
+            username: row.get(1)?,
+            full_name: row.get(2)?,
+            role: row.get(3)?,
+            aktif: row.get::<_, i64>(4)? != 0,
+            last_login_at: row.get(5)?,
+            created_at: row.get(6)?,
+        })
+    })?;
+    Ok(rec)
+}
+
+#[tauri::command]
+pub fn settings_users_update(
+    state: State<'_, AppState>,
+    id: i64,
+    payload: UserInput,
+) -> AppResult<UserRecord> {
+    validate_role(&payload.role)?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    conn.execute(
+        "UPDATE users
+         SET username = ?1, full_name = ?2, role = ?3, aktif = ?4,
+             updated_at = datetime('now')
+         WHERE id = ?5",
+        params![
+            payload.username.trim(),
+            payload.full_name.trim(),
+            payload.role,
+            if payload.aktif { 1 } else { 0 },
+            id
+        ],
+    )?;
+    let mut stmt = conn.prepare(
+        "SELECT id, username, full_name, role, aktif, last_login_at, created_at
+         FROM users WHERE id = ?1",
+    )?;
+    let rec = stmt.query_row(params![id], |row| {
+        Ok(UserRecord {
+            id: row.get(0)?,
+            username: row.get(1)?,
+            full_name: row.get(2)?,
+            role: row.get(3)?,
+            aktif: row.get::<_, i64>(4)? != 0,
+            last_login_at: row.get(5)?,
+            created_at: row.get(6)?,
+        })
+    })?;
+    Ok(rec)
+}
+
+#[tauri::command]
+pub fn settings_users_delete(state: State<'_, AppState>, id: i64) -> AppResult<()> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let n = conn.execute("DELETE FROM users WHERE id = ?1", params![id])?;
+    if n == 0 {
+        return Err(AppError::NotFound(format!("user id={id} tidak ditemukan")));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn settings_users_reset_password(
+    state: State<'_, AppState>,
+    id: i64,
+    new_password: String,
+) -> AppResult<()> {
+    let trimmed = new_password.trim();
+    if trimmed.len() < 6 {
+        return Err(AppError::Validation(
+            "password minimal 6 karakter".into(),
+        ));
+    }
+    let hash = bcrypt::hash(trimmed, bcrypt::DEFAULT_COST)
+        .map_err(|e| AppError::Internal(format!("bcrypt: {e}")))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let n = conn.execute(
+        "UPDATE users SET password_hash = ?1, updated_at = datetime('now') WHERE id = ?2",
+        params![hash, id],
+    )?;
+    if n == 0 {
+        return Err(AppError::NotFound(format!("user id={id} tidak ditemukan")));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Permission matrix
+// ---------------------------------------------------------------------------
+
+const PERMISSION_AREAS: &[&str] = &[
+    "anggota",
+    "buku",
+    "peminjaman",
+    "pengembalian",
+    "kunjungan",
+    "laporan",
+    "settings",
+    "audit_log",
+];
+const PERMISSION_ACTIONS: &[&str] = &["view", "create", "update", "delete"];
+
+const PERMISSIONS_MATRIX_KEY: &str = "rbac.permission_matrix_v1";
+
+pub type RoleActions = BTreeMap<String, bool>;
+pub type RoleArea = BTreeMap<String, RoleActions>;
+pub type PermissionMatrix = BTreeMap<String, RoleArea>;
+
+fn default_matrix() -> PermissionMatrix {
+    let mut out = PermissionMatrix::new();
+    for role in ["admin", "pustakawan"].iter() {
+        let mut area_map = RoleArea::new();
+        for area in PERMISSION_AREAS {
+            let mut actions = RoleActions::new();
+            for act in PERMISSION_ACTIONS {
+                let granted = match (*role, *area, *act) {
+                    ("pustakawan", "settings" | "audit_log", "view") => true,
+                    ("pustakawan", "settings" | "audit_log", _) => false,
+                    _ => true,
+                };
+                actions.insert((*act).to_string(), granted);
+            }
+            area_map.insert((*area).to_string(), actions);
+        }
+        out.insert((*role).to_string(), area_map);
+    }
+    out
+}
+
+#[tauri::command]
+pub fn settings_permissions_get(state: State<'_, AppState>) -> AppResult<PermissionMatrix> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let value: Option<String> = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = ?1",
+            params![PERMISSIONS_MATRIX_KEY],
+            |row| row.get(0),
+        )
+        .ok();
+    if let Some(v) = value {
+        if let Ok(parsed) = serde_json::from_str::<PermissionMatrix>(&v) {
+            return Ok(parsed);
+        }
+    }
+    Ok(default_matrix())
+}
+
+#[tauri::command]
+pub fn settings_permissions_save(
+    state: State<'_, AppState>,
+    matrix: PermissionMatrix,
+) -> AppResult<PermissionMatrix> {
+    let json = serde_json::to_string(&matrix)
+        .map_err(|e| AppError::Internal(format!("serialize matrix: {e}")))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![PERMISSIONS_MATRIX_KEY, json],
+    )?;
+    Ok(matrix)
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditLogQuery {
+    pub user: Option<String>,
+    pub action: Option<String>,
+    pub entity: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditLogEntry {
+    pub id: i64,
+    pub user_id: Option<i64>,
+    pub username: Option<String>,
+    pub aksi: String,
+    pub entitas: String,
+    pub entitas_id: Option<i64>,
+    pub detail: Option<String>,
+    pub created_at: String,
+}
+
+#[tauri::command]
+pub fn settings_audit_log_query(
+    state: State<'_, AppState>,
+    query: AuditLogQuery,
+) -> AppResult<Vec<AuditLogEntry>> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let limit = query.limit.unwrap_or(200).clamp(1, 1000);
+    let mut clauses: Vec<String> = Vec::new();
+    let mut binds: Vec<String> = Vec::new();
+    if let Some(u) = query.user.as_deref().filter(|s| !s.trim().is_empty()) {
+        clauses.push("u.username LIKE ?".into());
+        binds.push(format!("%{u}%"));
+    }
+    if let Some(a) = query.action.as_deref().filter(|s| !s.trim().is_empty()) {
+        clauses.push("a.aksi = ?".into());
+        binds.push(a.to_string());
+    }
+    if let Some(e) = query.entity.as_deref().filter(|s| !s.trim().is_empty()) {
+        clauses.push("a.entitas = ?".into());
+        binds.push(e.to_string());
+    }
+    if let Some(f) = query.from.as_deref().filter(|s| !s.trim().is_empty()) {
+        clauses.push("a.created_at >= ?".into());
+        binds.push(f.to_string());
+    }
+    if let Some(t) = query.to.as_deref().filter(|s| !s.trim().is_empty()) {
+        clauses.push("a.created_at <= ?".into());
+        binds.push(t.to_string());
+    }
+    let where_sql = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", clauses.join(" AND "))
+    };
+    let sql = format!(
+        "SELECT a.id, a.user_id, u.username, a.aksi, a.entitas, a.entitas_id,
+                a.detail, a.created_at
+         FROM audit_log a LEFT JOIN users u ON u.id = a.user_id
+         {where_sql}
+         ORDER BY a.id DESC LIMIT {limit}"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(binds.iter()), |row| {
+        Ok(AuditLogEntry {
+            id: row.get(0)?,
+            user_id: row.get(1)?,
+            username: row.get(2)?,
+            aksi: row.get(3)?,
+            entitas: row.get(4)?,
+            entitas_id: row.get(5)?,
+            detail: row.get(6)?,
+            created_at: row.get(7)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -94,6 +94,17 @@ pub fn run() {
             commands::kta::kta_template_update,
             commands::kta::kta_template_delete,
             commands::kta::kta_template_set_default,
+            commands::settings::settings_get_many,
+            commands::settings::settings_set_many,
+            commands::settings::settings_users_list,
+            commands::settings::settings_users_create,
+            commands::settings::settings_users_update,
+            commands::settings::settings_users_delete,
+            commands::settings::settings_users_reset_password,
+            commands::settings::settings_permissions_get,
+            commands::settings::settings_permissions_save,
+            commands::settings::settings_audit_log_query,
+            commands::manual::open_manual,
         ])
         .build(tauri::generate_context!())
         .expect("failed to build tauri app")

--- a/apps/desktop/src/components/layout/Header.tsx
+++ b/apps/desktop/src/components/layout/Header.tsx
@@ -16,6 +16,7 @@ import {
 import { useAuthStore } from '@/stores/authStore';
 import { useIdentityStore } from '@/stores/identityStore';
 import { logoutRequest } from '@/lib/auth';
+import { openManual } from '@/lib/manual';
 import { cn } from '@/lib/utils';
 
 const ROUTE_LABELS: Record<string, string> = {
@@ -109,11 +110,10 @@ export function Header() {
 
         <button
           type="button"
+          data-testid="header-manual"
           aria-label={t('common:menu.manualBook')}
           className="hidden h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground md:flex"
-          onClick={() => {
-            /* TODO: open manual — Devin 11 (revisi #4) */
-          }}
+          onClick={() => void openManual(identity)}
         >
           <BookOpen className="h-4 w-4" />
         </button>

--- a/apps/desktop/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/Sidebar.tsx
@@ -34,7 +34,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/pengembalian', labelKey: 'common:menu.pengembalian', Icon: Undo2 },
   { to: '/kunjungan', labelKey: 'common:menu.kunjungan', Icon: CalendarCheck },
   { to: '/laporan', labelKey: 'common:menu.laporan', Icon: BarChart3 },
-  { to: '/settings', labelKey: 'common:menu.settings', Icon: Settings, pending: true },
+  { to: '/settings', labelKey: 'common:menu.settings', Icon: Settings },
 ];
 
 export function Sidebar() {

--- a/apps/desktop/src/features/laporan/KasSubPage.tsx
+++ b/apps/desktop/src/features/laporan/KasSubPage.tsx
@@ -117,7 +117,7 @@ export function LaporanKas() {
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-base">
-              {t('laporan:kas.detail', { defaultValue: 'Detail Transaksi' })}
+              {t('laporan:kas.detail', { defaultValue: 'Detail Kas' })}
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">

--- a/apps/desktop/src/features/peminjaman/PeminjamanList.tsx
+++ b/apps/desktop/src/features/peminjaman/PeminjamanList.tsx
@@ -141,7 +141,7 @@ export function PeminjamanList() {
         <div>
           <h1 className="text-2xl font-semibold">{t('peminjaman:title', { defaultValue: 'Peminjaman' })}</h1>
           <p className="text-sm text-muted-foreground">
-            {t('peminjaman:subtitle', { defaultValue: 'Kelola transaksi peminjaman buku' })}
+            {t('peminjaman:subtitle', { defaultValue: 'Kelola aturan peminjaman buku' })}
           </p>
         </div>
         <Button asChild>

--- a/apps/desktop/src/features/settings/AkunPage.tsx
+++ b/apps/desktop/src/features/settings/AkunPage.tsx
@@ -1,0 +1,353 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast-manager';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import {
+  type UserInput,
+  type UserRecord,
+  type UserRole,
+  settingsApi,
+} from '@/lib/settings';
+import { FieldRow, SettingsSection } from './SettingsSection';
+
+interface UserFormState extends UserInput {
+  password: string;
+}
+
+const EMPTY_FORM: UserFormState = {
+  username: '',
+  fullName: '',
+  role: 'pustakawan',
+  aktif: true,
+  password: '',
+};
+
+function fmtDate(s: string | null): string {
+  if (!s) return '—';
+  try {
+    return new Date(s).toLocaleString();
+  } catch {
+    return s;
+  }
+}
+
+export function AkunPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { showToast } = useToast();
+  const [users, setUsers] = React.useState<UserRecord[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [editing, setEditing] = React.useState<UserRecord | null>(null);
+  const [creating, setCreating] = React.useState(false);
+  const [resetting, setResetting] = React.useState<UserRecord | null>(null);
+  const [deleting, setDeleting] = React.useState<UserRecord | null>(null);
+  const [form, setForm] = React.useState<UserFormState>(EMPTY_FORM);
+  const [resetPw, setResetPw] = React.useState('');
+
+  const reload = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await settingsApi.listUsers();
+      setUsers(list);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const openCreate = (): void => {
+    setForm(EMPTY_FORM);
+    setEditing(null);
+    setCreating(true);
+  };
+  const openEdit = (u: UserRecord): void => {
+    setForm({
+      username: u.username,
+      fullName: u.fullName,
+      role: u.role,
+      aktif: u.aktif,
+      password: '',
+    });
+    setEditing(u);
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    try {
+      if (editing) {
+        await settingsApi.updateUser(editing.id, {
+          username: form.username,
+          fullName: form.fullName,
+          role: form.role,
+          aktif: form.aktif,
+        });
+        showToast({
+          title: t('sections.akun.feedback.updateSuccess', { defaultValue: 'Pengguna berhasil diperbarui.' }),
+        });
+      } else {
+        await settingsApi.createUser({
+          username: form.username,
+          fullName: form.fullName,
+          role: form.role,
+          aktif: form.aktif,
+          password: form.password,
+        });
+        showToast({
+          title: t('sections.akun.feedback.createSuccess', { defaultValue: 'Pengguna berhasil ditambahkan.' }),
+        });
+      }
+      setEditing(null);
+      setCreating(false);
+      void reload();
+    } catch (e) {
+      showToast({
+        title: t('sections.identitas.saveError', { defaultValue: 'Gagal menyimpan' }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleDelete = async (): Promise<void> => {
+    if (!deleting) return;
+    await settingsApi.deleteUser(deleting.id);
+    showToast({
+      title: t('sections.akun.feedback.deleteSuccess', { defaultValue: 'Pengguna berhasil dihapus.' }),
+    });
+    setDeleting(null);
+    void reload();
+  };
+
+  const handleResetPassword = async (): Promise<void> => {
+    if (!resetting) return;
+    await settingsApi.resetPassword(resetting.id, resetPw);
+    showToast({
+      title: t('sections.akun.feedback.passwordReset', { defaultValue: 'Password berhasil direset.' }),
+    });
+    setResetting(null);
+    setResetPw('');
+  };
+
+  const dialogOpen = creating || editing !== null;
+  const closeDialog = (): void => {
+    setCreating(false);
+    setEditing(null);
+  };
+
+  return (
+    <SettingsSection i18nKey="akun">
+      <div className="flex items-center justify-end">
+        <Button size="sm" onClick={openCreate} data-testid="akun-add">
+          <Plus className="h-3.5 w-3.5" />
+          {t('sections.akun.addUser', { defaultValue: 'Tambah Pengguna' })}
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full text-sm" data-testid="akun-table">
+          <thead className="bg-muted/40">
+            <tr className="text-left">
+              <th className="px-3 py-2 font-medium">
+                {t('sections.akun.table.username', { defaultValue: 'Username' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.akun.table.fullName', { defaultValue: 'Nama Lengkap' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.akun.table.role', { defaultValue: 'Peran' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.akun.table.status', { defaultValue: 'Status' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.akun.table.lastLogin', { defaultValue: 'Login Terakhir' })}
+              </th>
+              <th className="px-3 py-2 text-right font-medium">
+                {t('sections.akun.table.actions', { defaultValue: 'Aksi' })}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={6} className="p-6 text-center text-muted-foreground">
+                  …
+                </td>
+              </tr>
+            ) : users.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="p-6 text-center text-muted-foreground">
+                  —
+                </td>
+              </tr>
+            ) : (
+              users.map((u) => (
+                <tr key={u.id} className="border-t">
+                  <td className="px-3 py-2 font-mono">{u.username}</td>
+                  <td className="px-3 py-2">{u.fullName}</td>
+                  <td className="px-3 py-2 capitalize">{u.role}</td>
+                  <td className="px-3 py-2">
+                    {u.aktif
+                      ? t('sections.akun.active', { defaultValue: 'Aktif' })
+                      : t('sections.akun.inactive', { defaultValue: 'Nonaktif' })}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">{fmtDate(u.lastLoginAt)}</td>
+                  <td className="px-3 py-2">
+                    <div className="flex justify-end gap-1">
+                      <Button size="icon" variant="ghost" onClick={() => openEdit(u)} aria-label="edit">
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => {
+                          setResetting(u);
+                          setResetPw('');
+                        }}
+                        aria-label="reset"
+                      >
+                        <RefreshCw className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => setDeleting(u)}
+                        aria-label="delete"
+                      >
+                        <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={(o) => !o && closeDialog()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editing
+                ? t('sections.akun.editUser', { defaultValue: 'Edit Pengguna' })
+                : t('sections.akun.addUser', { defaultValue: 'Tambah Pengguna' })}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-3">
+            <FieldRow label={t('sections.akun.table.username', { defaultValue: 'Username' })}>
+              <Input
+                value={form.username}
+                onChange={(e) => setForm((f) => ({ ...f, username: e.target.value }))}
+              />
+            </FieldRow>
+            <FieldRow label={t('sections.akun.table.fullName', { defaultValue: 'Nama Lengkap' })}>
+              <Input
+                value={form.fullName}
+                onChange={(e) => setForm((f) => ({ ...f, fullName: e.target.value }))}
+              />
+            </FieldRow>
+            <FieldRow label={t('sections.akun.table.role', { defaultValue: 'Peran' })}>
+              <Select
+                value={form.role}
+                onValueChange={(v) => setForm((f) => ({ ...f, role: v as UserRole }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="admin">
+                    {t('sections.hakAkses.roles.admin', { defaultValue: 'Admin' })}
+                  </SelectItem>
+                  <SelectItem value="pustakawan">
+                    {t('sections.hakAkses.roles.pustakawan', { defaultValue: 'Pustakawan' })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </FieldRow>
+            {!editing && (
+              <FieldRow label={t('sections.akun.newPassword', { defaultValue: 'Password Baru' })}>
+                <Input
+                  type="password"
+                  value={form.password}
+                  onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
+                />
+              </FieldRow>
+            )}
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={form.aktif}
+                onChange={(e) => setForm((f) => ({ ...f, aktif: e.target.checked }))}
+              />
+              {t('sections.akun.active', { defaultValue: 'Aktif' })}
+            </label>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={closeDialog}>
+              ✕
+            </Button>
+            <Button onClick={handleSubmit} data-testid="akun-save">
+              {t('actions.save', { defaultValue: 'Simpan' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={resetting !== null} onOpenChange={(o) => !o && setResetting(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('sections.akun.resetPassword', { defaultValue: 'Reset Password' })}
+            </DialogTitle>
+          </DialogHeader>
+          <FieldRow label={t('sections.akun.newPassword', { defaultValue: 'Password Baru' })}>
+            <Input type="password" value={resetPw} onChange={(e) => setResetPw(e.target.value)} />
+          </FieldRow>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setResetting(null)}>
+              ✕
+            </Button>
+            <Button onClick={handleResetPassword}>
+              {t('actions.save', { defaultValue: 'Simpan' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {deleting && (
+        <ConfirmDialog
+          open={deleting !== null}
+          onOpenChange={(o) => !o && setDeleting(null)}
+          title={t('sections.akun.delete.title', {
+            name: deleting.username,
+            defaultValue: `Hapus pengguna "${deleting.username}"?`,
+          })}
+          description={t('sections.akun.delete.description', {
+            defaultValue: 'Pengguna tidak akan bisa login lagi setelah dihapus.',
+          })}
+          destructive
+          onConfirm={handleDelete}
+        />
+      )}
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/AturanPeminjamanPage.tsx
+++ b/apps/desktop/src/features/settings/AturanPeminjamanPage.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast-manager';
+import {
+  DEFAULT_LOAN_RULES,
+  type LoanRules,
+  settingsApi,
+} from '@/lib/settings';
+import { FieldRow, SettingsSection } from './SettingsSection';
+
+const HARI_LABELS = ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab'];
+
+export function AturanPeminjamanPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { showToast } = useToast();
+  const [rules, setRules] = React.useState<LoanRules>(DEFAULT_LOAN_RULES);
+  const [saving, setSaving] = React.useState(false);
+  const [loaded, setLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    settingsApi.getLoanRules().then((r) => {
+      setRules(r);
+      setLoaded(true);
+    });
+  }, []);
+
+  const handleNumber =
+    (key: keyof Omit<LoanRules, 'hariLibur'>) =>
+    (e: React.ChangeEvent<HTMLInputElement>): void => {
+      const n = parseInt(e.target.value, 10);
+      setRules((prev) => ({ ...prev, [key]: Number.isFinite(n) ? n : 0 }));
+    };
+
+  const toggleHari = (day: number): void => {
+    setRules((prev) => {
+      const has = prev.hariLibur.includes(day);
+      return {
+        ...prev,
+        hariLibur: has
+          ? prev.hariLibur.filter((d) => d !== day)
+          : [...prev.hariLibur, day].sort(),
+      };
+    });
+  };
+
+  const handleSave = async (): Promise<void> => {
+    setSaving(true);
+    try {
+      await settingsApi.saveLoanRules(rules);
+      showToast({
+        title: t('sections.aturanPeminjaman.saveSuccess', {
+          defaultValue: 'Aturan peminjaman berhasil disimpan.',
+        }),
+      });
+    } catch (e) {
+      showToast({
+        title: t('sections.aturanPeminjaman.saveError', {
+          defaultValue: 'Gagal menyimpan aturan peminjaman.',
+        }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async (): Promise<void> => {
+    const next = await settingsApi.resetLoanRules();
+    setRules(next);
+  };
+
+  return (
+    <SettingsSection
+      i18nKey="aturanPeminjaman"
+      onSave={handleSave}
+      onReset={handleReset}
+      saving={saving || !loaded}
+    >
+      <div className="grid gap-4 sm:grid-cols-3">
+        <FieldRow
+          label={t('sections.aturanPeminjaman.fields.maksBuku', {
+            defaultValue: 'Maksimum buku per anggota',
+          })}
+          htmlFor="aturan-maks"
+        >
+          <Input
+            id="aturan-maks"
+            type="number"
+            min={1}
+            value={rules.maksBukuPinjam}
+            onChange={handleNumber('maksBukuPinjam')}
+            data-testid="aturan-maks"
+          />
+        </FieldRow>
+        <FieldRow
+          label={t('sections.aturanPeminjaman.fields.lamaPinjam', {
+            defaultValue: 'Durasi pinjam (hari)',
+          })}
+          htmlFor="aturan-lama"
+        >
+          <Input
+            id="aturan-lama"
+            type="number"
+            min={1}
+            value={rules.lamaPinjamHari}
+            onChange={handleNumber('lamaPinjamHari')}
+          />
+        </FieldRow>
+        <FieldRow
+          label={t('sections.aturanPeminjaman.fields.dendaPerHari', {
+            defaultValue: 'Denda per hari (Rp)',
+          })}
+          htmlFor="aturan-denda"
+        >
+          <Input
+            id="aturan-denda"
+            type="number"
+            min={0}
+            step={100}
+            value={rules.dendaPerHari}
+            onChange={handleNumber('dendaPerHari')}
+            data-testid="aturan-denda"
+          />
+        </FieldRow>
+      </div>
+
+      <FieldRow
+        label={t('sections.aturanPeminjaman.fields.hariLibur', {
+          defaultValue: 'Hari libur (tidak dihitung sebagai hari pinjam)',
+        })}
+        help={t('sections.aturanPeminjaman.hariLiburHelp', {
+          defaultValue: 'Pisahkan dengan koma. Contoh: 0,6 untuk Minggu & Sabtu.',
+        })}
+      >
+        <div className="flex flex-wrap gap-2">
+          {HARI_LABELS.map((label, idx) => {
+            const checked = rules.hariLibur.includes(idx);
+            return (
+              <label
+                key={idx}
+                className={`flex cursor-pointer items-center gap-1 rounded border px-2 py-1 text-xs transition-colors ${
+                  checked ? 'border-primary bg-primary/10 text-primary' : 'hover:bg-muted'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={checked}
+                  onChange={() => toggleHari(idx)}
+                />
+                {label}
+              </label>
+            );
+          })}
+        </div>
+      </FieldRow>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/AuditLogPage.tsx
+++ b/apps/desktop/src/features/settings/AuditLogPage.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { type AuditLogEntry, type AuditLogQuery, settingsApi } from '@/lib/settings';
+import { FieldRow, SettingsSection } from './SettingsSection';
+
+export function AuditLogPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const [query, setQuery] = React.useState<AuditLogQuery>({});
+  const [entries, setEntries] = React.useState<AuditLogEntry[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  const search = React.useCallback(async (q: AuditLogQuery) => {
+    setLoading(true);
+    try {
+      setEntries(await settingsApi.queryAuditLog(q));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void search({});
+  }, [search]);
+
+  const set = <K extends keyof AuditLogQuery>(k: K, v: AuditLogQuery[K]): void => {
+    setQuery((prev) => ({ ...prev, [k]: v }));
+  };
+
+  return (
+    <SettingsSection i18nKey="auditLog">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <FieldRow label={t('sections.auditLog.filter.user', { defaultValue: 'Pengguna' })}>
+          <Input
+            value={query.user ?? ''}
+            onChange={(e) => set('user', e.target.value)}
+            placeholder="admin"
+          />
+        </FieldRow>
+        <FieldRow label={t('sections.auditLog.filter.action', { defaultValue: 'Aksi' })}>
+          <Input
+            value={query.action ?? ''}
+            onChange={(e) => set('action', e.target.value)}
+            placeholder="login / create / update"
+          />
+        </FieldRow>
+        <FieldRow label={t('sections.auditLog.filter.entity', { defaultValue: 'Entitas' })}>
+          <Input
+            value={query.entity ?? ''}
+            onChange={(e) => set('entity', e.target.value)}
+            placeholder="anggota / buku"
+          />
+        </FieldRow>
+      </div>
+      <div className="flex justify-end">
+        <Button size="sm" onClick={() => void search(query)} data-testid="audit-search">
+          {t('actions.save', { defaultValue: 'Cari' })}
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border" data-testid="audit-table">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40">
+            <tr className="text-left">
+              <th className="px-3 py-2 font-medium">
+                {t('sections.auditLog.table.timestamp', { defaultValue: 'Waktu' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.auditLog.table.user', { defaultValue: 'Pengguna' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.auditLog.table.action', { defaultValue: 'Aksi' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.auditLog.table.entity', { defaultValue: 'Entitas' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.auditLog.table.entityId', { defaultValue: 'ID' })}
+              </th>
+              <th className="px-3 py-2 font-medium">
+                {t('sections.auditLog.table.detail', { defaultValue: 'Detail' })}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={6} className="p-6 text-center text-muted-foreground">
+                  …
+                </td>
+              </tr>
+            ) : entries.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="p-6 text-center text-muted-foreground">
+                  {t('sections.auditLog.empty', { defaultValue: 'Belum ada catatan.' })}
+                </td>
+              </tr>
+            ) : (
+              entries.map((e) => (
+                <tr key={e.id} className="border-t">
+                  <td className="px-3 py-2 font-mono text-xs">{e.createdAt}</td>
+                  <td className="px-3 py-2">{e.username ?? '—'}</td>
+                  <td className="px-3 py-2">{e.aksi}</td>
+                  <td className="px-3 py-2">{e.entitas}</td>
+                  <td className="px-3 py-2 font-mono text-xs">{e.entitasId ?? '—'}</td>
+                  <td className="px-3 py-2 text-muted-foreground">{e.detail ?? '—'}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/BackupPage.tsx
+++ b/apps/desktop/src/features/settings/BackupPage.tsx
@@ -1,0 +1,15 @@
+import { LaporanBackup } from '@/features/laporan/BackupSubPage';
+import { SettingsSection } from './SettingsSection';
+
+/**
+ * Backup & Restore sub-page (revisi #24). Embeds the full backup UI introduced
+ * in Devin Session 9 (`LaporanBackup`) inside the Settings shell so the
+ * functionality is reachable from both Laporan and Pengaturan.
+ */
+export function BackupPage(): JSX.Element {
+  return (
+    <SettingsSection i18nKey="backup">
+      <LaporanBackup />
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/BahasaPage.tsx
+++ b/apps/desktop/src/features/settings/BahasaPage.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useI18nStore, type Locale } from '@/stores/i18nStore';
+import { FieldRow, SettingsSection } from './SettingsSection';
+
+export function BahasaPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { locale, setLocale } = useI18nStore();
+
+  return (
+    <SettingsSection
+      i18nKey="bahasa"
+      onReset={() => {
+        setLocale('id');
+      }}
+    >
+      <FieldRow
+        label={t('sections.bahasa.fields.language', { defaultValue: 'Bahasa Aplikasi' })}
+      >
+        <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
+          <SelectTrigger data-testid="bahasa-select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="id">Bahasa Indonesia</SelectItem>
+            <SelectItem value="en">English</SelectItem>
+          </SelectContent>
+        </Select>
+      </FieldRow>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/HakAksesPage.tsx
+++ b/apps/desktop/src/features/settings/HakAksesPage.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useToast } from '@/components/ui/toast-manager';
+import {
+  DEFAULT_PERMISSION_MATRIX,
+  PERMISSION_ACTIONS,
+  PERMISSION_AREAS,
+  type PermissionAction,
+  type PermissionArea,
+  type PermissionMatrix,
+  type UserRole,
+  settingsApi,
+} from '@/lib/settings';
+import { SettingsSection } from './SettingsSection';
+
+const ROLES: UserRole[] = ['admin', 'pustakawan'];
+
+export function HakAksesPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { showToast } = useToast();
+  const [matrix, setMatrix] = React.useState<PermissionMatrix>(DEFAULT_PERMISSION_MATRIX);
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    settingsApi.getPermissionMatrix().then(setMatrix);
+  }, []);
+
+  const toggle = (
+    role: UserRole,
+    area: PermissionArea,
+    action: PermissionAction,
+  ): void => {
+    setMatrix((prev) => ({
+      ...prev,
+      [role]: {
+        ...prev[role],
+        [area]: {
+          ...prev[role][area],
+          [action]: !prev[role][area][action],
+        },
+      },
+    }));
+  };
+
+  const handleSave = async (): Promise<void> => {
+    setSaving(true);
+    try {
+      await settingsApi.savePermissionMatrix(matrix);
+      showToast({
+        title: t('sections.hakAkses.saveSuccess', { defaultValue: 'Matriks izin berhasil disimpan.' }),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async (): Promise<void> => {
+    const next = await settingsApi.resetPermissionMatrix();
+    setMatrix(next);
+  };
+
+  return (
+    <SettingsSection
+      i18nKey="hakAkses"
+      onSave={handleSave}
+      onReset={handleReset}
+      saving={saving}
+    >
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium">
+                {t('sections.hakAkses.areas.anggota', { defaultValue: 'Area' })}
+              </th>
+              {ROLES.flatMap((role) =>
+                PERMISSION_ACTIONS.map((act) => (
+                  <th
+                    key={`${role}-${act}`}
+                    className="px-2 py-2 text-center text-xs font-medium"
+                    title={`${role} · ${act}`}
+                  >
+                    <div className="flex flex-col">
+                      <span className="text-[0.65rem] uppercase text-muted-foreground">
+                        {t(`sections.hakAkses.roles.${role}`, { defaultValue: role })}
+                      </span>
+                      <span>{t(`sections.hakAkses.actions.${act}`, { defaultValue: act })}</span>
+                    </div>
+                  </th>
+                )),
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {PERMISSION_AREAS.map((area) => (
+              <tr key={area} className="border-t">
+                <td className="px-3 py-2 font-medium">
+                  {t(`sections.hakAkses.areas.${area}`, { defaultValue: area })}
+                </td>
+                {ROLES.flatMap((role) =>
+                  PERMISSION_ACTIONS.map((act) => (
+                    <td key={`${role}-${area}-${act}`} className="px-2 py-2 text-center">
+                      <input
+                        type="checkbox"
+                        checked={matrix[role][area][act]}
+                        onChange={() => toggle(role, area, act)}
+                        data-testid={`perm-${role}-${area}-${act}`}
+                      />
+                    </td>
+                  )),
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/IdentitasPage.tsx
+++ b/apps/desktop/src/features/settings/IdentitasPage.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast-manager';
+import { useIdentityStore } from '@/stores/identityStore';
+import { settingsApi, DEFAULT_IDENTITY } from '@/lib/settings';
+import { FieldRow, SettingsSection } from './SettingsSection';
+
+export function IdentitasPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { showToast } = useToast();
+  const identity = useIdentityStore((s) => s.identity);
+  const setIdentity = useIdentityStore((s) => s.setIdentity);
+  const loadIdentity = useIdentityStore((s) => s.loadIdentity);
+  const [draft, setDraft] = React.useState(identity);
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    setDraft(identity);
+  }, [identity]);
+
+  const onChange =
+    (key: keyof typeof identity) =>
+    (e: React.ChangeEvent<HTMLInputElement>): void => {
+      setDraft((prev) => ({ ...prev, [key]: e.target.value }));
+    };
+
+  const handleSave = async (): Promise<void> => {
+    setSaving(true);
+    try {
+      const saved = await settingsApi.saveIdentity(draft);
+      setIdentity(saved);
+      await loadIdentity();
+      showToast({
+        title: t('sections.identitas.saveSuccess', { defaultValue: 'Identitas berhasil disimpan.' }),
+      });
+    } catch (e) {
+      showToast({
+        title: t('sections.identitas.saveError', { defaultValue: 'Gagal menyimpan identitas.' }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async (): Promise<void> => {
+    setDraft(DEFAULT_IDENTITY);
+    const next = await settingsApi.resetIdentity();
+    setIdentity(next);
+    await loadIdentity();
+  };
+
+  return (
+    <SettingsSection
+      i18nKey="identitas"
+      onSave={handleSave}
+      onReset={handleReset}
+      saving={saving}
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <FieldRow
+          label={t('sections.identitas.fields.nama', { defaultValue: 'Nama Perpustakaan' })}
+          htmlFor="identitas-nama"
+        >
+          <Input
+            id="identitas-nama"
+            value={draft.nama}
+            onChange={onChange('nama')}
+            data-testid="identitas-nama"
+          />
+        </FieldRow>
+        <FieldRow
+          label={t('sections.identitas.fields.kepala', { defaultValue: 'Kepala Perpustakaan' })}
+          htmlFor="identitas-kepala"
+        >
+          <Input id="identitas-kepala" value={draft.kepala} onChange={onChange('kepala')} />
+        </FieldRow>
+        <FieldRow
+          label={t('sections.identitas.fields.npsn', { defaultValue: 'NPSN' })}
+          htmlFor="identitas-npsn"
+        >
+          <Input id="identitas-npsn" value={draft.npsn} onChange={onChange('npsn')} />
+        </FieldRow>
+        <FieldRow
+          label={t('sections.identitas.fields.tahunAjaran', { defaultValue: 'Tahun Ajaran' })}
+          htmlFor="identitas-tahun"
+        >
+          <Input
+            id="identitas-tahun"
+            value={draft.tahunAjaran}
+            onChange={onChange('tahunAjaran')}
+          />
+        </FieldRow>
+        <FieldRow
+          label={t('sections.identitas.fields.kontak', { defaultValue: 'Kontak' })}
+          htmlFor="identitas-kontak"
+        >
+          <Input id="identitas-kontak" value={draft.kontak} onChange={onChange('kontak')} />
+        </FieldRow>
+        <FieldRow
+          label={t('sections.identitas.fields.logoPath', { defaultValue: 'Path Logo' })}
+          htmlFor="identitas-logo"
+        >
+          <Input id="identitas-logo" value={draft.logoPath} onChange={onChange('logoPath')} />
+        </FieldRow>
+      </div>
+      <FieldRow
+        label={t('sections.identitas.fields.alamat', { defaultValue: 'Alamat' })}
+        htmlFor="identitas-alamat"
+      >
+        <Input id="identitas-alamat" value={draft.alamat} onChange={onChange('alamat')} />
+      </FieldRow>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/features/settings/SettingsLayout.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { Link, Outlet } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { Search } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Input } from '@/components/ui/input';
+import { SECTIONS, type SectionWithLabel, filterSections } from './sections';
+
+export function SettingsLayout(): JSX.Element {
+  const { t } = useTranslation(['settings', 'common']);
+  const [query, setQuery] = React.useState('');
+
+  const sections: SectionWithLabel[] = React.useMemo(
+    () =>
+      SECTIONS.map((s) => ({
+        ...s,
+        label: t(`settings:sections.${s.i18nKey}.label`, { defaultValue: s.id }),
+        summary: t(`settings:sections.${s.i18nKey}.summary`, { defaultValue: '' }),
+      })),
+    [t],
+  );
+
+  const filtered = React.useMemo(() => filterSections(sections, query), [sections, query]);
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col gap-6 p-6"
+      data-testid="settings-layout"
+    >
+      <header className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t('settings:title', { defaultValue: 'Pengaturan' })}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('settings:subtitle', {
+            defaultValue: 'Atur perilaku aplikasi, identitas perpustakaan, akun, dan integrasi.',
+          })}
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+        <aside className="flex flex-col gap-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              data-testid="settings-search"
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t('settings:search.placeholder', { defaultValue: 'Cari pengaturan…' })}
+              className="pl-9"
+              aria-label={t('settings:search.placeholder', { defaultValue: 'Cari pengaturan…' })}
+            />
+          </div>
+
+          {query.trim() && (
+            <p
+              className="text-xs text-muted-foreground"
+              data-testid="settings-search-count"
+            >
+              {t('settings:search.results', {
+                count: filtered.length,
+                defaultValue: '{{count}} hasil',
+              })}
+            </p>
+          )}
+
+          <nav className="flex flex-col gap-0.5" data-testid="settings-nav">
+            {filtered.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-muted-foreground">
+                {t('settings:search.empty', { defaultValue: 'Tidak ada pengaturan yang cocok.' })}
+              </p>
+            ) : (
+              filtered.map((section) => {
+                const Icon = section.Icon;
+                return (
+                  <Link
+                    key={section.id}
+                    to={section.to}
+                    data-testid={`settings-nav-${section.id}`}
+                    className={cn(
+                      'flex items-start gap-2 rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted',
+                      '[&.active]:bg-primary/10 [&.active]:font-medium [&.active]:text-primary',
+                    )}
+                    activeProps={{ className: 'active' }}
+                    title={section.summary}
+                  >
+                    <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate">{section.label}</span>
+                      <span className="block truncate text-[0.72rem] font-normal text-muted-foreground">
+                        {section.summary}
+                      </span>
+                    </span>
+                  </Link>
+                );
+              })
+            )}
+          </nav>
+        </aside>
+
+        <section className="min-w-0">
+          <Outlet />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/settings/SettingsSection.tsx
+++ b/apps/desktop/src/features/settings/SettingsSection.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { RefreshCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+
+interface SettingsSectionProps {
+  i18nKey: string;
+  onReset?: () => void | Promise<void>;
+  saving?: boolean;
+  onSave?: () => void | Promise<void>;
+  testId?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared section header + body shell used by every Settings sub-page.
+ *
+ * Provides:
+ *   - Title + summary (resolved from `settings:sections.<i18nKey>`)
+ *   - Optional "Reset bagian ini" button with confirm dialog
+ *   - Optional "Simpan" footer button
+ */
+export function SettingsSection({
+  i18nKey,
+  onReset,
+  onSave,
+  saving,
+  testId,
+  children,
+}: SettingsSectionProps): JSX.Element {
+  const { t } = useTranslation('settings');
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+
+  return (
+    <div
+      className="flex flex-col gap-6 rounded-lg border bg-card p-6 shadow-sm"
+      data-testid={testId ?? `settings-section-${i18nKey}`}
+    >
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold">
+            {t(`sections.${i18nKey}.label`, { defaultValue: i18nKey })}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t(`sections.${i18nKey}.summary`, { defaultValue: '' })}
+          </p>
+        </div>
+        {onReset && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setConfirmOpen(true)}
+            data-testid={`settings-reset-${i18nKey}`}
+            className="shrink-0"
+          >
+            <RefreshCcw className="h-3.5 w-3.5" />
+            {t('actions.resetSection', { defaultValue: 'Reset Bagian Ini' })}
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4">{children}</div>
+
+      {onSave && (
+        <div className="flex justify-end border-t pt-4">
+          <Button
+            type="button"
+            onClick={() => onSave()}
+            disabled={saving}
+            data-testid={`settings-save-${i18nKey}`}
+          >
+            {saving
+              ? t('actions.save', { defaultValue: 'Simpan' }) + '…'
+              : t('actions.save', { defaultValue: 'Simpan' })}
+          </Button>
+        </div>
+      )}
+
+      {onReset && (
+        <ConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title={t('actions.resetConfirmTitle', { defaultValue: 'Reset ke nilai default?' })}
+          description={t('actions.resetConfirmDescription', {
+            defaultValue:
+              'Pengaturan di bagian ini akan dikembalikan ke nilai default. Tindakan ini tidak dapat dibatalkan.',
+          })}
+          confirmText={t('actions.resetSection', { defaultValue: 'Reset Bagian Ini' })}
+          destructive
+          onConfirm={async () => {
+            await onReset();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+interface FieldRowProps {
+  label: React.ReactNode;
+  help?: React.ReactNode;
+  htmlFor?: string;
+  children: React.ReactNode;
+}
+
+export function FieldRow({ label, help, htmlFor, children }: FieldRowProps): JSX.Element {
+  return (
+    <div className="grid gap-1.5">
+      <label
+        htmlFor={htmlFor}
+        className="text-sm font-medium text-foreground"
+      >
+        {label}
+      </label>
+      {children}
+      {help && <p className="text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/settings/SinkronisasiPage.tsx
+++ b/apps/desktop/src/features/settings/SinkronisasiPage.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast-manager';
+import {
+  DEFAULT_SYNC_CONFIG,
+  type SyncConfig,
+  settingsApi,
+} from '@/lib/settings';
+import { FieldRow, SettingsSection } from './SettingsSection';
+
+export function SinkronisasiPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { showToast } = useToast();
+  const [cfg, setCfg] = React.useState<SyncConfig>(DEFAULT_SYNC_CONFIG);
+  const [saving, setSaving] = React.useState(false);
+  const [syncing, setSyncing] = React.useState(false);
+
+  React.useEffect(() => {
+    settingsApi.getSyncConfig().then(setCfg);
+  }, []);
+
+  const handleSave = async (): Promise<void> => {
+    setSaving(true);
+    try {
+      await settingsApi.saveSyncConfig(cfg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async (): Promise<void> => {
+    const next = await settingsApi.resetSyncConfig();
+    setCfg(next);
+  };
+
+  const handleSyncNow = async (): Promise<void> => {
+    setSyncing(true);
+    try {
+      const next = await settingsApi.syncNow();
+      setCfg(next);
+      showToast({
+        title: t('sections.sinkronisasi.syncSuccess', { defaultValue: 'Sinkronisasi berhasil.' }),
+      });
+    } catch (e) {
+      showToast({
+        title: t('sections.sinkronisasi.syncError', { defaultValue: 'Sinkronisasi gagal.' }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      i18nKey="sinkronisasi"
+      onSave={handleSave}
+      onReset={handleReset}
+      saving={saving}
+    >
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={cfg.enabled}
+          onChange={(e) => setCfg((c) => ({ ...c, enabled: e.target.checked }))}
+        />
+        {t('sections.sinkronisasi.fields.enabled', { defaultValue: 'Aktifkan Sinkronisasi' })}
+      </label>
+      <FieldRow
+        label={t('sections.sinkronisasi.fields.spreadsheetId', { defaultValue: 'ID Spreadsheet' })}
+      >
+        <Input
+          value={cfg.spreadsheetId}
+          onChange={(e) => setCfg((c) => ({ ...c, spreadsheetId: e.target.value }))}
+          disabled={!cfg.enabled}
+        />
+      </FieldRow>
+      <FieldRow label={t('sections.sinkronisasi.fields.apiKey', { defaultValue: 'API Key' })}>
+        <Input
+          type="password"
+          value={cfg.apiKey}
+          onChange={(e) => setCfg((c) => ({ ...c, apiKey: e.target.value }))}
+          disabled={!cfg.enabled}
+        />
+      </FieldRow>
+      <div className="flex items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-sm">
+        <span className="text-muted-foreground">
+          {t('sections.sinkronisasi.fields.lastSync', { defaultValue: 'Terakhir sinkron' })}:{' '}
+          {cfg.lastSync ? new Date(cfg.lastSync).toLocaleString() : '—'}
+        </span>
+        <Button size="sm" onClick={handleSyncNow} disabled={!cfg.enabled || syncing}>
+          {t('sections.sinkronisasi.syncNow', { defaultValue: 'Sinkron sekarang' })}
+        </Button>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/TampilanPage.tsx
+++ b/apps/desktop/src/features/settings/TampilanPage.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/components/ui/toast-manager';
+import { useThemeStore, type Theme } from '@/stores/themeStore';
+import {
+  DEFAULT_DISPLAY_PREFS,
+  type DisplayPrefs,
+  settingsApi,
+} from '@/lib/settings';
+import { FieldRow, SettingsSection } from './SettingsSection';
+
+const FONT_SCALES = [0.85, 0.9, 1.0, 1.1, 1.2, 1.3];
+
+function applyDisplayPrefs(prefs: DisplayPrefs): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.style.setProperty('--app-font-scale', String(prefs.fontScale));
+  root.style.fontSize = `${prefs.fontScale * 100}%`;
+  root.dataset.density = prefs.density;
+}
+
+export function TampilanPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { showToast } = useToast();
+  const { theme, setTheme } = useThemeStore();
+  const [prefs, setPrefs] = React.useState<DisplayPrefs>(DEFAULT_DISPLAY_PREFS);
+
+  React.useEffect(() => {
+    settingsApi.getDisplayPrefs().then((p) => {
+      setPrefs(p);
+      applyDisplayPrefs(p);
+    });
+  }, []);
+
+  const handleSavePrefs = async (next: DisplayPrefs): Promise<void> => {
+    setPrefs(next);
+    applyDisplayPrefs(next);
+    try {
+      await settingsApi.saveDisplayPrefs(next);
+    } catch (e) {
+      showToast({
+        title: t('sections.identitas.saveError', { defaultValue: 'Gagal menyimpan' }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleReset = async (): Promise<void> => {
+    setTheme('system');
+    const next = await settingsApi.resetDisplayPrefs();
+    setPrefs(next);
+    applyDisplayPrefs(next);
+  };
+
+  return (
+    <SettingsSection i18nKey="tampilan" onReset={handleReset}>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <FieldRow label={t('sections.tampilan.fields.theme', { defaultValue: 'Tema' })}>
+          <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
+            <SelectTrigger data-testid="tampilan-theme">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="light">Light</SelectItem>
+              <SelectItem value="dark">Dark</SelectItem>
+              <SelectItem value="system">System</SelectItem>
+            </SelectContent>
+          </Select>
+        </FieldRow>
+
+        <FieldRow label={t('sections.tampilan.fields.fontScale', { defaultValue: 'Skala font' })}>
+          <Select
+            value={String(prefs.fontScale)}
+            onValueChange={(v) => handleSavePrefs({ ...prefs, fontScale: parseFloat(v) })}
+          >
+            <SelectTrigger data-testid="tampilan-fontscale">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FONT_SCALES.map((s) => (
+                <SelectItem key={s} value={String(s)}>
+                  {Math.round(s * 100)}%
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FieldRow>
+
+        <FieldRow label={t('sections.tampilan.fields.density', { defaultValue: 'Kerapatan' })}>
+          <Select
+            value={prefs.density}
+            onValueChange={(v) =>
+              handleSavePrefs({ ...prefs, density: v as DisplayPrefs['density'] })
+            }
+          >
+            <SelectTrigger data-testid="tampilan-density">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="comfortable">
+                {t('sections.tampilan.density.comfortable', { defaultValue: 'Nyaman' })}
+              </SelectItem>
+              <SelectItem value="compact">
+                {t('sections.tampilan.density.compact', { defaultValue: 'Padat' })}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </FieldRow>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/TentangPage.tsx
+++ b/apps/desktop/src/features/settings/TentangPage.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next';
+import { BookOpen, Github } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { openManual } from '@/lib/manual';
+import { useIdentityStore } from '@/stores/identityStore';
+import { SettingsSection } from './SettingsSection';
+
+const APP_VERSION = '2.0.0-dev';
+const REPO_URL = 'https://github.com/alviarts/perpustakaan-offline';
+
+export function TentangPage(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { identity } = useIdentityStore();
+
+  return (
+    <SettingsSection i18nKey="tentang">
+      <dl className="grid gap-2 sm:grid-cols-[160px_1fr]">
+        <dt className="text-sm text-muted-foreground">
+          {t('sections.tentang.version', { defaultValue: 'Versi' })}
+        </dt>
+        <dd className="font-mono text-sm">{APP_VERSION}</dd>
+
+        <dt className="text-sm text-muted-foreground">
+          {t('sections.tentang.credits', { defaultValue: 'Kredit' })}
+        </dt>
+        <dd className="text-sm">
+          {t('sections.tentang.creditsValue', { defaultValue: 'alvi arts / vwrks' })}
+        </dd>
+
+        <dt className="text-sm text-muted-foreground">
+          {t('sections.tentang.license', { defaultValue: 'Lisensi' })}
+        </dt>
+        <dd className="text-sm">MIT</dd>
+
+        <dt className="text-sm text-muted-foreground">Perpustakaan</dt>
+        <dd className="text-sm">{identity.nama}</dd>
+      </dl>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          onClick={() => void openManual(identity)}
+          data-testid="tentang-open-manual"
+        >
+          <BookOpen className="h-4 w-4" />
+          {t('sections.tentang.openManual', { defaultValue: 'Buka Manual' })}
+        </Button>
+        <Button asChild variant="outline">
+          <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
+            <Github className="h-4 w-4" />
+            {t('sections.tentang.openRepo', { defaultValue: 'Repositori GitHub' })}
+          </a>
+        </Button>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/sections.ts
+++ b/apps/desktop/src/features/settings/sections.ts
@@ -1,0 +1,156 @@
+import {
+  IdCard,
+  Settings as SettingsIcon,
+  Database,
+  Palette,
+  Languages,
+  Users,
+  ShieldCheck,
+  HardDriveDownload,
+  RefreshCcw,
+  History,
+  Info,
+  BookText,
+} from 'lucide-react';
+
+/**
+ * 12 settings sub-page metadata (revisi #24).
+ *
+ * - `id` is the tail of the route, e.g. `identitas` → `/settings/identitas`.
+ * - `i18nKey` resolves to a `settings:sections.<key>` group containing
+ *   `label` + `summary` (and per-section field labels).
+ * - `keywords` is a hand-curated list of search terms (in addition to the
+ *   resolved label/summary translations) that the global search will match
+ *   against. Stored in code so we don't bloat translation files with synonyms.
+ */
+export interface SectionDef {
+  id: string;
+  to: string;
+  i18nKey: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  keywords: string[];
+}
+
+export const SECTIONS: SectionDef[] = [
+  {
+    id: 'identitas',
+    to: '/settings/identitas',
+    i18nKey: 'identitas',
+    Icon: IdCard,
+    keywords: ['identitas', 'identity', 'nama', 'logo', 'alamat', 'kepala', 'npsn', 'kontak'],
+  },
+  {
+    id: 'aturan-peminjaman',
+    to: '/settings/aturan-peminjaman',
+    i18nKey: 'aturanPeminjaman',
+    Icon: BookText,
+    keywords: [
+      'aturan peminjaman',
+      'loan rules',
+      'peminjaman',
+      'denda',
+      'fine',
+      'durasi',
+      'duration',
+      'limit',
+      'maksimum',
+      'hari libur',
+      'holiday',
+    ],
+  },
+  {
+    id: 'master-data',
+    to: '/settings/master-data',
+    i18nKey: 'masterData',
+    Icon: Database,
+    keywords: ['master data', 'ddc', 'kategori', 'bahasa', 'jurusan', 'kelas', 'agama'],
+  },
+  {
+    id: 'kta',
+    to: '/settings/kta',
+    i18nKey: 'kta',
+    Icon: IdCard,
+    keywords: ['kta', 'kartu', 'member card', 'template', 'barcode'],
+  },
+  {
+    id: 'tampilan',
+    to: '/settings/tampilan',
+    i18nKey: 'tampilan',
+    Icon: Palette,
+    keywords: ['tampilan', 'appearance', 'tema', 'theme', 'font', 'density', 'kerapatan'],
+  },
+  {
+    id: 'bahasa',
+    to: '/settings/bahasa',
+    i18nKey: 'bahasa',
+    Icon: Languages,
+    keywords: ['bahasa', 'language', 'indonesia', 'english', 'i18n', 'locale'],
+  },
+  {
+    id: 'akun',
+    to: '/settings/akun',
+    i18nKey: 'akun',
+    Icon: Users,
+    keywords: ['akun', 'pengguna', 'users', 'pustakawan', 'admin', 'password', 'reset'],
+  },
+  {
+    id: 'hak-akses',
+    to: '/settings/hak-akses',
+    i18nKey: 'hakAkses',
+    Icon: ShieldCheck,
+    keywords: ['hak akses', 'permission', 'role', 'admin', 'pustakawan', 'matrix'],
+  },
+  {
+    id: 'backup',
+    to: '/settings/backup',
+    i18nKey: 'backup',
+    Icon: HardDriveDownload,
+    keywords: ['backup', 'restore', 'database', 'jadwal', 'schedule'],
+  },
+  {
+    id: 'sinkronisasi',
+    to: '/settings/sinkronisasi',
+    i18nKey: 'sinkronisasi',
+    Icon: RefreshCcw,
+    keywords: ['sinkronisasi', 'sync', 'google sheets', 'spreadsheet', 'api key'],
+  },
+  {
+    id: 'audit-log',
+    to: '/settings/audit-log',
+    i18nKey: 'auditLog',
+    Icon: History,
+    keywords: ['audit log', 'riwayat', 'history', 'aksi', 'log'],
+  },
+  {
+    id: 'tentang',
+    to: '/settings/tentang',
+    i18nKey: 'tentang',
+    Icon: Info,
+    keywords: ['tentang', 'about', 'version', 'versi', 'manual', 'kredit', 'credits', 'github'],
+  },
+];
+
+export const SETTINGS_ICON = SettingsIcon;
+
+export interface SectionWithLabel extends SectionDef {
+  label: string;
+  summary: string;
+}
+
+/**
+ * Pure, dependency-free search filter (revisi #24). Used by both the runtime
+ * Settings sidebar and the unit test `settings-search.test.ts`. Matches against
+ * the resolved label, summary, and curated keywords list. Returns the original
+ * order when `query` is empty so the navigation stays stable.
+ */
+export function filterSections(
+  sections: SectionWithLabel[],
+  query: string,
+): SectionWithLabel[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return sections;
+  return sections.filter((s) => {
+    const haystack = [s.label, s.summary, ...s.keywords].join(' ').toLowerCase();
+    return haystack.includes(q);
+  });
+}

--- a/apps/desktop/src/i18n/en/laporan.json
+++ b/apps/desktop/src/i18n/en/laporan.json
@@ -47,7 +47,7 @@
     "saldo": "Closing Balance",
     "breakdown": "Income Breakdown",
     "breakdownHint": "Manual / fines / lost / capital",
-    "detail": "Transactions"
+    "detail": "Cash Detail"
   },
   "backup": {
     "title": "Database Backup",

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -1,6 +1,174 @@
 {
   "title": "Settings",
-  "placeholder": "Settings page will be built in Devin Session 11.",
-  "language": "App Language",
-  "theme": "App Theme"
+  "subtitle": "Configure application behaviour, library identity, accounts, and integrations.",
+  "search": {
+    "placeholder": "Search settings…",
+    "empty": "No matching settings.",
+    "results": "{{count}} results"
+  },
+  "actions": {
+    "resetAll": "Reset All",
+    "resetSection": "Reset This Section",
+    "resetConfirmTitle": "Reset to defaults?",
+    "resetConfirmDescription": "Settings in this section will be reverted to default values. This action cannot be undone.",
+    "save": "Save"
+  },
+  "sections": {
+    "identitas": {
+      "label": "Library Identity",
+      "summary": "Name, logo, address, head librarian, NPSN, contact.",
+      "fields": {
+        "nama": "Library Name",
+        "alamat": "Address",
+        "kepala": "Head Librarian",
+        "npsn": "NPSN",
+        "tahunAjaran": "Academic Year",
+        "logoPath": "Logo Path",
+        "kontak": "Contact"
+      },
+      "saveSuccess": "Identity saved.",
+      "saveError": "Failed to save identity."
+    },
+    "aturanPeminjaman": {
+      "label": "Loan Rules",
+      "summary": "Borrow limits, durations, fines, holidays.",
+      "fields": {
+        "maksBuku": "Max books per member",
+        "lamaPinjam": "Loan duration (days)",
+        "dendaPerHari": "Fine per day (IDR)",
+        "hariLibur": "Holidays (excluded from loan days)"
+      },
+      "hariLiburHelp": "Comma-separated. Example: 0,6 for Sunday & Saturday.",
+      "saveSuccess": "Loan rules saved.",
+      "saveError": "Failed to save loan rules."
+    },
+    "masterData": {
+      "label": "Master Data",
+      "summary": "DDC, categories, languages, majors, classes, religions."
+    },
+    "kta": {
+      "label": "Member Card (KTA)",
+      "summary": "Card template, barcode, fonts."
+    },
+    "tampilan": {
+      "label": "Appearance",
+      "summary": "Theme, text size, layout density.",
+      "fields": {
+        "theme": "Theme",
+        "fontScale": "Font scale",
+        "density": "Density"
+      },
+      "density": {
+        "compact": "Compact",
+        "comfortable": "Comfortable"
+      }
+    },
+    "bahasa": {
+      "label": "Language",
+      "summary": "Application interface language.",
+      "fields": {
+        "language": "Application Language"
+      }
+    },
+    "akun": {
+      "label": "Accounts & Users",
+      "summary": "Manage librarian and admin accounts, reset password.",
+      "table": {
+        "username": "Username",
+        "fullName": "Full Name",
+        "role": "Role",
+        "status": "Status",
+        "lastLogin": "Last Login",
+        "actions": "Actions"
+      },
+      "addUser": "Add User",
+      "editUser": "Edit User",
+      "resetPassword": "Reset Password",
+      "newPassword": "New Password",
+      "active": "Active",
+      "inactive": "Inactive",
+      "feedback": {
+        "createSuccess": "User created.",
+        "updateSuccess": "User updated.",
+        "deleteSuccess": "User deleted.",
+        "passwordReset": "Password reset."
+      },
+      "delete": {
+        "title": "Delete user \"{{name}}\"?",
+        "description": "The user will no longer be able to log in once deleted."
+      }
+    },
+    "hakAkses": {
+      "label": "Permissions",
+      "summary": "Permission matrix per role (admin, librarian).",
+      "roles": {
+        "admin": "Admin",
+        "pustakawan": "Librarian"
+      },
+      "areas": {
+        "anggota": "Members",
+        "buku": "Books",
+        "peminjaman": "Loans",
+        "pengembalian": "Returns",
+        "kunjungan": "Visits",
+        "laporan": "Reports",
+        "settings": "Settings",
+        "audit_log": "Audit Log"
+      },
+      "actions": {
+        "view": "View",
+        "create": "Create",
+        "update": "Update",
+        "delete": "Delete"
+      },
+      "saveSuccess": "Permission matrix saved."
+    },
+    "backup": {
+      "label": "Backup & Restore",
+      "summary": "Backup database, schedule, restore from file."
+    },
+    "sinkronisasi": {
+      "label": "Synchronization",
+      "summary": "Optional Google Sheets sync.",
+      "fields": {
+        "enabled": "Enable sync",
+        "spreadsheetId": "Spreadsheet ID",
+        "apiKey": "API Key",
+        "lastSync": "Last sync"
+      },
+      "syncNow": "Sync now",
+      "syncSuccess": "Sync succeeded.",
+      "syncError": "Sync failed."
+    },
+    "auditLog": {
+      "label": "Audit Log",
+      "summary": "History of user actions on application data.",
+      "filter": {
+        "user": "User",
+        "action": "Action",
+        "entity": "Entity",
+        "from": "From",
+        "to": "To"
+      },
+      "table": {
+        "timestamp": "Timestamp",
+        "user": "User",
+        "action": "Action",
+        "entity": "Entity",
+        "entityId": "ID",
+        "detail": "Detail"
+      },
+      "empty": "No records yet."
+    },
+    "tentang": {
+      "label": "About",
+      "summary": "Application version, credits, manual link.",
+      "version": "Version",
+      "credits": "Credits",
+      "creditsValue": "alvi arts / vwrks",
+      "openManual": "Open Manual",
+      "openRepo": "GitHub Repository",
+      "license": "License"
+    }
+  }
 }

--- a/apps/desktop/src/i18n/id/laporan.json
+++ b/apps/desktop/src/i18n/id/laporan.json
@@ -47,7 +47,7 @@
     "saldo": "Saldo Akhir",
     "breakdown": "Breakdown Pemasukan",
     "breakdownHint": "Manual / denda / hilang / modal",
-    "detail": "Detail Transaksi"
+    "detail": "Detail Kas"
   },
   "backup": {
     "title": "Backup Database",

--- a/apps/desktop/src/i18n/id/peminjaman.json
+++ b/apps/desktop/src/i18n/id/peminjaman.json
@@ -1,6 +1,6 @@
 {
   "title": "Peminjaman",
-  "subtitle": "Kelola transaksi peminjaman buku",
+  "subtitle": "Kelola aturan peminjaman buku",
   "aturanPeminjaman": "Aturan Peminjaman",
   "searchPlaceholder": "Cari nomor / nama / NIS",
   "empty": "Belum ada peminjaman",

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -1,6 +1,174 @@
 {
   "title": "Pengaturan",
-  "placeholder": "Halaman pengaturan akan dibuat di Devin Session 11.",
-  "language": "Bahasa Aplikasi",
-  "theme": "Tema Aplikasi"
+  "subtitle": "Atur perilaku aplikasi, identitas perpustakaan, akun, dan integrasi.",
+  "search": {
+    "placeholder": "Cari pengaturan…",
+    "empty": "Tidak ada pengaturan yang cocok.",
+    "results": "{{count}} hasil"
+  },
+  "actions": {
+    "resetAll": "Reset Semua",
+    "resetSection": "Reset Bagian Ini",
+    "resetConfirmTitle": "Reset ke nilai default?",
+    "resetConfirmDescription": "Pengaturan di bagian ini akan dikembalikan ke nilai default. Tindakan ini tidak dapat dibatalkan.",
+    "save": "Simpan"
+  },
+  "sections": {
+    "identitas": {
+      "label": "Identitas Perpustakaan",
+      "summary": "Nama, logo, alamat, kepala perpustakaan, NPSN, kontak.",
+      "fields": {
+        "nama": "Nama Perpustakaan",
+        "alamat": "Alamat",
+        "kepala": "Kepala Perpustakaan",
+        "npsn": "NPSN",
+        "tahunAjaran": "Tahun Ajaran",
+        "logoPath": "Path Logo",
+        "kontak": "Kontak"
+      },
+      "saveSuccess": "Identitas berhasil disimpan.",
+      "saveError": "Gagal menyimpan identitas."
+    },
+    "aturanPeminjaman": {
+      "label": "Aturan Peminjaman",
+      "summary": "Batas peminjaman, durasi, denda, hari libur.",
+      "fields": {
+        "maksBuku": "Maksimum buku per anggota",
+        "lamaPinjam": "Durasi pinjam (hari)",
+        "dendaPerHari": "Denda per hari (Rp)",
+        "hariLibur": "Hari libur (tidak dihitung sebagai hari pinjam)"
+      },
+      "hariLiburHelp": "Pisahkan dengan koma. Contoh: 0,6 untuk Minggu & Sabtu.",
+      "saveSuccess": "Aturan peminjaman berhasil disimpan.",
+      "saveError": "Gagal menyimpan aturan peminjaman."
+    },
+    "masterData": {
+      "label": "Master Data",
+      "summary": "DDC, kategori, bahasa, jurusan, kelas, agama."
+    },
+    "kta": {
+      "label": "Kartu Tanda Anggota",
+      "summary": "Template kartu, barcode, font."
+    },
+    "tampilan": {
+      "label": "Tampilan",
+      "summary": "Tema, ukuran teks, kerapatan tampilan.",
+      "fields": {
+        "theme": "Tema",
+        "fontScale": "Skala font",
+        "density": "Kerapatan"
+      },
+      "density": {
+        "compact": "Padat",
+        "comfortable": "Nyaman"
+      }
+    },
+    "bahasa": {
+      "label": "Bahasa",
+      "summary": "Bahasa antarmuka aplikasi.",
+      "fields": {
+        "language": "Bahasa Aplikasi"
+      }
+    },
+    "akun": {
+      "label": "Akun & Pengguna",
+      "summary": "Kelola akun pustakawan, admin, dan reset password.",
+      "table": {
+        "username": "Username",
+        "fullName": "Nama Lengkap",
+        "role": "Peran",
+        "status": "Status",
+        "lastLogin": "Login Terakhir",
+        "actions": "Aksi"
+      },
+      "addUser": "Tambah Pengguna",
+      "editUser": "Edit Pengguna",
+      "resetPassword": "Reset Password",
+      "newPassword": "Password Baru",
+      "active": "Aktif",
+      "inactive": "Nonaktif",
+      "feedback": {
+        "createSuccess": "Pengguna berhasil ditambahkan.",
+        "updateSuccess": "Pengguna berhasil diperbarui.",
+        "deleteSuccess": "Pengguna berhasil dihapus.",
+        "passwordReset": "Password berhasil direset."
+      },
+      "delete": {
+        "title": "Hapus pengguna \"{{name}}\"?",
+        "description": "Pengguna tidak akan bisa login lagi setelah dihapus."
+      }
+    },
+    "hakAkses": {
+      "label": "Hak Akses",
+      "summary": "Matriks izin per peran (admin, pustakawan).",
+      "roles": {
+        "admin": "Admin",
+        "pustakawan": "Pustakawan"
+      },
+      "areas": {
+        "anggota": "Anggota",
+        "buku": "Buku",
+        "peminjaman": "Peminjaman",
+        "pengembalian": "Pengembalian",
+        "kunjungan": "Kunjungan",
+        "laporan": "Laporan",
+        "settings": "Pengaturan",
+        "audit_log": "Audit Log"
+      },
+      "actions": {
+        "view": "Lihat",
+        "create": "Tambah",
+        "update": "Ubah",
+        "delete": "Hapus"
+      },
+      "saveSuccess": "Matriks izin berhasil disimpan."
+    },
+    "backup": {
+      "label": "Backup & Restore",
+      "summary": "Backup database, jadwal otomatis, restore dari file."
+    },
+    "sinkronisasi": {
+      "label": "Sinkronisasi",
+      "summary": "Sinkronisasi opsional ke Google Sheets.",
+      "fields": {
+        "enabled": "Aktifkan Sinkronisasi",
+        "spreadsheetId": "ID Spreadsheet",
+        "apiKey": "API Key",
+        "lastSync": "Terakhir sinkron"
+      },
+      "syncNow": "Sinkron sekarang",
+      "syncSuccess": "Sinkronisasi berhasil.",
+      "syncError": "Sinkronisasi gagal."
+    },
+    "auditLog": {
+      "label": "Audit Log",
+      "summary": "Riwayat aksi pengguna terhadap data aplikasi.",
+      "filter": {
+        "user": "Pengguna",
+        "action": "Aksi",
+        "entity": "Entitas",
+        "from": "Dari",
+        "to": "Sampai"
+      },
+      "table": {
+        "timestamp": "Waktu",
+        "user": "Pengguna",
+        "action": "Aksi",
+        "entity": "Entitas",
+        "entityId": "ID",
+        "detail": "Detail"
+      },
+      "empty": "Belum ada catatan."
+    },
+    "tentang": {
+      "label": "Tentang",
+      "summary": "Versi aplikasi, kredit, link manual.",
+      "version": "Versi",
+      "credits": "Kredit",
+      "creditsValue": "alvi arts / vwrks",
+      "openManual": "Buka Manual",
+      "openRepo": "Repositori GitHub",
+      "license": "Lisensi"
+    }
+  }
 }

--- a/apps/desktop/src/lib/manual.ts
+++ b/apps/desktop/src/lib/manual.ts
@@ -1,0 +1,33 @@
+/**
+ * Manual book opener (revisi #4).
+ *
+ * - In Tauri builds: invokes the Rust `open_manual` command which spawns a
+ *   dedicated webview window pointing at the bundled `/manual/index.html`.
+ * - In the browser fallback (`pnpm dev`, `vitest`, Playwright): opens the same
+ *   URL in a new browser tab.
+ *
+ * After opening, posts the current library identity to the manual window so it
+ * can render the perpustakaan name in its header (revisi #11 cross-cut).
+ */
+import { isTauri } from '@/lib/auth';
+import type { LibraryIdentity } from '@/stores/identityStore';
+
+const MANUAL_URL = '/manual/index.html';
+
+export async function openManual(identity?: LibraryIdentity): Promise<void> {
+  if (isTauri()) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('open_manual');
+    return;
+  }
+  const win = window.open(MANUAL_URL, '_blank', 'noopener,noreferrer');
+  if (win && identity?.nama) {
+    setTimeout(() => {
+      try {
+        win.postMessage({ type: 'po:identity', nama: identity.nama }, '*');
+      } catch {
+        // Ignore — manual window may be on a different origin.
+      }
+    }, 500);
+  }
+}

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -1,0 +1,693 @@
+/**
+ * Settings API client (revisi #24).
+ *
+ * Provides typed access to:
+ *   - Library identity        (Tauri: identity_get / identity_save)
+ *   - Loan rules              (key-value via setting_get / setting_save)
+ *   - Display preferences     (key-value)
+ *   - Sync configuration      (key-value)
+ *   - User accounts CRUD      (Tauri: settings_users_*)
+ *   - Permission matrix       (Tauri: settings_permissions_*)
+ *   - Audit log query         (Tauri: settings_audit_log_query)
+ *
+ * Each function falls back to a localStorage-backed mock so the UI is fully
+ * functional in `pnpm dev` and in `vitest` (jsdom) without a Rust backend.
+ */
+import { isTauri } from '@/lib/auth';
+import type { LibraryIdentity } from '@/stores/identityStore';
+
+// ---------------------------------------------------------------------------
+// Loan rules (Aturan Peminjaman)
+// ---------------------------------------------------------------------------
+
+export interface LoanRules {
+  maksBukuPinjam: number;
+  lamaPinjamHari: number;
+  dendaPerHari: number;
+  hariLibur: number[]; // 0=Sun..6=Sat (akan di-skip dari hitungan denda)
+}
+
+export const DEFAULT_LOAN_RULES: LoanRules = {
+  maksBukuPinjam: 3,
+  lamaPinjamHari: 7,
+  dendaPerHari: 500,
+  hariLibur: [0],
+};
+
+const LOAN_RULES_KEYS = {
+  maks: 'transaksi.maks_buku_pinjam',
+  lama: 'transaksi.lama_pinjam_hari',
+  denda: 'transaksi.denda_per_hari',
+  libur: 'transaksi.hari_libur',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Display preferences
+// ---------------------------------------------------------------------------
+
+export type Density = 'compact' | 'comfortable';
+
+export interface DisplayPrefs {
+  fontScale: number; // 0.8..1.4
+  density: Density;
+}
+
+export const DEFAULT_DISPLAY_PREFS: DisplayPrefs = {
+  fontScale: 1.0,
+  density: 'comfortable',
+};
+
+// ---------------------------------------------------------------------------
+// Sync configuration
+// ---------------------------------------------------------------------------
+
+export interface SyncConfig {
+  enabled: boolean;
+  spreadsheetId: string;
+  apiKey: string;
+  lastSync: string | null;
+}
+
+export const DEFAULT_SYNC_CONFIG: SyncConfig = {
+  enabled: false,
+  spreadsheetId: '',
+  apiKey: '',
+  lastSync: null,
+};
+
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+export type UserRole = 'admin' | 'pustakawan';
+
+export interface UserRecord {
+  id: number;
+  username: string;
+  fullName: string;
+  role: UserRole;
+  aktif: boolean;
+  lastLoginAt: string | null;
+  createdAt: string;
+}
+
+export interface UserInput {
+  username: string;
+  fullName: string;
+  role: UserRole;
+  aktif: boolean;
+  password?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Permissions
+// ---------------------------------------------------------------------------
+
+export type PermissionAction = 'view' | 'create' | 'update' | 'delete';
+export type PermissionArea =
+  | 'anggota'
+  | 'buku'
+  | 'peminjaman'
+  | 'pengembalian'
+  | 'kunjungan'
+  | 'laporan'
+  | 'settings'
+  | 'audit_log';
+
+export const PERMISSION_AREAS: PermissionArea[] = [
+  'anggota',
+  'buku',
+  'peminjaman',
+  'pengembalian',
+  'kunjungan',
+  'laporan',
+  'settings',
+  'audit_log',
+];
+
+export const PERMISSION_ACTIONS: PermissionAction[] = ['view', 'create', 'update', 'delete'];
+
+export type PermissionMatrix = Record<UserRole, Record<PermissionArea, Record<PermissionAction, boolean>>>;
+
+const allTrue = (): Record<PermissionAction, boolean> => ({
+  view: true,
+  create: true,
+  update: true,
+  delete: true,
+});
+
+const onlyView = (): Record<PermissionAction, boolean> => ({
+  view: true,
+  create: false,
+  update: false,
+  delete: false,
+});
+
+export const DEFAULT_PERMISSION_MATRIX: PermissionMatrix = {
+  admin: PERMISSION_AREAS.reduce(
+    (acc, area) => ({ ...acc, [area]: allTrue() }),
+    {} as Record<PermissionArea, Record<PermissionAction, boolean>>,
+  ),
+  pustakawan: PERMISSION_AREAS.reduce(
+    (acc, area) => {
+      const all = allTrue();
+      // Pustakawan tidak bisa edit settings / audit log secara default
+      if (area === 'settings' || area === 'audit_log') {
+        return { ...acc, [area]: onlyView() };
+      }
+      return { ...acc, [area]: all };
+    },
+    {} as Record<PermissionArea, Record<PermissionAction, boolean>>,
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+export interface AuditLogEntry {
+  id: number;
+  userId: number | null;
+  username: string | null;
+  aksi: string;
+  entitas: string;
+  entitasId: number | null;
+  detail: string | null;
+  createdAt: string;
+}
+
+export interface AuditLogQuery {
+  user?: string;
+  action?: string;
+  entity?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mock storage helpers (localStorage)
+// ---------------------------------------------------------------------------
+
+const MOCK_KEYS = {
+  loanRules: 'po:settings:loan-rules',
+  display: 'po:settings:display',
+  sync: 'po:settings:sync',
+  users: 'po:settings:users',
+  permissions: 'po:settings:permissions',
+  audit: 'po:settings:audit-log',
+  identity: 'po:settings:identity',
+};
+
+const readMock = <T,>(key: string, fallback: T): T => {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+const writeMock = (key: string, value: unknown): void => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(key, JSON.stringify(value));
+};
+
+// ---------------------------------------------------------------------------
+// Identity (delegates to identityStore command)
+// ---------------------------------------------------------------------------
+
+interface RustIdentity {
+  nama: string;
+  alamat: string;
+  kepala: string;
+  npsn: string;
+  tahun_ajaran: string;
+  logo_path: string;
+  kontak: string;
+}
+
+const fromRust = (r: RustIdentity): LibraryIdentity => ({
+  nama: r.nama,
+  alamat: r.alamat,
+  kepala: r.kepala,
+  npsn: r.npsn,
+  tahunAjaran: r.tahun_ajaran,
+  logoPath: r.logo_path,
+  kontak: r.kontak,
+});
+
+const toRust = (i: LibraryIdentity): RustIdentity => ({
+  nama: i.nama,
+  alamat: i.alamat,
+  kepala: i.kepala,
+  npsn: i.npsn,
+  tahun_ajaran: i.tahunAjaran,
+  logo_path: i.logoPath,
+  kontak: i.kontak,
+});
+
+export const DEFAULT_IDENTITY: LibraryIdentity = {
+  nama: 'Perpustakaan Sekolah',
+  alamat: '-',
+  kepala: '-',
+  npsn: '-',
+  tahunAjaran: '2024/2025',
+  logoPath: '',
+  kontak: '-',
+};
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+export interface SettingsApi {
+  getIdentity(): Promise<LibraryIdentity>;
+  saveIdentity(payload: LibraryIdentity): Promise<LibraryIdentity>;
+  resetIdentity(): Promise<LibraryIdentity>;
+
+  getLoanRules(): Promise<LoanRules>;
+  saveLoanRules(rules: LoanRules): Promise<LoanRules>;
+  resetLoanRules(): Promise<LoanRules>;
+
+  getDisplayPrefs(): Promise<DisplayPrefs>;
+  saveDisplayPrefs(prefs: DisplayPrefs): Promise<DisplayPrefs>;
+  resetDisplayPrefs(): Promise<DisplayPrefs>;
+
+  getSyncConfig(): Promise<SyncConfig>;
+  saveSyncConfig(cfg: SyncConfig): Promise<SyncConfig>;
+  resetSyncConfig(): Promise<SyncConfig>;
+  syncNow(): Promise<SyncConfig>;
+
+  listUsers(): Promise<UserRecord[]>;
+  createUser(payload: UserInput): Promise<UserRecord>;
+  updateUser(id: number, payload: UserInput): Promise<UserRecord>;
+  deleteUser(id: number): Promise<void>;
+  resetPassword(id: number, newPassword: string): Promise<void>;
+
+  getPermissionMatrix(): Promise<PermissionMatrix>;
+  savePermissionMatrix(matrix: PermissionMatrix): Promise<PermissionMatrix>;
+  resetPermissionMatrix(): Promise<PermissionMatrix>;
+
+  queryAuditLog(query: AuditLogQuery): Promise<AuditLogEntry[]>;
+  __resetMock?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Mock implementation (browser fallback)
+// ---------------------------------------------------------------------------
+
+let mockUserSeq = 100;
+
+function seedMockUsers(): UserRecord[] {
+  const now = new Date().toISOString();
+  return [
+    {
+      id: 1,
+      username: 'admin',
+      fullName: 'Administrator',
+      role: 'admin',
+      aktif: true,
+      lastLoginAt: now,
+      createdAt: now,
+    },
+    {
+      id: 2,
+      username: 'pustakawan1',
+      fullName: 'Pustakawan Satu',
+      role: 'pustakawan',
+      aktif: true,
+      lastLoginAt: null,
+      createdAt: now,
+    },
+  ];
+}
+
+function seedMockAudit(): AuditLogEntry[] {
+  const base = Date.now();
+  return [
+    {
+      id: 1,
+      userId: 1,
+      username: 'admin',
+      aksi: 'login',
+      entitas: 'auth',
+      entitasId: null,
+      detail: null,
+      createdAt: new Date(base - 60_000).toISOString(),
+    },
+    {
+      id: 2,
+      userId: 1,
+      username: 'admin',
+      aksi: 'create',
+      entitas: 'anggota',
+      entitasId: 42,
+      detail: 'Andini Putri',
+      createdAt: new Date(base - 30_000).toISOString(),
+    },
+  ];
+}
+
+const mockApi: SettingsApi = {
+  async getIdentity() {
+    return readMock<LibraryIdentity>(MOCK_KEYS.identity, DEFAULT_IDENTITY);
+  },
+  async saveIdentity(payload) {
+    writeMock(MOCK_KEYS.identity, payload);
+    return payload;
+  },
+  async resetIdentity() {
+    writeMock(MOCK_KEYS.identity, DEFAULT_IDENTITY);
+    return DEFAULT_IDENTITY;
+  },
+
+  async getLoanRules() {
+    return readMock<LoanRules>(MOCK_KEYS.loanRules, DEFAULT_LOAN_RULES);
+  },
+  async saveLoanRules(rules) {
+    writeMock(MOCK_KEYS.loanRules, rules);
+    return rules;
+  },
+  async resetLoanRules() {
+    writeMock(MOCK_KEYS.loanRules, DEFAULT_LOAN_RULES);
+    return DEFAULT_LOAN_RULES;
+  },
+
+  async getDisplayPrefs() {
+    return readMock<DisplayPrefs>(MOCK_KEYS.display, DEFAULT_DISPLAY_PREFS);
+  },
+  async saveDisplayPrefs(prefs) {
+    writeMock(MOCK_KEYS.display, prefs);
+    return prefs;
+  },
+  async resetDisplayPrefs() {
+    writeMock(MOCK_KEYS.display, DEFAULT_DISPLAY_PREFS);
+    return DEFAULT_DISPLAY_PREFS;
+  },
+
+  async getSyncConfig() {
+    return readMock<SyncConfig>(MOCK_KEYS.sync, DEFAULT_SYNC_CONFIG);
+  },
+  async saveSyncConfig(cfg) {
+    writeMock(MOCK_KEYS.sync, cfg);
+    return cfg;
+  },
+  async resetSyncConfig() {
+    writeMock(MOCK_KEYS.sync, DEFAULT_SYNC_CONFIG);
+    return DEFAULT_SYNC_CONFIG;
+  },
+  async syncNow() {
+    const cfg = await this.getSyncConfig();
+    const updated = { ...cfg, lastSync: new Date().toISOString() };
+    writeMock(MOCK_KEYS.sync, updated);
+    return updated;
+  },
+
+  async listUsers() {
+    let users = readMock<UserRecord[] | null>(MOCK_KEYS.users, null);
+    if (!users) {
+      users = seedMockUsers();
+      writeMock(MOCK_KEYS.users, users);
+    }
+    return users;
+  },
+  async createUser(payload) {
+    const users = await this.listUsers();
+    if (users.some((u) => u.username === payload.username)) {
+      throw new Error('username_taken');
+    }
+    mockUserSeq += 1;
+    const next: UserRecord = {
+      id: mockUserSeq,
+      username: payload.username,
+      fullName: payload.fullName,
+      role: payload.role,
+      aktif: payload.aktif,
+      lastLoginAt: null,
+      createdAt: new Date().toISOString(),
+    };
+    writeMock(MOCK_KEYS.users, [...users, next]);
+    return next;
+  },
+  async updateUser(id, payload) {
+    const users = await this.listUsers();
+    const idx = users.findIndex((u) => u.id === id);
+    const existing = idx === -1 ? undefined : users[idx];
+    if (idx === -1 || !existing) throw new Error('user_not_found');
+    const updated: UserRecord = {
+      ...existing,
+      username: payload.username,
+      fullName: payload.fullName,
+      role: payload.role,
+      aktif: payload.aktif,
+    };
+    const next = [...users];
+    next[idx] = updated;
+    writeMock(MOCK_KEYS.users, next);
+    return updated;
+  },
+  async deleteUser(id) {
+    const users = await this.listUsers();
+    writeMock(
+      MOCK_KEYS.users,
+      users.filter((u) => u.id !== id),
+    );
+  },
+  async resetPassword(id, _newPassword) {
+    const users = await this.listUsers();
+    if (!users.some((u) => u.id === id)) throw new Error('user_not_found');
+    return;
+  },
+
+  async getPermissionMatrix() {
+    return readMock<PermissionMatrix>(MOCK_KEYS.permissions, DEFAULT_PERMISSION_MATRIX);
+  },
+  async savePermissionMatrix(matrix) {
+    writeMock(MOCK_KEYS.permissions, matrix);
+    return matrix;
+  },
+  async resetPermissionMatrix() {
+    writeMock(MOCK_KEYS.permissions, DEFAULT_PERMISSION_MATRIX);
+    return DEFAULT_PERMISSION_MATRIX;
+  },
+
+  async queryAuditLog(query) {
+    let entries = readMock<AuditLogEntry[] | null>(MOCK_KEYS.audit, null);
+    if (!entries) {
+      entries = seedMockAudit();
+      writeMock(MOCK_KEYS.audit, entries);
+    }
+    let filtered = entries;
+    if (query.user) {
+      const q = query.user.toLowerCase();
+      filtered = filtered.filter((e) => (e.username ?? '').toLowerCase().includes(q));
+    }
+    if (query.action) {
+      filtered = filtered.filter((e) => e.aksi === query.action);
+    }
+    if (query.entity) {
+      filtered = filtered.filter((e) => e.entitas === query.entity);
+    }
+    if (query.from) {
+      filtered = filtered.filter((e) => e.createdAt >= query.from!);
+    }
+    if (query.to) {
+      filtered = filtered.filter((e) => e.createdAt <= query.to!);
+    }
+    if (query.limit) {
+      filtered = filtered.slice(0, query.limit);
+    }
+    return filtered;
+  },
+
+  __resetMock() {
+    if (typeof window === 'undefined') return;
+    Object.values(MOCK_KEYS).forEach((k) => window.localStorage.removeItem(k));
+    mockUserSeq = 100;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tauri implementation
+// ---------------------------------------------------------------------------
+
+const tauriApi: SettingsApi = {
+  async getIdentity() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return fromRust(await invoke<RustIdentity>('identity_get'));
+  },
+  async saveIdentity(payload) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return fromRust(
+      await invoke<RustIdentity>('identity_save', { payload: toRust(payload) }),
+    );
+  },
+  async resetIdentity() {
+    return tauriApi.saveIdentity(DEFAULT_IDENTITY);
+  },
+
+  async getLoanRules() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const rows = await invoke<Record<string, string>>('settings_get_many', {
+      keys: Object.values(LOAN_RULES_KEYS),
+    });
+    return {
+      maksBukuPinjam: parseInt(rows[LOAN_RULES_KEYS.maks] ?? '', 10) || DEFAULT_LOAN_RULES.maksBukuPinjam,
+      lamaPinjamHari: parseInt(rows[LOAN_RULES_KEYS.lama] ?? '', 10) || DEFAULT_LOAN_RULES.lamaPinjamHari,
+      dendaPerHari: parseInt(rows[LOAN_RULES_KEYS.denda] ?? '', 10) || DEFAULT_LOAN_RULES.dendaPerHari,
+      hariLibur: parseHariLibur(rows[LOAN_RULES_KEYS.libur] ?? ''),
+    };
+  },
+  async saveLoanRules(rules) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('settings_set_many', {
+      entries: {
+        [LOAN_RULES_KEYS.maks]: String(rules.maksBukuPinjam),
+        [LOAN_RULES_KEYS.lama]: String(rules.lamaPinjamHari),
+        [LOAN_RULES_KEYS.denda]: String(rules.dendaPerHari),
+        [LOAN_RULES_KEYS.libur]: rules.hariLibur.join(','),
+      },
+    });
+    return rules;
+  },
+  async resetLoanRules() {
+    return tauriApi.saveLoanRules(DEFAULT_LOAN_RULES);
+  },
+
+  async getDisplayPrefs() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const rows = await invoke<Record<string, string>>('settings_get_many', {
+      keys: ['ui.font_scale', 'ui.density'],
+    });
+    const fontScale = parseFloat(rows['ui.font_scale'] ?? '');
+    const density = (rows['ui.density'] ?? '') as Density;
+    return {
+      fontScale: Number.isFinite(fontScale) && fontScale > 0 ? fontScale : DEFAULT_DISPLAY_PREFS.fontScale,
+      density: density === 'compact' || density === 'comfortable' ? density : DEFAULT_DISPLAY_PREFS.density,
+    };
+  },
+  async saveDisplayPrefs(prefs) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('settings_set_many', {
+      entries: {
+        'ui.font_scale': String(prefs.fontScale),
+        'ui.density': prefs.density,
+      },
+    });
+    return prefs;
+  },
+  async resetDisplayPrefs() {
+    return tauriApi.saveDisplayPrefs(DEFAULT_DISPLAY_PREFS);
+  },
+
+  async getSyncConfig() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const rows = await invoke<Record<string, string>>('settings_get_many', {
+      keys: ['sync.enabled', 'sync.spreadsheet_id', 'sync.api_key', 'sync.last_sync'],
+    });
+    return {
+      enabled: rows['sync.enabled'] === '1',
+      spreadsheetId: rows['sync.spreadsheet_id'] ?? '',
+      apiKey: rows['sync.api_key'] ?? '',
+      lastSync: rows['sync.last_sync'] || null,
+    };
+  },
+  async saveSyncConfig(cfg) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('settings_set_many', {
+      entries: {
+        'sync.enabled': cfg.enabled ? '1' : '0',
+        'sync.spreadsheet_id': cfg.spreadsheetId,
+        'sync.api_key': cfg.apiKey,
+        'sync.last_sync': cfg.lastSync ?? '',
+      },
+    });
+    return cfg;
+  },
+  async resetSyncConfig() {
+    return tauriApi.saveSyncConfig(DEFAULT_SYNC_CONFIG);
+  },
+  async syncNow() {
+    const cfg = await tauriApi.getSyncConfig();
+    return tauriApi.saveSyncConfig({ ...cfg, lastSync: new Date().toISOString() });
+  },
+
+  async listUsers() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<UserRecord[]>('settings_users_list');
+  },
+  async createUser(payload) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<UserRecord>('settings_users_create', { payload });
+  },
+  async updateUser(id, payload) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<UserRecord>('settings_users_update', { id, payload });
+  },
+  async deleteUser(id) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('settings_users_delete', { id });
+  },
+  async resetPassword(id, newPassword) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('settings_users_reset_password', { id, newPassword });
+  },
+
+  async getPermissionMatrix() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<PermissionMatrix>('settings_permissions_get');
+  },
+  async savePermissionMatrix(matrix) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<PermissionMatrix>('settings_permissions_save', { matrix });
+  },
+  async resetPermissionMatrix() {
+    return tauriApi.savePermissionMatrix(DEFAULT_PERMISSION_MATRIX);
+  },
+
+  async queryAuditLog(query) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<AuditLogEntry[]>('settings_audit_log_query', { query });
+  },
+};
+
+function parseHariLibur(raw: string): number[] {
+  if (!raw) return DEFAULT_LOAN_RULES.hariLibur;
+  return raw
+    .split(',')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => Number.isInteger(n) && n >= 0 && n <= 6);
+}
+
+function rpc(): SettingsApi {
+  return isTauri() ? tauriApi : mockApi;
+}
+
+export const settingsApi: SettingsApi = {
+  getIdentity: () => rpc().getIdentity(),
+  saveIdentity: (payload) => rpc().saveIdentity(payload),
+  resetIdentity: () => rpc().resetIdentity(),
+  getLoanRules: () => rpc().getLoanRules(),
+  saveLoanRules: (rules) => rpc().saveLoanRules(rules),
+  resetLoanRules: () => rpc().resetLoanRules(),
+  getDisplayPrefs: () => rpc().getDisplayPrefs(),
+  saveDisplayPrefs: (prefs) => rpc().saveDisplayPrefs(prefs),
+  resetDisplayPrefs: () => rpc().resetDisplayPrefs(),
+  getSyncConfig: () => rpc().getSyncConfig(),
+  saveSyncConfig: (cfg) => rpc().saveSyncConfig(cfg),
+  resetSyncConfig: () => rpc().resetSyncConfig(),
+  syncNow: () => rpc().syncNow(),
+  listUsers: () => rpc().listUsers(),
+  createUser: (payload) => rpc().createUser(payload),
+  updateUser: (id, payload) => rpc().updateUser(id, payload),
+  deleteUser: (id) => rpc().deleteUser(id),
+  resetPassword: (id, pw) => rpc().resetPassword(id, pw),
+  getPermissionMatrix: () => rpc().getPermissionMatrix(),
+  savePermissionMatrix: (m) => rpc().savePermissionMatrix(m),
+  resetPermissionMatrix: () => rpc().resetPermissionMatrix(),
+  queryAuditLog: (q) => rpc().queryAuditLog(q),
+  __resetMock: () => mockApi.__resetMock?.(),
+};

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -12,16 +12,28 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthedSettingsRouteImport } from './routes/_authed/settings'
 import { Route as AuthedLaporanRouteImport } from './routes/_authed/laporan'
 import { Route as AuthedKunjunganRouteImport } from './routes/_authed/kunjungan'
 import { Route as AuthedDashboardRouteImport } from './routes/_authed/dashboard'
+import { Route as AuthedSettingsIndexRouteImport } from './routes/_authed/settings/index'
 import { Route as AuthedPengembalianIndexRouteImport } from './routes/_authed/pengembalian/index'
 import { Route as AuthedPeminjamanIndexRouteImport } from './routes/_authed/peminjaman/index'
 import { Route as AuthedLaporanIndexRouteImport } from './routes/_authed/laporan/index'
 import { Route as AuthedBukuIndexRouteImport } from './routes/_authed/buku/index'
 import { Route as AuthedAnggotaIndexRouteImport } from './routes/_authed/anggota/index'
+import { Route as AuthedSettingsTentangRouteImport } from './routes/_authed/settings/tentang'
+import { Route as AuthedSettingsTampilanRouteImport } from './routes/_authed/settings/tampilan'
+import { Route as AuthedSettingsSinkronisasiRouteImport } from './routes/_authed/settings/sinkronisasi'
 import { Route as AuthedSettingsMasterDataRouteImport } from './routes/_authed/settings/master-data'
 import { Route as AuthedSettingsKtaRouteImport } from './routes/_authed/settings/kta'
+import { Route as AuthedSettingsIdentitasRouteImport } from './routes/_authed/settings/identitas'
+import { Route as AuthedSettingsHakAksesRouteImport } from './routes/_authed/settings/hak-akses'
+import { Route as AuthedSettingsBahasaRouteImport } from './routes/_authed/settings/bahasa'
+import { Route as AuthedSettingsBackupRouteImport } from './routes/_authed/settings/backup'
+import { Route as AuthedSettingsAuditLogRouteImport } from './routes/_authed/settings/audit-log'
+import { Route as AuthedSettingsAturanPeminjamanRouteImport } from './routes/_authed/settings/aturan-peminjaman'
+import { Route as AuthedSettingsAkunRouteImport } from './routes/_authed/settings/akun'
 import { Route as AuthedPeminjamanNewRouteImport } from './routes/_authed/peminjaman/new'
 import { Route as AuthedPeminjamanIdRouteImport } from './routes/_authed/peminjaman/$id'
 import { Route as AuthedLaporanTopPeminjamRouteImport } from './routes/_authed/laporan/top-peminjam'
@@ -49,6 +61,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthedSettingsRoute = AuthedSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedLaporanRoute = AuthedLaporanRouteImport.update({
   id: '/laporan',
   path: '/laporan',
@@ -63,6 +80,11 @@ const AuthedDashboardRoute = AuthedDashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
   getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedSettingsIndexRoute = AuthedSettingsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthedSettingsRoute,
 } as any)
 const AuthedPengembalianIndexRoute = AuthedPengembalianIndexRouteImport.update({
   id: '/pengembalian/',
@@ -89,16 +111,68 @@ const AuthedAnggotaIndexRoute = AuthedAnggotaIndexRouteImport.update({
   path: '/anggota/',
   getParentRoute: () => AuthedRoute,
 } as any)
+const AuthedSettingsTentangRoute = AuthedSettingsTentangRouteImport.update({
+  id: '/tentang',
+  path: '/tentang',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsTampilanRoute = AuthedSettingsTampilanRouteImport.update({
+  id: '/tampilan',
+  path: '/tampilan',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsSinkronisasiRoute =
+  AuthedSettingsSinkronisasiRouteImport.update({
+    id: '/sinkronisasi',
+    path: '/sinkronisasi',
+    getParentRoute: () => AuthedSettingsRoute,
+  } as any)
 const AuthedSettingsMasterDataRoute =
   AuthedSettingsMasterDataRouteImport.update({
-    id: '/settings/master-data',
-    path: '/settings/master-data',
-    getParentRoute: () => AuthedRoute,
+    id: '/master-data',
+    path: '/master-data',
+    getParentRoute: () => AuthedSettingsRoute,
   } as any)
 const AuthedSettingsKtaRoute = AuthedSettingsKtaRouteImport.update({
-  id: '/settings/kta',
-  path: '/settings/kta',
-  getParentRoute: () => AuthedRoute,
+  id: '/kta',
+  path: '/kta',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsIdentitasRoute = AuthedSettingsIdentitasRouteImport.update({
+  id: '/identitas',
+  path: '/identitas',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsHakAksesRoute = AuthedSettingsHakAksesRouteImport.update({
+  id: '/hak-akses',
+  path: '/hak-akses',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsBahasaRoute = AuthedSettingsBahasaRouteImport.update({
+  id: '/bahasa',
+  path: '/bahasa',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsBackupRoute = AuthedSettingsBackupRouteImport.update({
+  id: '/backup',
+  path: '/backup',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsAuditLogRoute = AuthedSettingsAuditLogRouteImport.update({
+  id: '/audit-log',
+  path: '/audit-log',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
+const AuthedSettingsAturanPeminjamanRoute =
+  AuthedSettingsAturanPeminjamanRouteImport.update({
+    id: '/aturan-peminjaman',
+    path: '/aturan-peminjaman',
+    getParentRoute: () => AuthedSettingsRoute,
+  } as any)
+const AuthedSettingsAkunRoute = AuthedSettingsAkunRouteImport.update({
+  id: '/akun',
+  path: '/akun',
+  getParentRoute: () => AuthedSettingsRoute,
 } as any)
 const AuthedPeminjamanNewRoute = AuthedPeminjamanNewRouteImport.update({
   id: '/peminjaman/new',
@@ -168,6 +242,7 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof AuthedDashboardRoute
   '/kunjungan': typeof AuthedKunjunganRoute
   '/laporan': typeof AuthedLaporanRouteWithChildren
+  '/settings': typeof AuthedSettingsRouteWithChildren
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/cetak-kta': typeof AuthedAnggotaCetakKtaRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
@@ -180,13 +255,24 @@ export interface FileRoutesByFullPath {
   '/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/peminjaman/new': typeof AuthedPeminjamanNewRoute
+  '/settings/akun': typeof AuthedSettingsAkunRoute
+  '/settings/aturan-peminjaman': typeof AuthedSettingsAturanPeminjamanRoute
+  '/settings/audit-log': typeof AuthedSettingsAuditLogRoute
+  '/settings/backup': typeof AuthedSettingsBackupRoute
+  '/settings/bahasa': typeof AuthedSettingsBahasaRoute
+  '/settings/hak-akses': typeof AuthedSettingsHakAksesRoute
+  '/settings/identitas': typeof AuthedSettingsIdentitasRoute
   '/settings/kta': typeof AuthedSettingsKtaRoute
   '/settings/master-data': typeof AuthedSettingsMasterDataRoute
+  '/settings/sinkronisasi': typeof AuthedSettingsSinkronisasiRoute
+  '/settings/tampilan': typeof AuthedSettingsTampilanRoute
+  '/settings/tentang': typeof AuthedSettingsTentangRoute
   '/anggota/': typeof AuthedAnggotaIndexRoute
   '/buku/': typeof AuthedBukuIndexRoute
   '/laporan/': typeof AuthedLaporanIndexRoute
   '/peminjaman/': typeof AuthedPeminjamanIndexRoute
   '/pengembalian/': typeof AuthedPengembalianIndexRoute
+  '/settings/': typeof AuthedSettingsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -205,13 +291,24 @@ export interface FileRoutesByTo {
   '/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/peminjaman/new': typeof AuthedPeminjamanNewRoute
+  '/settings/akun': typeof AuthedSettingsAkunRoute
+  '/settings/aturan-peminjaman': typeof AuthedSettingsAturanPeminjamanRoute
+  '/settings/audit-log': typeof AuthedSettingsAuditLogRoute
+  '/settings/backup': typeof AuthedSettingsBackupRoute
+  '/settings/bahasa': typeof AuthedSettingsBahasaRoute
+  '/settings/hak-akses': typeof AuthedSettingsHakAksesRoute
+  '/settings/identitas': typeof AuthedSettingsIdentitasRoute
   '/settings/kta': typeof AuthedSettingsKtaRoute
   '/settings/master-data': typeof AuthedSettingsMasterDataRoute
+  '/settings/sinkronisasi': typeof AuthedSettingsSinkronisasiRoute
+  '/settings/tampilan': typeof AuthedSettingsTampilanRoute
+  '/settings/tentang': typeof AuthedSettingsTentangRoute
   '/anggota': typeof AuthedAnggotaIndexRoute
   '/buku': typeof AuthedBukuIndexRoute
   '/laporan': typeof AuthedLaporanIndexRoute
   '/peminjaman': typeof AuthedPeminjamanIndexRoute
   '/pengembalian': typeof AuthedPengembalianIndexRoute
+  '/settings': typeof AuthedSettingsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -221,6 +318,7 @@ export interface FileRoutesById {
   '/_authed/dashboard': typeof AuthedDashboardRoute
   '/_authed/kunjungan': typeof AuthedKunjunganRoute
   '/_authed/laporan': typeof AuthedLaporanRouteWithChildren
+  '/_authed/settings': typeof AuthedSettingsRouteWithChildren
   '/_authed/anggota/$id': typeof AuthedAnggotaIdRoute
   '/_authed/anggota/cetak-kta': typeof AuthedAnggotaCetakKtaRoute
   '/_authed/anggota/new': typeof AuthedAnggotaNewRoute
@@ -233,13 +331,24 @@ export interface FileRoutesById {
   '/_authed/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/_authed/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/_authed/peminjaman/new': typeof AuthedPeminjamanNewRoute
+  '/_authed/settings/akun': typeof AuthedSettingsAkunRoute
+  '/_authed/settings/aturan-peminjaman': typeof AuthedSettingsAturanPeminjamanRoute
+  '/_authed/settings/audit-log': typeof AuthedSettingsAuditLogRoute
+  '/_authed/settings/backup': typeof AuthedSettingsBackupRoute
+  '/_authed/settings/bahasa': typeof AuthedSettingsBahasaRoute
+  '/_authed/settings/hak-akses': typeof AuthedSettingsHakAksesRoute
+  '/_authed/settings/identitas': typeof AuthedSettingsIdentitasRoute
   '/_authed/settings/kta': typeof AuthedSettingsKtaRoute
   '/_authed/settings/master-data': typeof AuthedSettingsMasterDataRoute
+  '/_authed/settings/sinkronisasi': typeof AuthedSettingsSinkronisasiRoute
+  '/_authed/settings/tampilan': typeof AuthedSettingsTampilanRoute
+  '/_authed/settings/tentang': typeof AuthedSettingsTentangRoute
   '/_authed/anggota/': typeof AuthedAnggotaIndexRoute
   '/_authed/buku/': typeof AuthedBukuIndexRoute
   '/_authed/laporan/': typeof AuthedLaporanIndexRoute
   '/_authed/peminjaman/': typeof AuthedPeminjamanIndexRoute
   '/_authed/pengembalian/': typeof AuthedPengembalianIndexRoute
+  '/_authed/settings/': typeof AuthedSettingsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -249,6 +358,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/kunjungan'
     | '/laporan'
+    | '/settings'
     | '/anggota/$id'
     | '/anggota/cetak-kta'
     | '/anggota/new'
@@ -261,13 +371,24 @@ export interface FileRouteTypes {
     | '/laporan/top-peminjam'
     | '/peminjaman/$id'
     | '/peminjaman/new'
+    | '/settings/akun'
+    | '/settings/aturan-peminjaman'
+    | '/settings/audit-log'
+    | '/settings/backup'
+    | '/settings/bahasa'
+    | '/settings/hak-akses'
+    | '/settings/identitas'
     | '/settings/kta'
     | '/settings/master-data'
+    | '/settings/sinkronisasi'
+    | '/settings/tampilan'
+    | '/settings/tentang'
     | '/anggota/'
     | '/buku/'
     | '/laporan/'
     | '/peminjaman/'
     | '/pengembalian/'
+    | '/settings/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -286,13 +407,24 @@ export interface FileRouteTypes {
     | '/laporan/top-peminjam'
     | '/peminjaman/$id'
     | '/peminjaman/new'
+    | '/settings/akun'
+    | '/settings/aturan-peminjaman'
+    | '/settings/audit-log'
+    | '/settings/backup'
+    | '/settings/bahasa'
+    | '/settings/hak-akses'
+    | '/settings/identitas'
     | '/settings/kta'
     | '/settings/master-data'
+    | '/settings/sinkronisasi'
+    | '/settings/tampilan'
+    | '/settings/tentang'
     | '/anggota'
     | '/buku'
     | '/laporan'
     | '/peminjaman'
     | '/pengembalian'
+    | '/settings'
   id:
     | '__root__'
     | '/'
@@ -301,6 +433,7 @@ export interface FileRouteTypes {
     | '/_authed/dashboard'
     | '/_authed/kunjungan'
     | '/_authed/laporan'
+    | '/_authed/settings'
     | '/_authed/anggota/$id'
     | '/_authed/anggota/cetak-kta'
     | '/_authed/anggota/new'
@@ -313,13 +446,24 @@ export interface FileRouteTypes {
     | '/_authed/laporan/top-peminjam'
     | '/_authed/peminjaman/$id'
     | '/_authed/peminjaman/new'
+    | '/_authed/settings/akun'
+    | '/_authed/settings/aturan-peminjaman'
+    | '/_authed/settings/audit-log'
+    | '/_authed/settings/backup'
+    | '/_authed/settings/bahasa'
+    | '/_authed/settings/hak-akses'
+    | '/_authed/settings/identitas'
     | '/_authed/settings/kta'
     | '/_authed/settings/master-data'
+    | '/_authed/settings/sinkronisasi'
+    | '/_authed/settings/tampilan'
+    | '/_authed/settings/tentang'
     | '/_authed/anggota/'
     | '/_authed/buku/'
     | '/_authed/laporan/'
     | '/_authed/peminjaman/'
     | '/_authed/pengembalian/'
+    | '/_authed/settings/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -351,6 +495,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authed/settings': {
+      id: '/_authed/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthedSettingsRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/laporan': {
       id: '/_authed/laporan'
       path: '/laporan'
@@ -371,6 +522,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/dashboard'
       preLoaderRoute: typeof AuthedDashboardRouteImport
       parentRoute: typeof AuthedRoute
+    }
+    '/_authed/settings/': {
+      id: '/_authed/settings/'
+      path: '/'
+      fullPath: '/settings/'
+      preLoaderRoute: typeof AuthedSettingsIndexRouteImport
+      parentRoute: typeof AuthedSettingsRoute
     }
     '/_authed/pengembalian/': {
       id: '/_authed/pengembalian/'
@@ -407,19 +565,89 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedAnggotaIndexRouteImport
       parentRoute: typeof AuthedRoute
     }
+    '/_authed/settings/tentang': {
+      id: '/_authed/settings/tentang'
+      path: '/tentang'
+      fullPath: '/settings/tentang'
+      preLoaderRoute: typeof AuthedSettingsTentangRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/tampilan': {
+      id: '/_authed/settings/tampilan'
+      path: '/tampilan'
+      fullPath: '/settings/tampilan'
+      preLoaderRoute: typeof AuthedSettingsTampilanRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/sinkronisasi': {
+      id: '/_authed/settings/sinkronisasi'
+      path: '/sinkronisasi'
+      fullPath: '/settings/sinkronisasi'
+      preLoaderRoute: typeof AuthedSettingsSinkronisasiRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
     '/_authed/settings/master-data': {
       id: '/_authed/settings/master-data'
-      path: '/settings/master-data'
+      path: '/master-data'
       fullPath: '/settings/master-data'
       preLoaderRoute: typeof AuthedSettingsMasterDataRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRoute
     }
     '/_authed/settings/kta': {
       id: '/_authed/settings/kta'
-      path: '/settings/kta'
+      path: '/kta'
       fullPath: '/settings/kta'
       preLoaderRoute: typeof AuthedSettingsKtaRouteImport
-      parentRoute: typeof AuthedRoute
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/identitas': {
+      id: '/_authed/settings/identitas'
+      path: '/identitas'
+      fullPath: '/settings/identitas'
+      preLoaderRoute: typeof AuthedSettingsIdentitasRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/hak-akses': {
+      id: '/_authed/settings/hak-akses'
+      path: '/hak-akses'
+      fullPath: '/settings/hak-akses'
+      preLoaderRoute: typeof AuthedSettingsHakAksesRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/bahasa': {
+      id: '/_authed/settings/bahasa'
+      path: '/bahasa'
+      fullPath: '/settings/bahasa'
+      preLoaderRoute: typeof AuthedSettingsBahasaRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/backup': {
+      id: '/_authed/settings/backup'
+      path: '/backup'
+      fullPath: '/settings/backup'
+      preLoaderRoute: typeof AuthedSettingsBackupRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/audit-log': {
+      id: '/_authed/settings/audit-log'
+      path: '/audit-log'
+      fullPath: '/settings/audit-log'
+      preLoaderRoute: typeof AuthedSettingsAuditLogRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/aturan-peminjaman': {
+      id: '/_authed/settings/aturan-peminjaman'
+      path: '/aturan-peminjaman'
+      fullPath: '/settings/aturan-peminjaman'
+      preLoaderRoute: typeof AuthedSettingsAturanPeminjamanRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/akun': {
+      id: '/_authed/settings/akun'
+      path: '/akun'
+      fullPath: '/settings/akun'
+      preLoaderRoute: typeof AuthedSettingsAkunRouteImport
+      parentRoute: typeof AuthedSettingsRoute
     }
     '/_authed/peminjaman/new': {
       id: '/_authed/peminjaman/new'
@@ -530,10 +758,47 @@ const AuthedLaporanRouteWithChildren = AuthedLaporanRoute._addFileChildren(
   AuthedLaporanRouteChildren,
 )
 
+interface AuthedSettingsRouteChildren {
+  AuthedSettingsAkunRoute: typeof AuthedSettingsAkunRoute
+  AuthedSettingsAturanPeminjamanRoute: typeof AuthedSettingsAturanPeminjamanRoute
+  AuthedSettingsAuditLogRoute: typeof AuthedSettingsAuditLogRoute
+  AuthedSettingsBackupRoute: typeof AuthedSettingsBackupRoute
+  AuthedSettingsBahasaRoute: typeof AuthedSettingsBahasaRoute
+  AuthedSettingsHakAksesRoute: typeof AuthedSettingsHakAksesRoute
+  AuthedSettingsIdentitasRoute: typeof AuthedSettingsIdentitasRoute
+  AuthedSettingsKtaRoute: typeof AuthedSettingsKtaRoute
+  AuthedSettingsMasterDataRoute: typeof AuthedSettingsMasterDataRoute
+  AuthedSettingsSinkronisasiRoute: typeof AuthedSettingsSinkronisasiRoute
+  AuthedSettingsTampilanRoute: typeof AuthedSettingsTampilanRoute
+  AuthedSettingsTentangRoute: typeof AuthedSettingsTentangRoute
+  AuthedSettingsIndexRoute: typeof AuthedSettingsIndexRoute
+}
+
+const AuthedSettingsRouteChildren: AuthedSettingsRouteChildren = {
+  AuthedSettingsAkunRoute: AuthedSettingsAkunRoute,
+  AuthedSettingsAturanPeminjamanRoute: AuthedSettingsAturanPeminjamanRoute,
+  AuthedSettingsAuditLogRoute: AuthedSettingsAuditLogRoute,
+  AuthedSettingsBackupRoute: AuthedSettingsBackupRoute,
+  AuthedSettingsBahasaRoute: AuthedSettingsBahasaRoute,
+  AuthedSettingsHakAksesRoute: AuthedSettingsHakAksesRoute,
+  AuthedSettingsIdentitasRoute: AuthedSettingsIdentitasRoute,
+  AuthedSettingsKtaRoute: AuthedSettingsKtaRoute,
+  AuthedSettingsMasterDataRoute: AuthedSettingsMasterDataRoute,
+  AuthedSettingsSinkronisasiRoute: AuthedSettingsSinkronisasiRoute,
+  AuthedSettingsTampilanRoute: AuthedSettingsTampilanRoute,
+  AuthedSettingsTentangRoute: AuthedSettingsTentangRoute,
+  AuthedSettingsIndexRoute: AuthedSettingsIndexRoute,
+}
+
+const AuthedSettingsRouteWithChildren = AuthedSettingsRoute._addFileChildren(
+  AuthedSettingsRouteChildren,
+)
+
 interface AuthedRouteChildren {
   AuthedDashboardRoute: typeof AuthedDashboardRoute
   AuthedKunjunganRoute: typeof AuthedKunjunganRoute
   AuthedLaporanRoute: typeof AuthedLaporanRouteWithChildren
+  AuthedSettingsRoute: typeof AuthedSettingsRouteWithChildren
   AuthedAnggotaIdRoute: typeof AuthedAnggotaIdRoute
   AuthedAnggotaCetakKtaRoute: typeof AuthedAnggotaCetakKtaRoute
   AuthedAnggotaNewRoute: typeof AuthedAnggotaNewRoute
@@ -541,8 +806,6 @@ interface AuthedRouteChildren {
   AuthedBukuNewRoute: typeof AuthedBukuNewRoute
   AuthedPeminjamanIdRoute: typeof AuthedPeminjamanIdRoute
   AuthedPeminjamanNewRoute: typeof AuthedPeminjamanNewRoute
-  AuthedSettingsKtaRoute: typeof AuthedSettingsKtaRoute
-  AuthedSettingsMasterDataRoute: typeof AuthedSettingsMasterDataRoute
   AuthedAnggotaIndexRoute: typeof AuthedAnggotaIndexRoute
   AuthedBukuIndexRoute: typeof AuthedBukuIndexRoute
   AuthedPeminjamanIndexRoute: typeof AuthedPeminjamanIndexRoute
@@ -553,6 +816,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedDashboardRoute: AuthedDashboardRoute,
   AuthedKunjunganRoute: AuthedKunjunganRoute,
   AuthedLaporanRoute: AuthedLaporanRouteWithChildren,
+  AuthedSettingsRoute: AuthedSettingsRouteWithChildren,
   AuthedAnggotaIdRoute: AuthedAnggotaIdRoute,
   AuthedAnggotaCetakKtaRoute: AuthedAnggotaCetakKtaRoute,
   AuthedAnggotaNewRoute: AuthedAnggotaNewRoute,
@@ -560,8 +824,6 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedBukuNewRoute: AuthedBukuNewRoute,
   AuthedPeminjamanIdRoute: AuthedPeminjamanIdRoute,
   AuthedPeminjamanNewRoute: AuthedPeminjamanNewRoute,
-  AuthedSettingsKtaRoute: AuthedSettingsKtaRoute,
-  AuthedSettingsMasterDataRoute: AuthedSettingsMasterDataRoute,
   AuthedAnggotaIndexRoute: AuthedAnggotaIndexRoute,
   AuthedBukuIndexRoute: AuthedBukuIndexRoute,
   AuthedPeminjamanIndexRoute: AuthedPeminjamanIndexRoute,

--- a/apps/desktop/src/routes/_authed/settings.tsx
+++ b/apps/desktop/src/routes/_authed/settings.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { SettingsLayout } from '@/features/settings/SettingsLayout';
+
+export const Route = createFileRoute('/_authed/settings')({
+  component: SettingsLayout,
+});

--- a/apps/desktop/src/routes/_authed/settings/akun.tsx
+++ b/apps/desktop/src/routes/_authed/settings/akun.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AkunPage } from '@/features/settings/AkunPage';
+
+export const Route = createFileRoute('/_authed/settings/akun')({
+  component: AkunPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/aturan-peminjaman.tsx
+++ b/apps/desktop/src/routes/_authed/settings/aturan-peminjaman.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AturanPeminjamanPage } from '@/features/settings/AturanPeminjamanPage';
+
+export const Route = createFileRoute('/_authed/settings/aturan-peminjaman')({
+  component: AturanPeminjamanPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/audit-log.tsx
+++ b/apps/desktop/src/routes/_authed/settings/audit-log.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AuditLogPage } from '@/features/settings/AuditLogPage';
+
+export const Route = createFileRoute('/_authed/settings/audit-log')({
+  component: AuditLogPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/backup.tsx
+++ b/apps/desktop/src/routes/_authed/settings/backup.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { BackupPage } from '@/features/settings/BackupPage';
+
+export const Route = createFileRoute('/_authed/settings/backup')({
+  component: BackupPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/bahasa.tsx
+++ b/apps/desktop/src/routes/_authed/settings/bahasa.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { BahasaPage } from '@/features/settings/BahasaPage';
+
+export const Route = createFileRoute('/_authed/settings/bahasa')({
+  component: BahasaPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/hak-akses.tsx
+++ b/apps/desktop/src/routes/_authed/settings/hak-akses.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { HakAksesPage } from '@/features/settings/HakAksesPage';
+
+export const Route = createFileRoute('/_authed/settings/hak-akses')({
+  component: HakAksesPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/identitas.tsx
+++ b/apps/desktop/src/routes/_authed/settings/identitas.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { IdentitasPage } from '@/features/settings/IdentitasPage';
+
+export const Route = createFileRoute('/_authed/settings/identitas')({
+  component: IdentitasPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/index.tsx
+++ b/apps/desktop/src/routes/_authed/settings/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_authed/settings/')({
+  beforeLoad: () => {
+    throw redirect({ to: '/settings/identitas' });
+  },
+});

--- a/apps/desktop/src/routes/_authed/settings/sinkronisasi.tsx
+++ b/apps/desktop/src/routes/_authed/settings/sinkronisasi.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { SinkronisasiPage } from '@/features/settings/SinkronisasiPage';
+
+export const Route = createFileRoute('/_authed/settings/sinkronisasi')({
+  component: SinkronisasiPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/tampilan.tsx
+++ b/apps/desktop/src/routes/_authed/settings/tampilan.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { TampilanPage } from '@/features/settings/TampilanPage';
+
+export const Route = createFileRoute('/_authed/settings/tampilan')({
+  component: TampilanPage,
+});

--- a/apps/desktop/src/routes/_authed/settings/tentang.tsx
+++ b/apps/desktop/src/routes/_authed/settings/tentang.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { TentangPage } from '@/features/settings/TentangPage';
+
+export const Route = createFileRoute('/_authed/settings/tentang')({
+  component: TentangPage,
+});

--- a/apps/desktop/tests/e2e/settings.spec.ts
+++ b/apps/desktop/tests/e2e/settings.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+async function adminLogin(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/login');
+  await page.evaluate(() => {
+    localStorage.clear();
+  });
+  await page.reload();
+  await page.getByLabel(/Nama Pengguna|Username/).fill('admin');
+  await page.getByLabel(/Kata Sandi|Password/).fill('admin123');
+  await page.getByRole('button', { name: /Masuk|Sign in/ }).click();
+  await page.waitForURL(/\/dashboard/);
+}
+
+test.describe('settings — search & navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await adminLogin(page);
+    await page.goto('/settings');
+    await page.waitForURL(/\/settings\/identitas/);
+  });
+
+  test('default redirect lands on Identitas', async ({ page }) => {
+    await expect(page).toHaveURL(/\/settings\/identitas/);
+    await expect(page.getByTestId('settings-section-identitas')).toBeVisible();
+  });
+
+  test('sidebar lists 12 settings sections', async ({ page }) => {
+    const nav = page.getByTestId('settings-nav');
+    await expect(nav).toBeVisible();
+    const links = nav.locator('a');
+    await expect(links).toHaveCount(12);
+  });
+
+  test('search "denda" filters down to Aturan Peminjaman', async ({ page }) => {
+    const search = page.getByTestId('settings-search');
+    await search.fill('denda');
+    const nav = page.getByTestId('settings-nav');
+    const links = nav.locator('a');
+    await expect(links).toHaveCount(1);
+    await expect(links.first()).toContainText(/Aturan Peminjaman|Loan Rules/);
+  });
+
+  test('search empty state shows message', async ({ page }) => {
+    await page.getByTestId('settings-search').fill('qqqqzzzzz');
+    await expect(page.getByTestId('settings-nav')).toContainText(/Tidak ada|No matching/);
+  });
+
+  test('navigates to Tampilan and Reset shows confirm', async ({ page }) => {
+    await page.getByTestId('settings-nav-tampilan').click();
+    await expect(page).toHaveURL(/\/settings\/tampilan/);
+    await page.getByTestId('settings-reset-tampilan').click();
+    await expect(page.getByRole('alertdialog')).toBeVisible();
+  });
+
+  test('navigates to Tentang and shows credit + manual button', async ({ page }) => {
+    await page.getByTestId('settings-nav-tentang').click();
+    await expect(page).toHaveURL(/\/settings\/tentang/);
+    await expect(page.getByText(/alvi arts/i)).toBeVisible();
+    await expect(page.getByTestId('tentang-open-manual')).toBeVisible();
+  });
+});

--- a/apps/desktop/tests/unit/i18n-coverage.test.ts
+++ b/apps/desktop/tests/unit/i18n-coverage.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * i18n parity guard (revisi #25). Mirrors `scripts/i18n-lint.mjs` so the same
+ * invariant is checked in unit tests as well as in CI.
+ *
+ *   id ↔ en must contain the exact same set of leaf keys for every namespace.
+ *
+ * If you add a new key to `apps/desktop/src/i18n/id/*.json`, you MUST add the
+ * same key to `apps/desktop/src/i18n/en/*.json` (with an English translation).
+ */
+function flattenKeys(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return [prefix];
+  }
+  const record = obj as Record<string, unknown>;
+  const out: string[] = [];
+  for (const key of Object.keys(record)) {
+    const next = prefix ? `${prefix}.${key}` : key;
+    out.push(...flattenKeys(record[key], next));
+  }
+  return out;
+}
+
+const I18N_ROOT = resolve(__dirname, '../../src/i18n');
+
+function loadNamespace(locale: 'id' | 'en', file: string): unknown {
+  const raw = readFileSync(resolve(I18N_ROOT, locale, file), 'utf8');
+  return JSON.parse(raw);
+}
+
+describe('i18n coverage', () => {
+  const idFiles = readdirSync(resolve(I18N_ROOT, 'id')).filter((f) => f.endsWith('.json'));
+  const enFiles = readdirSync(resolve(I18N_ROOT, 'en')).filter((f) => f.endsWith('.json'));
+
+  it('id and en contain the same namespaces', () => {
+    expect(idFiles.sort()).toEqual(enFiles.sort());
+  });
+
+  for (const file of idFiles) {
+    it(`namespace "${file}" has identical keys in id and en`, () => {
+      const idKeys = flattenKeys(loadNamespace('id', file)).sort();
+      const enKeys = flattenKeys(loadNamespace('en', file)).sort();
+
+      const onlyInId = idKeys.filter((k) => !enKeys.includes(k));
+      const onlyInEn = enKeys.filter((k) => !idKeys.includes(k));
+
+      expect(onlyInId, `missing in en/${file}`).toEqual([]);
+      expect(onlyInEn, `missing in id/${file}`).toEqual([]);
+    });
+  }
+
+  it('settings namespace contains a key per sub-page', () => {
+    const settings = loadNamespace('id', 'settings.json') as Record<string, unknown>;
+    const sections = settings.sections as Record<string, unknown>;
+    const required = [
+      'identitas',
+      'aturanPeminjaman',
+      'masterData',
+      'kta',
+      'tampilan',
+      'bahasa',
+      'akun',
+      'hakAkses',
+      'backup',
+      'sinkronisasi',
+      'auditLog',
+      'tentang',
+    ];
+    for (const r of required) {
+      expect(sections, `missing settings.sections.${r}`).toHaveProperty(r);
+    }
+  });
+});

--- a/apps/desktop/tests/unit/settings-search.test.ts
+++ b/apps/desktop/tests/unit/settings-search.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { SECTIONS, filterSections, type SectionWithLabel } from '../../src/features/settings/sections';
+
+const labelled: SectionWithLabel[] = SECTIONS.map((s) => ({
+  ...s,
+  // Use the curated keywords as the label/summary for unit testing so the test
+  // doesn't depend on the i18n bundle being initialized.
+  label: s.id,
+  summary: s.keywords.join(' '),
+}));
+
+describe('settings search filter', () => {
+  it('returns all sections when query is empty', () => {
+    expect(filterSections(labelled, '')).toHaveLength(labelled.length);
+    expect(filterSections(labelled, '   ')).toHaveLength(labelled.length);
+  });
+
+  it('matches "denda" only against Aturan Peminjaman', () => {
+    const result = filterSections(labelled, 'denda').map((s) => s.id);
+    expect(result).toEqual(['aturan-peminjaman']);
+  });
+
+  it('matches "ddc" only against Master Data', () => {
+    const result = filterSections(labelled, 'ddc').map((s) => s.id);
+    expect(result).toEqual(['master-data']);
+  });
+
+  it('case-insensitive: "TEMA" matches Tampilan', () => {
+    const result = filterSections(labelled, 'TEMA').map((s) => s.id);
+    expect(result).toContain('tampilan');
+  });
+
+  it('"sync" matches Sinkronisasi', () => {
+    const result = filterSections(labelled, 'sync').map((s) => s.id);
+    expect(result).toEqual(['sinkronisasi']);
+  });
+
+  it('"manual" matches Tentang', () => {
+    const result = filterSections(labelled, 'manual').map((s) => s.id);
+    expect(result).toEqual(['tentang']);
+  });
+
+  it('returns empty list for nonsense', () => {
+    expect(filterSections(labelled, 'qqqzzz123')).toEqual([]);
+  });
+
+  it('preserves original order', () => {
+    const result = filterSections(labelled, '').map((s) => s.id);
+    expect(result).toEqual(labelled.map((s) => s.id));
+  });
+});

--- a/apps/manual/build.mjs
+++ b/apps/manual/build.mjs
@@ -1,0 +1,448 @@
+/**
+ * Manual book HTML generator (revisi #4).
+ *
+ * Reads the legacy `docs/manual.md`, converts to a self-contained, responsive
+ * HTML page with:
+ *   - sticky table of contents (built from h2/h3 headings)
+ *   - full-text search (filters TOC + highlights matches)
+ *   - light/dark mode toggle
+ *   - placeholder hooks for the library identity (`{{LIB_NAMA}}`) injected at
+ *     runtime by the frontend before opening the manual
+ *
+ * Output is written to:
+ *   - `apps/desktop/public/manual/index.html`  (served by Vite in dev + bundled
+ *     into the Tauri frontend in release)
+ *
+ * Markdown rendering is intentionally hand-rolled (no external deps) so the
+ * build runs offline without network access during CI.
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+
+const sources = [resolve(repoRoot, 'docs/manual.md')];
+const outDirs = [resolve(repoRoot, 'apps/desktop/public/manual')];
+
+const escapeHtml = (s) =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
+const slugify = (s) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+
+/**
+ * Tiny Markdown → HTML converter targeted at the subset used in `docs/manual.md`.
+ * Supports: headings, paragraphs, fenced/inline code, bold/italic, links,
+ * bullet & ordered lists, blockquotes, horizontal rules.
+ */
+function renderMarkdown(md) {
+  const lines = md.replace(/\r\n/g, '\n').split('\n');
+  const out = [];
+  const toc = [];
+  let i = 0;
+
+  const flushParagraph = (buf) => {
+    if (buf.length === 0) return;
+    out.push(`<p>${formatInline(buf.join(' '))}</p>`);
+    buf.length = 0;
+  };
+
+  const formatInline = (raw) => {
+    let s = escapeHtml(raw);
+    // Inline code first to protect from other replacements
+    s = s.replace(/`([^`]+)`/g, (_m, c) => `<code>${c}</code>`);
+    // Bold **text**
+    s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    // Italic *text*
+    s = s.replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
+    // Links [text](href)
+    s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, t, h) => {
+      const url = h.startsWith('http') || h.startsWith('#') ? h : escapeHtml(h);
+      const ext = url.startsWith('http')
+        ? ' target="_blank" rel="noopener noreferrer"'
+        : '';
+      return `<a href="${url}"${ext}>${t}</a>`;
+    });
+    return s;
+  };
+
+  const buf = [];
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block
+    const fence = /^```([a-zA-Z0-9_-]*)\s*$/.exec(line);
+    if (fence) {
+      flushParagraph(buf);
+      const lang = fence[1] || '';
+      const codeLines = [];
+      i += 1;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        codeLines.push(lines[i]);
+        i += 1;
+      }
+      i += 1; // skip closing fence
+      out.push(
+        `<pre><code class="lang-${escapeHtml(lang)}">${escapeHtml(
+          codeLines.join('\n'),
+        )}</code></pre>`,
+      );
+      continue;
+    }
+
+    // Heading
+    const heading = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      flushParagraph(buf);
+      const level = heading[1].length;
+      const text = heading[2].replace(/\{#[^}]+\}\s*$/, '').trim();
+      const slug = slugify(text);
+      if (level <= 3 && level >= 2) {
+        toc.push({ level, text, slug });
+      }
+      out.push(
+        `<h${level} id="${slug}"><a href="#${slug}" class="anchor" aria-hidden="true">#</a> ${formatInline(text)}</h${level}>`,
+      );
+      i += 1;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^---+\s*$/.test(line)) {
+      flushParagraph(buf);
+      out.push('<hr />');
+      i += 1;
+      continue;
+    }
+
+    // Blockquote
+    if (/^>\s?/.test(line)) {
+      flushParagraph(buf);
+      const quoteLines = [];
+      while (i < lines.length && /^>\s?/.test(lines[i])) {
+        quoteLines.push(lines[i].replace(/^>\s?/, ''));
+        i += 1;
+      }
+      out.push(`<blockquote>${formatInline(quoteLines.join(' '))}</blockquote>`);
+      continue;
+    }
+
+    // Unordered list
+    if (/^[-*+]\s+/.test(line)) {
+      flushParagraph(buf);
+      const items = [];
+      while (i < lines.length && /^[-*+]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^[-*+]\s+/, ''));
+        i += 1;
+      }
+      out.push(
+        `<ul>${items.map((it) => `<li>${formatInline(it)}</li>`).join('')}</ul>`,
+      );
+      continue;
+    }
+
+    // Ordered list
+    if (/^\d+\.\s+/.test(line)) {
+      flushParagraph(buf);
+      const items = [];
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\d+\.\s+/, ''));
+        i += 1;
+      }
+      out.push(
+        `<ol>${items.map((it) => `<li>${formatInline(it)}</li>`).join('')}</ol>`,
+      );
+      continue;
+    }
+
+    // Blank line ends paragraph
+    if (line.trim() === '') {
+      flushParagraph(buf);
+      i += 1;
+      continue;
+    }
+
+    buf.push(line);
+    i += 1;
+  }
+  flushParagraph(buf);
+
+  return { html: out.join('\n'), toc };
+}
+
+const TEMPLATE_CSS = `
+:root {
+  --bg: #ffffff;
+  --bg-elevated: #f7f8fa;
+  --fg: #0f172a;
+  --fg-muted: #475569;
+  --accent: #2563eb;
+  --border: #e2e8f0;
+  --code-bg: #f1f5f9;
+  --shadow: 0 1px 2px rgba(15,23,42,0.08);
+}
+:root[data-theme='dark'] {
+  --bg: #0f172a;
+  --bg-elevated: #1e293b;
+  --fg: #f1f5f9;
+  --fg-muted: #94a3b8;
+  --accent: #60a5fa;
+  --border: #334155;
+  --code-bg: #1e293b;
+  --shadow: 0 1px 2px rgba(0,0,0,0.4);
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.65;
+  font-size: 16px;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+header.topbar {
+  position: sticky; top: 0; z-index: 10;
+  display: flex; align-items: center; gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+header.topbar .brand {
+  font-weight: 700;
+  font-size: 1rem;
+  margin-right: auto;
+}
+header.topbar .brand small {
+  display: block; font-weight: 400; color: var(--fg-muted); font-size: 0.78rem;
+}
+header.topbar input[type='search'] {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.9rem;
+  min-width: 220px;
+}
+header.topbar button {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+header.topbar button:hover { background: var(--bg); }
+.layout { display: grid; grid-template-columns: 280px 1fr; gap: 1.5rem; max-width: 1200px; margin: 0 auto; padding: 1.5rem 1.25rem; }
+@media (max-width: 768px) { .layout { grid-template-columns: 1fr; } }
+nav.toc {
+  position: sticky; top: 5rem;
+  align-self: start;
+  font-size: 0.9rem;
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+nav.toc ul { list-style: none; padding: 0; margin: 0; }
+nav.toc li { margin: 0.15rem 0; }
+nav.toc a {
+  display: block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  color: var(--fg-muted);
+}
+nav.toc a:hover, nav.toc a.active { color: var(--fg); background: var(--bg-elevated); text-decoration: none; }
+nav.toc .level-3 { padding-left: 1rem; font-size: 0.85rem; }
+nav.toc.hidden-by-search li.hidden { display: none; }
+@media (max-width: 768px) { nav.toc { position: static; max-height: none; } }
+main.content { min-width: 0; }
+main.content h1, main.content h2, main.content h3 {
+  scroll-margin-top: 5rem;
+  line-height: 1.25;
+}
+main.content h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.4rem; margin-top: 2.25rem; }
+main.content code {
+  background: var(--code-bg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.88em;
+}
+main.content pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+}
+main.content pre code { background: transparent; padding: 0; font-size: 0.88em; }
+main.content blockquote {
+  border-left: 4px solid var(--accent);
+  padding: 0.4rem 1rem;
+  background: var(--bg-elevated);
+  color: var(--fg-muted);
+  margin: 1rem 0;
+  border-radius: 0 6px 6px 0;
+}
+main.content hr { border: 0; border-top: 1px solid var(--border); margin: 2rem 0; }
+.anchor { color: var(--fg-muted); margin-right: 0.25rem; opacity: 0; transition: opacity .15s; }
+h2:hover .anchor, h3:hover .anchor { opacity: 1; }
+.match-highlight { background: rgba(255, 230, 0, 0.55); border-radius: 3px; }
+:root[data-theme='dark'] .match-highlight { background: rgba(96, 165, 250, 0.45); color: var(--fg); }
+`;
+
+const TEMPLATE_JS = `
+(function () {
+  const root = document.documentElement;
+  const STORAGE = 'po-manual:theme';
+  const stored = localStorage.getItem(STORAGE);
+  const initial = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  root.setAttribute('data-theme', initial);
+
+  const themeBtn = document.getElementById('theme-toggle');
+  themeBtn.addEventListener('click', () => {
+    const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', next);
+    localStorage.setItem(STORAGE, next);
+  });
+
+  const tocEl = document.querySelector('nav.toc');
+  const search = document.getElementById('search');
+  const headings = Array.from(document.querySelectorAll('main.content h2, main.content h3'));
+  const blocks = Array.from(document.querySelectorAll('main.content > *'));
+  const tocItems = Array.from(tocEl.querySelectorAll('li'));
+
+  function clearHighlights() {
+    document.querySelectorAll('.match-highlight').forEach((el) => {
+      const text = document.createTextNode(el.textContent);
+      el.parentNode.replaceChild(text, el);
+    });
+    blocks.forEach((b) => (b.style.display = ''));
+    tocEl.classList.remove('hidden-by-search');
+    tocItems.forEach((li) => li.classList.remove('hidden'));
+  }
+
+  search.addEventListener('input', () => {
+    const q = search.value.trim().toLowerCase();
+    if (!q) { clearHighlights(); return; }
+    clearHighlights();
+    tocEl.classList.add('hidden-by-search');
+    const visibleSlugs = new Set();
+    let currentSlug = null;
+    blocks.forEach((b) => {
+      if (b.tagName === 'H2' || b.tagName === 'H3') {
+        currentSlug = b.id;
+      }
+      const t = (b.textContent || '').toLowerCase();
+      if (t.includes(q)) {
+        b.style.display = '';
+        if (currentSlug) visibleSlugs.add(currentSlug);
+      } else {
+        b.style.display = 'none';
+      }
+    });
+    headings.forEach((h) => {
+      if (visibleSlugs.has(h.id)) h.style.display = '';
+    });
+    tocItems.forEach((li) => {
+      const anchor = li.querySelector('a');
+      const slug = anchor && anchor.getAttribute('href').replace(/^#/, '');
+      if (slug && visibleSlugs.has(slug)) li.classList.remove('hidden');
+      else li.classList.add('hidden');
+    });
+  });
+
+  // ScrollSpy: highlight active TOC entry
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((e) => {
+      if (e.isIntersecting) {
+        const id = e.target.id;
+        tocItems.forEach((li) => {
+          const a = li.querySelector('a');
+          if (a && a.getAttribute('href') === '#' + id) a.classList.add('active');
+          else if (a) a.classList.remove('active');
+        });
+      }
+    });
+  }, { rootMargin: '-30% 0px -65% 0px' });
+  headings.forEach((h) => observer.observe(h));
+
+  // Library identity hook (frontend can postMessage to update brand)
+  window.addEventListener('message', (ev) => {
+    if (!ev.data || ev.data.type !== 'po:identity') return;
+    const brand = document.getElementById('brand-nama');
+    if (brand && typeof ev.data.nama === 'string' && ev.data.nama.trim()) {
+      brand.textContent = ev.data.nama;
+    }
+  });
+})();
+`;
+
+function buildHtml({ html, toc }, { libNama }) {
+  const tocHtml = toc
+    .map((t) => {
+      const cls = `level-${t.level}`;
+      return `<li class="${cls}"><a href="#${t.slug}">${escapeHtml(t.text)}</a></li>`;
+    })
+    .join('');
+
+  return `<!doctype html>
+<html lang="id">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Buku Manual — Perpustakaan Offline</title>
+  <style>${TEMPLATE_CSS}</style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <span id="brand-nama">${escapeHtml(libNama)}</span>
+      <small>Buku Manual Pengguna</small>
+    </div>
+    <input id="search" type="search" placeholder="Cari di manual…" aria-label="Cari" />
+    <button id="theme-toggle" aria-label="Toggle theme">Light / Dark</button>
+  </header>
+  <div class="layout">
+    <nav class="toc" aria-label="Daftar isi">
+      <ul>${tocHtml}</ul>
+    </nav>
+    <main class="content">
+      ${html}
+    </main>
+  </div>
+  <script>${TEMPLATE_JS}</script>
+</body>
+</html>
+`;
+}
+
+function buildAll() {
+  const md = sources.map((s) => readFileSync(s, 'utf8')).join('\n\n');
+  const rendered = renderMarkdown(md);
+  // Default identity placeholder; the frontend can override via postMessage.
+  const html = buildHtml(rendered, { libNama: 'Perpustakaan Sekolah' });
+  outDirs.forEach((dir) => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'index.html'), html, 'utf8');
+  });
+  // eslint-disable-next-line no-console
+  console.log(`[manual] wrote ${rendered.toc.length} TOC entries to ${outDirs.length} target(s).`);
+}
+
+buildAll();

--- a/apps/manual/package.json
+++ b/apps/manual/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@perpustakaan/manual",
+  "private": true,
+  "version": "2.0.0-dev",
+  "description": "Generator HTML untuk Buku Manual Perpustakaan Offline (revisi #4)",
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "lint": "echo 'manual: nothing to lint'",
+    "typecheck": "echo 'manual: no typescript'",
+    "test": "echo 'manual: no tests'"
+  }
+}

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -106,7 +106,7 @@ sessions:
   - id: 11
     title: Settings comprehensive 12 kategori + manual book HTML + audit wording final
     status: COMPLETED
-    pr: PENDING
+    pr: https://github.com/alviarts/perpustakaan-offline/pull/48
     completed_at: 2026-05-03
     dependencies: [3, 5, 10]
 
@@ -132,7 +132,7 @@ sessions:
 | 8 | Dashboard modern + charts | COMPLETED | [#45](https://github.com/alviarts/perpustakaan-offline/pull/45) | 2026-05-03 | 4, 5, 6 |
 | 9 | Laporan komplit | COMPLETED | [#46](https://github.com/alviarts/perpustakaan-offline/pull/46) | 2026-05-03 | 6, 7, 8 |
 | 10 | KTA system | COMPLETED | [#47](https://github.com/alviarts/perpustakaan-offline/pull/47) | 2026-05-03 | 4, 5 |
-| 11 | Settings 12 kategori + manual + audit wording | COMPLETED | PENDING | 2026-05-03 | 3, 5, 10 |
+| 11 | Settings 12 kategori + manual + audit wording | COMPLETED | [#48](https://github.com/alviarts/perpustakaan-offline/pull/48) | 2026-05-03 | 3, 5, 10 |
 | 12 | Installer MSI + release v1.0.0 | PENDING | PENDING | — | 2..11 |
 
 ## Update protocol

--- a/docs/migration-v2/PROGRESS.md
+++ b/docs/migration-v2/PROGRESS.md
@@ -21,7 +21,7 @@ project: perpustakaan-offline
 migration: v1 (python+customtkinter) -> v2 (tauri 2.0 + react 18 + ts + tailwind 3 + shadcn + zustand)
 total_sessions: 12
 schema_version: 1
-last_updated: 2026-05-03 (session 10)
+last_updated: 2026-05-03 (session 11)
 ```
 
 ## Sessions
@@ -105,9 +105,9 @@ sessions:
 
   - id: 11
     title: Settings comprehensive 12 kategori + manual book HTML + audit wording final
-    status: PENDING
+    status: COMPLETED
     pr: PENDING
-    completed_at: null
+    completed_at: 2026-05-03
     dependencies: [3, 5, 10]
 
   - id: 12
@@ -132,7 +132,7 @@ sessions:
 | 8 | Dashboard modern + charts | COMPLETED | [#45](https://github.com/alviarts/perpustakaan-offline/pull/45) | 2026-05-03 | 4, 5, 6 |
 | 9 | Laporan komplit | COMPLETED | [#46](https://github.com/alviarts/perpustakaan-offline/pull/46) | 2026-05-03 | 6, 7, 8 |
 | 10 | KTA system | COMPLETED | [#47](https://github.com/alviarts/perpustakaan-offline/pull/47) | 2026-05-03 | 4, 5 |
-| 11 | Settings 12 kategori + manual + audit wording | PENDING | PENDING | — | 3, 5, 10 |
+| 11 | Settings 12 kategori + manual + audit wording | COMPLETED | PENDING | 2026-05-03 | 3, 5, 10 |
 | 12 | Installer MSI + release v1.0.0 | PENDING | PENDING | — | 2..11 |
 
 ## Update protocol

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "pnpm": ">=9.0.0"
   },
   "scripts": {
-    "dev": "pnpm --filter @perpustakaan/desktop dev",
-    "tauri:dev": "pnpm --filter @perpustakaan/desktop tauri dev",
-    "build": "pnpm --filter @perpustakaan/desktop build",
-    "tauri:build": "pnpm --filter @perpustakaan/desktop tauri build",
+    "dev": "pnpm --filter @perpustakaan/manual build && pnpm --filter @perpustakaan/desktop dev",
+    "tauri:dev": "pnpm --filter @perpustakaan/manual build && pnpm --filter @perpustakaan/desktop tauri dev",
+    "build": "pnpm --filter @perpustakaan/manual build && pnpm --filter @perpustakaan/desktop build",
+    "tauri:build": "pnpm --filter @perpustakaan/manual build && pnpm --filter @perpustakaan/desktop tauri build",
+    "manual:build": "pnpm --filter @perpustakaan/manual build",
     "lint": "pnpm -r --parallel lint",
     "typecheck": "pnpm -r --parallel typecheck",
     "test": "pnpm -r --parallel test",
+    "i18n:lint": "node scripts/i18n-lint.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\""
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,8 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(jiti@1.21.7)(jsdom@25.0.1)
 
+  apps/manual: {}
+
   packages/shared:
     devDependencies:
       typescript:

--- a/scripts/i18n-lint.mjs
+++ b/scripts/i18n-lint.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * i18n linter (revisi #25).
+ *
+ * Verifies that:
+ *   1. Every locale (id, en) has the same set of namespaces.
+ *   2. Within each namespace, every leaf key present in `id/<ns>.json` also
+ *      exists in `en/<ns>.json` and vice-versa.
+ *
+ * Exits non-zero on any divergence so CI can gate on it.
+ *
+ * Note: orphan-key detection (key never referenced from source) is intentionally
+ *      out of scope here — TanStack Router auto-generates routes that may use
+ *      keys via `t(...)` with computed names. Adding strict orphan checks
+ *      would produce too many false positives without static analysis. The
+ *      coverage check (id/en parity) is the high-value invariant.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const i18nRoot = resolve(repoRoot, 'apps/desktop/src/i18n');
+const locales = ['id', 'en'];
+
+function leafKeys(obj, prefix = '') {
+  const keys = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const next = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      keys.push(...leafKeys(v, next));
+    } else {
+      keys.push(next);
+    }
+  }
+  return keys.sort();
+}
+
+function loadNamespace(locale, ns) {
+  const path = resolve(i18nRoot, locale, `${ns}.json`);
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function main() {
+  const errors = [];
+  const namespacesPerLocale = new Map();
+  for (const locale of locales) {
+    const dir = resolve(i18nRoot, locale);
+    const files = readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => basename(f, '.json'))
+      .sort();
+    namespacesPerLocale.set(locale, files);
+  }
+
+  const baseLocale = locales[0];
+  const baseNamespaces = namespacesPerLocale.get(baseLocale);
+  for (const other of locales.slice(1)) {
+    const otherNamespaces = namespacesPerLocale.get(other);
+    const missing = baseNamespaces.filter((ns) => !otherNamespaces.includes(ns));
+    const extra = otherNamespaces.filter((ns) => !baseNamespaces.includes(ns));
+    for (const ns of missing) errors.push(`[${other}] missing namespace '${ns}' (present in ${baseLocale})`);
+    for (const ns of extra) errors.push(`[${other}] extra namespace '${ns}' (not in ${baseLocale})`);
+  }
+
+  for (const ns of baseNamespaces) {
+    const tables = {};
+    for (const locale of locales) {
+      if (!namespacesPerLocale.get(locale).includes(ns)) continue;
+      tables[locale] = leafKeys(loadNamespace(locale, ns));
+    }
+    const localeNames = Object.keys(tables);
+    if (localeNames.length < 2) continue;
+    const [a, b] = localeNames;
+    const set = (arr) => new Set(arr);
+    const aSet = set(tables[a]);
+    const bSet = set(tables[b]);
+    for (const k of tables[a]) {
+      if (!bSet.has(k)) errors.push(`[${b}/${ns}] missing key '${k}' (present in ${a})`);
+    }
+    for (const k of tables[b]) {
+      if (!aSet.has(k)) errors.push(`[${a}/${ns}] missing key '${k}' (present in ${b})`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('i18n-lint: found divergences:');
+    for (const err of errors) console.error(`  - ${err}`);
+    console.error(`\n${errors.length} issue(s) found.`);
+    process.exit(1);
+  }
+  console.log('i18n-lint: id ↔ en parity OK across all namespaces.');
+}
+
+main();


### PR DESCRIPTION
## Summary

Session 11/12 — covers revisi #4 (Manual book HTML), #24 (Settings 12 kategori
search/tooltip/reset), #25 (Audit wording final).

### Settings shell (`/settings`)
- Parent layout `apps/desktop/src/features/settings/SettingsLayout.tsx` with
  sidebar nav + global search filter + per-section "Reset Bagian Ini".
- Real-time search uses pure `filterSections()` matching against label,
  summary, and curated keyword list (covered by `settings-search.test.ts`).
- 12 sub-pages, each at `/settings/<id>`:
  1. **Identitas Perpustakaan** — nama, alamat, kepala, NPSN, tahun ajaran,
     kontak, logo path; saves via `identity_save` and broadcasts to
     `useIdentityStore` (revisi #11 cross-cut).
  2. **Aturan Peminjaman** — maks buku per anggota, durasi pinjam, denda per
     hari, hari libur (multi-select chip).
  3. **Master Data** — re-mounts existing Devin 5 page inside Settings shell.
  4. **KTA Template** — re-mounts existing Devin 10 page.
  5. **Tampilan** — theme dropdown (Light/Dark/System), font scale, density
     (comfortable/compact); applies to `<html data-density="…">` + CSS var.
  6. **Bahasa** — ID/EN switcher backed by `useI18nStore`.
  7. **Akun & Pengguna** — table CRUD (admin/pustakawan, aktif toggle, reset
     password) backed by 5 new Tauri commands.
  8. **Hak Akses** — permission matrix (8 areas × 4 actions × 2 roles)
     persisted as JSON in `settings` table.
  9. **Backup & Restore** — embeds existing Devin 9 backup UI.
  10. **Sinkronisasi** — Google Sheets API key + spreadsheet ID + "Sync
      sekarang" button (Tauri stub for now).
  11. **Audit Log** — filterable table (user / action / entity).
  12. **Tentang** — versi, kredit "alvi arts / vwrks", lisensi, "Buka Manual"
      button, link repo GitHub.

### Manual Book (`apps/manual` — revisi #4)
- New workspace package `@perpustakaan/manual` with hand-rolled
  Markdown→HTML generator (`apps/manual/build.mjs`, no external deps).
- Output: `apps/desktop/public/manual/index.html` (67 KB, 88 TOC entries).
- Features: sticky responsive sidebar TOC (collapses <768 px), full-text
  search with match highlighting, light/dark theme toggle persisted to
  `localStorage`, identity-aware header (postMessage hook for
  perpustakaan name).
- New Tauri command `open_manual` opens the manual in a dedicated 960×720
  webview window (with browser fallback for `pnpm dev` / Playwright).
- Header `<BookOpen />` button + Tentang sub-page both call `openManual()`.
- Build wired into root scripts: `pnpm dev`, `pnpm build`, `pnpm tauri:dev`,
  `pnpm tauri:build` all prepend `pnpm --filter @perpustakaan/manual build`.
- Added `apps/desktop/public/manual/` to `.gitignore` since it's generated.

### Tauri backend
- 11 new commands in `apps/desktop/src-tauri/src/commands/settings.rs`:
  `settings_get_many`, `settings_set_many`, `settings_users_list`,
  `settings_users_create`, `settings_users_update`, `settings_users_delete`,
  `settings_users_reset_password`, `settings_permissions_get`,
  `settings_permissions_save`, `settings_audit_log_query`.
- 1 new command `commands::manual::open_manual`.
- All registered in `lib.rs` invoke handler.

### Wording audit (revisi #25)
- "Transaksi" → "Aturan Peminjaman" / "Cash Detail" in user-facing strings:
  - `i18n/id/peminjaman.json`: subtitle "Kelola transaksi peminjaman buku"
    → "Kelola aturan peminjaman buku"
  - `i18n/id/laporan.json` + `i18n/en/laporan.json`: kas.detail
    "Detail Transaksi" / "Transactions" → "Detail Kas" / "Cash Detail"
  - Matching defaultValues in `KasSubPage.tsx`, `PeminjamanList.tsx`
- DB setting keys (`transaksi.maks_buku_pinjam`, etc.) and Rust comments
  about SQL transactions are intentionally left unchanged (internal
  identifiers, not user-facing).

### i18n parity
- New `apps/desktop/src/i18n/{id,en}/settings.json` — 12 sections × labels,
  summaries, fields, helps, success/error messages. Both locales kept in
  exact parity (verified by lint).
- New `scripts/i18n-lint.mjs` + `pnpm i18n:lint` script enforces id ↔ en
  key-set parity across all namespaces.
- Sidebar: removed `pending: true` from Settings nav item.

### Tests
- Unit `tests/unit/i18n-coverage.test.ts` — verifies same namespaces and
  same leaf keys in id and en, plus that all 12 settings sections exist.
- Unit `tests/unit/settings-search.test.ts` — covers empty query, exact
  matches ("denda" → only Aturan Peminjaman, "ddc" → only Master Data,
  "manual" → only Tentang), case insensitivity, ordering, empty result.
- E2E `tests/e2e/settings.spec.ts` — default redirect to identitas, sidebar
  shows 12 sections, search filters, reset confirm dialog, Tentang shows
  credit + manual button.

## Review & Testing Checklist for Human

- [ ] Open the app, log in as admin, click Settings in sidebar — verify it
      lands on Identitas and the 12-item sidebar nav renders.
- [ ] Type "denda" in the Settings search — verify only "Aturan Peminjaman"
      remains in the nav.
- [ ] Open `/settings/aturan-peminjaman`, change denda + hari libur, click
      Simpan — verify toast and that values persist on reload.
- [ ] Click "Buka Manual" in either the Header or Tentang sub-page — verify
      a new window/tab opens with the manual, that the search bar filters
      content, and that the theme toggle persists.
- [ ] Run `pnpm i18n:lint`, `pnpm test`, `pnpm typecheck`, `pnpm lint`
      locally — all should pass.
- [ ] Spot-check that the existing Master Data and KTA pages still render
      correctly inside the new Settings shell (no double-header etc.).

### Notes
Manual book is built from `docs/manual.md` at the start of every dev/build
script — it is never committed to the repo. CI should regenerate it as part
of the build job.

Footer: Devin session 11/12.
