### PR TITLE
ci: drop id-ID from WiX language list (unsupported by tauri-bundler)

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
     ],
     "windows": {
       "wix": {
-        "language": ["en-US", "id-ID"],
+        "language": ["en-US"],
         "bannerPath": "icons/source/wix-banner.bmp",
         "dialogImagePath": "icons/source/wix-dialog.bmp"
       },


### PR DESCRIPTION
## Summary

Second hotfix on the v1.0.0 release pipeline. After PR #50 fixed the
`--bundles` arg, the MSI bundler reached the WiX `light` step and
panicked with:

```
thread '<unnamed>' panicked at crates/tauri-bundler/src/bundle/windows/msi/mod.rs:810:7:
Language id-ID not found. It must be one of es-ES, th-TH, it-IT,
et-EE, pt-PT, de-DE, hu-HU, sv-SE, lt-LT, sl-SI, pl-PL, en-US,
zh-TW, fi-FI, ja-JP, lv-LV, ro-RO, ru-RU, bg-BG, sk-SK, nl-NL,
uk-UA, zh-CN, ar-SA, da-DK, nb-NO, tr-TR, eu-ES, sr-Latn-CS, ca-ES,
cs-CZ, el-GR, ko-KR, vi-VN, hr-HR, fr-FR, he-IL, pt-BR
```

WiX maintains its own list of installer-locale IDs and Indonesian
isn't on it. Dropping `id-ID` from `bundle.windows.wix.language`
keeps just `en-US`, which is what we want for the wizard chrome.
The application UI itself stays Indonesian (driven by our React
i18n at runtime, not the WiX strings).

After this lands I will move the `v1.0.0` tag to the new HEAD on
`main` so the release pipeline reruns.

## Review & Testing Checklist for Human

- [ ] Confirm you're OK with the installer wizard pages (welcome,
      license, install location, finish) being English-only. The app
      itself remains in Indonesian.
- [ ] After re-tag, verify the new run produces both NSIS .exe and
      MSI artifacts and that `release-v2` publishes them at
      https://github.com/alviarts/perpustakaan-offline/releases/tag/v1.0.0.

### Notes

- Single-line config change. No source / test changes.
- NSIS installer was already English-only (`displayLanguageSelector:
  false`, `languages: ["English"]`), so this just brings WiX in line.
