### PR TITLE
ci: drop --bundles arg from tauri:build to fix Windows installer job

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -154,8 +154,8 @@ jobs:
         with:
           workspaces: apps/desktop/src-tauri -> target
 
-      - name: Tauri build (NSIS .exe + MSI)
-        run: pnpm tauri:build -- --bundles nsis,msi
+      - name: Tauri build (uses bundle.targets="all" -> NSIS .exe + MSI on Windows)
+        run: pnpm tauri:build
 
       - name: Upload Windows installer artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

CI hotfix on top of session 12. The `windows-latest` job in `ci-v2.yml`
failed on the `v1.0.0` tag run with:

```
error: unexpected argument '--bundles' found
tip: a similar argument exists: '--benches'
```

The argument was being forwarded past Tauri's CLI parser to `cargo`
(the runner), because `pnpm tauri:build -- --bundles nsis,msi` puts
`--bundles nsis,msi` after Tauri's own `--` separator. Tauri already
ships `bundle.targets: "all"` in `tauri.conf.json`, which on Windows
emits both NSIS `.exe` and MSI by default — so the flag was redundant
to begin with.

Fix: drop the `-- --bundles nsis,msi` and just call `pnpm tauri:build`.

Once this is merged into `main`, I'll re-tag `v1.0.0` (delete the
remote tag, re-tag the new `main` HEAD, force-push the tag) so the
release workflow re-runs.

## Review & Testing Checklist for Human

- [ ] Confirm you're OK with re-tagging `v1.0.0` after this lands. The
      original tag `v1.0.0` has no published release attached (the
      `release-v2` job was skipped because `build-windows-installer`
      failed), so re-tagging is safe and won't clobber anything users
      already downloaded.
- [ ] Once the tag is moved, watch the new
      `build-windows-installer` job — it should now produce NSIS .exe
      and MSI artifacts and pass them to `release-v2`, which will
      publish a fresh GitHub Release at
      `https://github.com/alviarts/perpustakaan-offline/releases/tag/v1.0.0`.

### Notes

- Pure CI change, no source / test / config changes.
- The output of `tauri build --help` confirms `[ARGS]...` after the
  CLI separator are forwarded to the runner (cargo), which is why
  `--bundles` was rejected.
