### PR TITLE
fix(manual): externalize CSS/JS so Buku Manual renders under Tauri 2 prod CSP

### DIFF
--- a/apps/desktop/src-tauri/src/commands/manual.rs
+++ b/apps/desktop/src-tauri/src/commands/manual.rs
@@ -26,6 +26,11 @@ pub fn open_manual(app: AppHandle) -> AppResult<()> {
     .inner_size(960.0, 720.0)
     .min_inner_size(640.0, 480.0)
     .resizable(true)
+    .closable(true)
+    .minimizable(true)
+    .maximizable(true)
+    .decorations(true)
+    .visible(true)
     .build()
     .map_err(|e| AppError::Internal(format!("open_manual: {e}")))?;
     Ok(())

--- a/apps/manual/build.mjs
+++ b/apps/manual/build.mjs
@@ -1,17 +1,23 @@
 /**
  * Manual book HTML generator (revisi #4).
  *
- * Reads the legacy `docs/manual.md`, converts to a self-contained, responsive
- * HTML page with:
+ * Reads the legacy `docs/manual.md`, converts to a responsive HTML page with:
  *   - sticky table of contents (built from h2/h3 headings)
  *   - full-text search (filters TOC + highlights matches)
  *   - light/dark mode toggle
  *   - placeholder hooks for the library identity (`{{LIB_NAMA}}`) injected at
  *     runtime by the frontend before opening the manual
  *
- * Output is written to:
- *   - `apps/desktop/public/manual/index.html`  (served by Vite in dev + bundled
- *     into the Tauri frontend in release)
+ * Output is written as three sibling files so the page renders correctly
+ * under Tauri 2's strict production CSP (which strips `'unsafe-inline'`
+ * for assets it cannot hash at build time):
+ *   - `apps/desktop/public/manual/index.html`
+ *   - `apps/desktop/public/manual/style.css`
+ *   - `apps/desktop/public/manual/app.js`
+ *
+ * Inline `<style>`/`<script>` tags are intentionally avoided — same-origin
+ * external files are allowed by the default `'self'` directives without any
+ * nonce/hash plumbing.
  *
  * Markdown rendering is intentionally hand-rolled (no external deps) so the
  * build runs offline without network access during CI.
@@ -407,7 +413,7 @@ function buildHtml({ html, toc }, { libNama }) {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Buku Manual — Perpustakaan Offline</title>
-  <style>${TEMPLATE_CSS}</style>
+  <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
   <header class="topbar">
@@ -426,7 +432,7 @@ function buildHtml({ html, toc }, { libNama }) {
       ${html}
     </main>
   </div>
-  <script>${TEMPLATE_JS}</script>
+  <script src="./app.js"></script>
 </body>
 </html>
 `;
@@ -440,9 +446,11 @@ function buildAll() {
   outDirs.forEach((dir) => {
     mkdirSync(dir, { recursive: true });
     writeFileSync(resolve(dir, 'index.html'), html, 'utf8');
+    writeFileSync(resolve(dir, 'style.css'), TEMPLATE_CSS.trim() + '\n', 'utf8');
+    writeFileSync(resolve(dir, 'app.js'), TEMPLATE_JS.trim() + '\n', 'utf8');
   });
   // eslint-disable-next-line no-console
-  console.log(`[manual] wrote ${rendered.toc.length} TOC entries to ${outDirs.length} target(s).`);
+  console.log(`[manual] wrote ${rendered.toc.length} TOC entries + style.css + app.js to ${outDirs.length} target(s).`);
 }
 
 buildAll();


### PR DESCRIPTION
## Summary

Fixes a Windows-only regression discovered during manual install testing of `v1.0.0`: opening **Settings → Tentang → Buku Manual** produced a blank webview window with no interactive elements, and the X button on the manual window did not respond.

### Root cause

`apps/desktop/public/manual/index.html` (generated by `apps/manual/build.mjs`) embedded its CSS via an inline `<style>` block and its theme / search / TOC logic via an inline `<script>` block.

Tauri 2's production CSP rewriter computes hashes/nonces for the main entry HTML that Vite processes (`apps/desktop/index.html`), but **not** for static files in `public/` (which are copied verbatim). Per CSP spec, the presence of any nonce in the runtime CSP causes browsers (including Windows WebView2) to ignore `'unsafe-inline'`, so the manual page's inline script and style were silently blocked at load. With the script blocked the page stalled at load (no theme bootstrap, no event wiring), which on Windows WebView2 also prevented the close button events from being processed.

References:
- Tauri 2 CSP docs: https://tauri.app/security/csp
- Related upstream issue: https://github.com/tauri-apps/tauri/issues/8476

### Fix

1. `apps/manual/build.mjs` now writes three sibling files instead of a single self-contained HTML:
   - `apps/desktop/public/manual/index.html`
   - `apps/desktop/public/manual/style.css`
   - `apps/desktop/public/manual/app.js`

   The HTML references them with `<link rel="stylesheet" href="./style.css">` and `<script src="./app.js"></script>`. Same-origin external assets are allowed by the existing `default-src 'self'` directive without any hash/nonce plumbing, so the page renders identically in dev and production.

2. `apps/desktop/src-tauri/src/commands/manual.rs` now sets `closable`, `minimizable`, `maximizable`, `decorations`, and `visible` explicitly on the `WebviewWindowBuilder`. These match Tauri's own documented defaults, but pinning them defensively rules out any Windows-specific platform default that could otherwise leave the window non-closable if a future regression slips in.

No functional or visual change to the manual itself — the markdown source, TOC structure, theme toggle, and search behavior are all unchanged. The build pipeline runs `pnpm --filter @perpustakaan/manual build` before `tauri build` (root `tauri:build` script), so the new `style.css` / `app.js` are bundled into the Windows installer without any further config.

## Review & Testing Checklist for Human

- [ ] Pull this branch, run `pnpm install && pnpm tauri:build`, install the resulting MSI/NSIS on Windows.
- [ ] Open the app, log in (`admin` / `admin123`), Settings → Tentang → click **Buku Manual**.
- [ ] Confirm the manual window now renders with full styling (sidebar TOC, search box, Light/Dark toggle button, formatted content).
- [ ] Confirm the **X button on the manual window closes it** without forcing it via Task Manager.
- [ ] Confirm theme toggle and search filtering inside the manual still work.
- [ ] Spot-check the main app's flows (login → dashboard → anggota → buku) to confirm no regression — should be impossible since only `manual.rs` and `build.mjs` changed, but worth a sanity pass.

### Notes

- `apps/desktop/public/manual/` is gitignored (regenerated on every build by `pnpm --filter @perpustakaan/manual build`), so no diff appears for the generated `index.html` / `style.css` / `app.js` — only the build script and the Tauri command. CI / release pipeline regenerates them on every build.
- Verified locally on Linux: `pnpm lint`, `pnpm typecheck`, `pnpm test` (129 tests), and `pnpm i18n:lint` all pass on this branch. Strict-CSP behavior was reproduced in Chrome with a `<meta http-equiv="Content-Security-Policy">` injection that mirrors Tauri's runtime CSP — the inline-style version went near-blank, the externalized version rendered fully styled.