### PR TITLE
fix(errors): add formatTauriError helper + sweep call sites (BUG-002)

### DIFF
--- a/apps/desktop/src/features/anggota/AnggotaList.tsx
+++ b/apps/desktop/src/features/anggota/AnggotaList.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight, CreditCard, FileSpreadsheet, Plus, Search } 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { formatTauriError } from '@/lib/errors';
 import {
   Select,
   SelectContent,
@@ -88,7 +89,7 @@ export function AnggotaList({ search, onSearchChange }: AnggotaListProps) {
       showToast({
         variant: 'destructive',
         title: t('anggota:feedback.loadError'),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setIsLoading(false);

--- a/apps/desktop/src/features/anggota/ImportExcelDialog.tsx
+++ b/apps/desktop/src/features/anggota/ImportExcelDialog.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { read, utils, type WorkBook } from 'xlsx';
 import { Button } from '@/components/ui/button';
+import { formatTauriError } from '@/lib/errors';
 import {
   Dialog,
   DialogContent,
@@ -111,7 +112,7 @@ export function ImportExcelDialog({ open, onOpenChange, onImported }: ImportExce
       setFilename(file.name);
       setRows(parsed);
     } catch (err) {
-      setParseError(err instanceof Error ? err.message : String(err));
+      setParseError(formatTauriError(err));
       setRows([]);
     }
   };
@@ -135,7 +136,7 @@ export function ImportExcelDialog({ open, onOpenChange, onImported }: ImportExce
       showToast({
         variant: 'destructive',
         title: t('anggota:feedback.importSuccess', { inserted: 0 }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setBusy(false);

--- a/apps/desktop/src/features/buku/BukuList.tsx
+++ b/apps/desktop/src/features/buku/BukuList.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useSearch } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
+import { formatTauriError } from '@/lib/errors';
 import {
   BookOpenText,
   ChevronLeft,
@@ -93,7 +94,7 @@ export function BukuList({ search, onSearchChange }: BukuListProps) {
       showToast({
         variant: 'destructive',
         title: t('buku:feedback.loadError'),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setIsLoading(false);
@@ -131,7 +132,7 @@ export function BukuList({ search, onSearchChange }: BukuListProps) {
         showToast({
           variant: 'destructive',
           title: t('buku:feedback.loadError'),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
         setDetail(null);
       })

--- a/apps/desktop/src/features/buku/ImportBukuDialog.tsx
+++ b/apps/desktop/src/features/buku/ImportBukuDialog.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { read, utils, type WorkBook } from 'xlsx';
 import { Button } from '@/components/ui/button';
+import { formatTauriError } from '@/lib/errors';
 import {
   Dialog,
   DialogContent,
@@ -110,7 +111,7 @@ export function ImportBukuDialog({ open, onOpenChange, onImported }: ImportBukuD
       setFilename(file.name);
       setRows(parsed);
     } catch (err) {
-      setParseError(err instanceof Error ? err.message : String(err));
+      setParseError(formatTauriError(err));
       setRows([]);
     }
   };
@@ -134,7 +135,7 @@ export function ImportBukuDialog({ open, onOpenChange, onImported }: ImportBukuD
       showToast({
         variant: 'destructive',
         title: t('buku:feedback.importSuccess', { inserted: 0 }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setBusy(false);

--- a/apps/desktop/src/features/dashboard/DashboardPage.tsx
+++ b/apps/desktop/src/features/dashboard/DashboardPage.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { KpiCard } from '@/components/shared/KpiCard';
 import { ChartPie } from '@/components/shared/ChartPie';
 import { ChartBar } from '@/components/shared/ChartBar';
+import { formatTauriError } from '@/lib/errors';
 import {
   dashboardApi,
   type DashboardKpi,
@@ -56,7 +57,7 @@ export function DashboardPage() {
       })
       .catch((err) => {
         if (cancel) return;
-        setError(err instanceof Error ? err.message : String(err));
+        setError(formatTauriError(err));
       })
       .finally(() => {
         if (!cancel) setLoading(false);

--- a/apps/desktop/src/features/kunjungan/KunjunganDialog.tsx
+++ b/apps/desktop/src/features/kunjungan/KunjunganDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
+import { formatTauriError } from '@/lib/errors';
 import {
   Dialog,
   DialogContent,
@@ -82,7 +83,7 @@ export function KunjunganDialog({ open, onOpenChange, onCreated }: KunjunganDial
       onCreated?.();
       onOpenChange(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatTauriError(err));
     } finally {
       setSubmitting(false);
     }

--- a/apps/desktop/src/features/kunjungan/KunjunganPage.tsx
+++ b/apps/desktop/src/features/kunjungan/KunjunganPage.tsx
@@ -12,6 +12,7 @@ import { kunjunganApi, rangeForPreset, type KunjunganRow } from '@/lib/kunjungan
 import { KunjunganBackdrop } from './KunjunganBackdrop';
 import { KunjunganQuickStatsBar } from './QuickStats';
 import { KunjunganDialog } from './KunjunganDialog';
+import { formatTauriError } from '@/lib/errors';
 
 const SUMBER_TONE: Record<KunjunganRow['sumber'], string> = {
   manual: 'bg-primary/10 text-primary',
@@ -51,7 +52,7 @@ export function KunjunganPage() {
         showToast({
           variant: 'destructive',
           title: t('kunjungan:feedback.loadError', { defaultValue: 'Gagal memuat kunjungan' }),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
       })
       .finally(() => {
@@ -73,7 +74,7 @@ export function KunjunganPage() {
       showToast({
         variant: 'destructive',
         title: t('kunjungan:feedback.deleteError', { defaultValue: 'Gagal menghapus kunjungan' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     }
   }

--- a/apps/desktop/src/features/laporan/BackupSubPage.tsx
+++ b/apps/desktop/src/features/laporan/BackupSubPage.tsx
@@ -11,6 +11,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/toast-manager';
 import { isTauri } from '@/lib/auth';
 import { describeCron, laporanApi, type BackupResult, type BackupSchedule } from '@/lib/laporan';
+import { formatTauriError } from '@/lib/errors';
 
 export function LaporanBackup() {
   const { t } = useTranslation(['laporan']);
@@ -64,7 +65,7 @@ export function LaporanBackup() {
       showToast({
         variant: 'destructive',
         title: t('laporan:backup.failed', { defaultValue: 'Backup gagal' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setBusy(false);
@@ -99,7 +100,7 @@ export function LaporanBackup() {
       showToast({
         variant: 'destructive',
         title: t('laporan:backup.restoreFailed', { defaultValue: 'Restore gagal' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setBusy(false);
@@ -119,7 +120,7 @@ export function LaporanBackup() {
       showToast({
         variant: 'destructive',
         title: t('laporan:backup.scheduleFailed', { defaultValue: 'Gagal menyimpan jadwal' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setSaving(false);

--- a/apps/desktop/src/features/laporan/GrafikSubPage.tsx
+++ b/apps/desktop/src/features/laporan/GrafikSubPage.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@/components/ui/toast-manager';
 import { laporanApi, toCsv, type GrafikBucket, type Granularity } from '@/lib/laporan';
 import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
 import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+import { formatTauriError } from '@/lib/errors';
 
 export function LaporanGrafik() {
   const { t } = useTranslation(['laporan']);
@@ -30,7 +31,7 @@ export function LaporanGrafik() {
         showToast({
           variant: 'destructive',
           title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
       })
       .finally(() => {

--- a/apps/desktop/src/features/laporan/KasSubPage.tsx
+++ b/apps/desktop/src/features/laporan/KasSubPage.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/components/ui/toast-manager';
 import { laporanApi, toCsv, type KasSummary } from '@/lib/laporan';
 import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
 import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+import { formatTauriError } from '@/lib/errors';
 
 const RUPIAH = new Intl.NumberFormat('id-ID', {
   style: 'currency',
@@ -34,7 +35,7 @@ export function LaporanKas() {
         showToast({
           variant: 'destructive',
           title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
       })
       .finally(() => {

--- a/apps/desktop/src/features/laporan/TopBukuSubPage.tsx
+++ b/apps/desktop/src/features/laporan/TopBukuSubPage.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/components/ui/toast-manager';
 import { laporanApi, toCsv, type TopBukuRow } from '@/lib/laporan';
 import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
 import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+import { formatTauriError } from '@/lib/errors';
 
 export function LaporanTopBuku() {
   const { t } = useTranslation(['laporan']);
@@ -28,7 +29,7 @@ export function LaporanTopBuku() {
         showToast({
           variant: 'destructive',
           title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
       })
       .finally(() => {

--- a/apps/desktop/src/features/laporan/TopPeminjamSubPage.tsx
+++ b/apps/desktop/src/features/laporan/TopPeminjamSubPage.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/components/ui/toast-manager';
 import { laporanApi, toCsv, type TopPeminjamRow } from '@/lib/laporan';
 import { presetRangeMonth, RangeToolbar } from './RangeToolbar';
 import { buildLaporanPdfHtml, downloadText, printHtml } from './utils';
+import { formatTauriError } from '@/lib/errors';
 
 export function LaporanTopPeminjam() {
   const { t } = useTranslation(['laporan']);
@@ -28,7 +29,7 @@ export function LaporanTopPeminjam() {
         showToast({
           variant: 'destructive',
           title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
       })
       .finally(() => {

--- a/apps/desktop/src/features/master-data/MasterDataPage.tsx
+++ b/apps/desktop/src/features/master-data/MasterDataPage.tsx
@@ -4,6 +4,7 @@ import { Pencil, Plus, Search, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { formatTauriError } from '@/lib/errors';
 import {
   Dialog,
   DialogContent,
@@ -57,7 +58,7 @@ export function MasterDataPage() {
       showToast({
         variant: 'destructive',
         title: t('masterData:feedback.loadError'),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setIsLoading(false);
@@ -219,7 +220,7 @@ export function MasterDataPage() {
             showToast({
               variant: 'destructive',
               title: t('masterData:feedback.deleteError'),
-              description: err instanceof Error ? err.message : String(err),
+              description: formatTauriError(err),
             });
           }
         }}
@@ -296,7 +297,7 @@ function MasterEditDialog({
       showToast({
         variant: 'destructive',
         title: item ? t('masterData:feedback.updateError') : t('masterData:feedback.createError'),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setBusy(false);

--- a/apps/desktop/src/features/peminjaman/PeminjamanDetail.tsx
+++ b/apps/desktop/src/features/peminjaman/PeminjamanDetail.tsx
@@ -10,6 +10,7 @@ import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { useToast } from '@/components/ui/toast-manager';
 import { peminjamanApi, type PeminjamanDetail as Detail } from '@/lib/peminjaman';
 import { generateNotaPdf } from '@/lib/pdf/nota';
+import { formatTauriError } from '@/lib/errors';
 
 export function PeminjamanDetailView() {
   const { t } = useTranslation(['peminjaman', 'common']);
@@ -33,7 +34,7 @@ export function PeminjamanDetailView() {
       showToast({
         variant: 'destructive',
         title: t('peminjaman:feedback.loadError', { defaultValue: 'Gagal memuat detail' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     }
   }
@@ -79,7 +80,7 @@ export function PeminjamanDetailView() {
       showToast({
         variant: 'destructive',
         title: t('peminjaman:feedback.returnError', { defaultValue: 'Gagal mengembalikan' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setSubmitting(false);
@@ -101,7 +102,7 @@ export function PeminjamanDetailView() {
       showToast({
         variant: 'destructive',
         title: t('peminjaman:feedback.printError', { defaultValue: 'Gagal mencetak nota' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     }
   }

--- a/apps/desktop/src/features/peminjaman/PeminjamanForm.tsx
+++ b/apps/desktop/src/features/peminjaman/PeminjamanForm.tsx
@@ -10,6 +10,7 @@ import { DatePicker } from '@/components/ui/date-picker';
 import { useToast } from '@/components/ui/toast-manager';
 import { anggotaApi, type Anggota } from '@/lib/anggota';
 import { bukuApi, type Buku } from '@/lib/buku';
+import { formatTauriError } from '@/lib/errors';
 import {
   peminjamanApi,
   type AnggotaSummary,
@@ -159,7 +160,7 @@ export function PeminjamanForm() {
       showToast({
         variant: 'destructive',
         title: t('peminjaman:feedback.createError', { defaultValue: 'Gagal membuat peminjaman' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setSubmitting(false);

--- a/apps/desktop/src/features/peminjaman/PeminjamanList.tsx
+++ b/apps/desktop/src/features/peminjaman/PeminjamanList.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight, Plus, Search } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { formatTauriError } from '@/lib/errors';
 import {
   Select,
   SelectContent,
@@ -58,7 +59,7 @@ export function PeminjamanList() {
       showToast({
         variant: 'destructive',
         title: t('peminjaman:feedback.loadError', { defaultValue: 'Gagal memuat peminjaman' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setLoading(false);

--- a/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
+++ b/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
@@ -8,6 +8,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 import { useToast } from '@/components/ui/toast-manager';
 import { calculateDenda, peminjamanApi, type PeminjamanDetail, type PeminjamanRow } from '@/lib/peminjaman';
+import { formatTauriError } from '@/lib/errors';
 
 const DENDA_PER_HARI = 500;
 
@@ -66,7 +67,7 @@ export function PengembalianPage() {
         showToast({
           variant: 'destructive',
           title: t('peminjaman:feedback.loadError', { defaultValue: 'Gagal memuat detail' }),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
       });
     return () => {
@@ -112,7 +113,7 @@ export function PengembalianPage() {
       showToast({
         variant: 'destructive',
         title: t('peminjaman:feedback.returnError', { defaultValue: 'Gagal mengembalikan' }),
-        description: err instanceof Error ? err.message : String(err),
+        description: formatTauriError(err),
       });
     } finally {
       setSubmitting(false);

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Tauri command error formatter.
+ *
+ * Tauri's `invoke()` rejects with whatever the Rust side returned via
+ * `serde_json`, NOT with an `Error` instance. Our backend returns
+ * `AppError` which serializes as an externally-tagged enum object such as
+ * `{ "Validation": "tidak ada eksemplar tersedia ..." }`. The naive fallback
+ * `String(err)` on that object yields the literal string `"[object Object]"`,
+ * which is what users were seeing in toasts (BUG-002).
+ *
+ * `formatTauriError` extracts the human-readable message from the known
+ * variants while still gracefully handling plain `Error` instances and
+ * strings (used by frontend-only paths like the import dialogs).
+ */
+
+const APP_ERROR_KEYS = ['Validation', 'NotFound', 'Conflict', 'Internal'] as const;
+
+export type AppErrorKey = (typeof APP_ERROR_KEYS)[number];
+
+export type TauriAppError = { [K in AppErrorKey]?: string };
+
+export function formatTauriError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object') {
+    const record = err as Record<string, unknown>;
+    for (const key of APP_ERROR_KEYS) {
+      const v = record[key];
+      if (typeof v === 'string') return v;
+    }
+    // Fall back to JSON serialization so at least the user sees the shape
+    // instead of `[object Object]`.
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}

--- a/apps/desktop/src/routes/_authed/anggota/$id.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/$id.tsx
@@ -8,6 +8,7 @@ import { AnggotaForm } from '@/features/anggota/AnggotaForm';
 import { anggotaApi, type Anggota } from '@/lib/anggota';
 import { toAnggotaInput } from '@/features/anggota/schema';
 import { useToast } from '@/components/ui/toast-manager';
+import { formatTauriError } from '@/lib/errors';
 
 export const Route = createFileRoute('/_authed/anggota/$id')({
   component: EditAnggotaRoute,
@@ -48,7 +49,7 @@ function EditAnggotaRoute() {
         showToast({
           variant: 'destructive',
           title: t('anggota:feedback.loadError'),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
         void navigate({ to: '/anggota' });
       })
@@ -96,7 +97,7 @@ function EditAnggotaRoute() {
               showToast({
                 variant: 'destructive',
                 title: t('anggota:feedback.updateError', {
-                  message: err instanceof Error ? err.message : String(err),
+                  message: formatTauriError(err),
                 }),
               });
             }
@@ -120,7 +121,7 @@ function EditAnggotaRoute() {
             showToast({
               variant: 'destructive',
               title: t('anggota:feedback.deleteError', {
-                message: err instanceof Error ? err.message : String(err),
+                message: formatTauriError(err),
               }),
             });
           }

--- a/apps/desktop/src/routes/_authed/anggota/new.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/new.tsx
@@ -7,6 +7,7 @@ import { AnggotaForm } from '@/features/anggota/AnggotaForm';
 import { anggotaApi } from '@/lib/anggota';
 import { toAnggotaInput } from '@/features/anggota/schema';
 import { useToast } from '@/components/ui/toast-manager';
+import { formatTauriError } from '@/lib/errors';
 
 export const Route = createFileRoute('/_authed/anggota/new')({
   component: NewAnggotaRoute,
@@ -59,7 +60,7 @@ function NewAnggotaRoute() {
             showToast({
               variant: 'destructive',
               title: t('anggota:feedback.createError', {
-                message: err instanceof Error ? err.message : String(err),
+                message: formatTauriError(err),
               }),
             });
           }

--- a/apps/desktop/src/routes/_authed/buku/$id.tsx
+++ b/apps/desktop/src/routes/_authed/buku/$id.tsx
@@ -9,6 +9,7 @@ import { bukuApi, type Buku } from '@/lib/buku';
 import { masterDataApi, type MasterItem } from '@/lib/masterData';
 import { toBukuInput } from '@/features/buku/schema';
 import { useToast } from '@/components/ui/toast-manager';
+import { formatTauriError } from '@/lib/errors';
 
 export const Route = createFileRoute('/_authed/buku/$id')({
   component: EditBukuRoute,
@@ -49,7 +50,7 @@ function EditBukuRoute() {
         showToast({
           variant: 'destructive',
           title: t('buku:feedback.loadError'),
-          description: err instanceof Error ? err.message : String(err),
+          description: formatTauriError(err),
         });
         void navigate({ to: '/buku' });
       })
@@ -98,7 +99,7 @@ function EditBukuRoute() {
                 showToast({
                   variant: 'destructive',
                   title: t('buku:feedback.updateError', {
-                    message: err instanceof Error ? err.message : String(err),
+                    message: formatTauriError(err),
                   }),
                 });
               }
@@ -123,7 +124,7 @@ function EditBukuRoute() {
             showToast({
               variant: 'destructive',
               title: t('buku:feedback.deleteError'),
-              description: err instanceof Error ? err.message : String(err),
+              description: formatTauriError(err),
             });
           }
         }}

--- a/apps/desktop/src/routes/_authed/buku/new.tsx
+++ b/apps/desktop/src/routes/_authed/buku/new.tsx
@@ -8,6 +8,7 @@ import { bukuApi } from '@/lib/buku';
 import { masterDataApi, type MasterItem } from '@/lib/masterData';
 import { toBukuInput } from '@/features/buku/schema';
 import { useToast } from '@/components/ui/toast-manager';
+import { formatTauriError } from '@/lib/errors';
 
 export const Route = createFileRoute('/_authed/buku/new')({
   component: NewBukuRoute,
@@ -60,7 +61,7 @@ function NewBukuRoute() {
             showToast({
               variant: 'destructive',
               title: t('buku:feedback.createError', {
-                message: err instanceof Error ? err.message : String(err),
+                message: formatTauriError(err),
               }),
             });
           }

--- a/apps/desktop/tests/unit/errors.test.ts
+++ b/apps/desktop/tests/unit/errors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { formatTauriError } from '@/lib/errors';
+
+describe('formatTauriError', () => {
+  it('extracts the message from AppError::Validation', () => {
+    expect(formatTauriError({ Validation: 'kode_buku required' })).toBe(
+      'kode_buku required',
+    );
+  });
+
+  it('extracts the message from AppError::NotFound', () => {
+    expect(formatTauriError({ NotFound: 'buku id=42' })).toBe('buku id=42');
+  });
+
+  it('extracts the message from AppError::Conflict', () => {
+    expect(formatTauriError({ Conflict: 'kode_buku sudah dipakai' })).toBe(
+      'kode_buku sudah dipakai',
+    );
+  });
+
+  it('extracts the message from AppError::Internal', () => {
+    expect(formatTauriError({ Internal: 'db locked' })).toBe('db locked');
+  });
+
+  it('passes through Error instances', () => {
+    expect(formatTauriError(new Error('boom'))).toBe('boom');
+  });
+
+  it('passes through plain strings', () => {
+    expect(formatTauriError('upload failed')).toBe('upload failed');
+  });
+
+  it('falls back to JSON.stringify for unknown object shapes', () => {
+    expect(formatTauriError({ foo: 'bar' })).toBe('{"foo":"bar"}');
+  });
+
+  it('handles null and undefined gracefully', () => {
+    expect(formatTauriError(null)).toBe('null');
+    expect(formatTauriError(undefined)).toBe('undefined');
+  });
+
+  it('handles numeric and boolean primitives', () => {
+    expect(formatTauriError(42)).toBe('42');
+    expect(formatTauriError(false)).toBe('false');
+  });
+
+  it('never returns "[object Object]" for AppError-shaped objects', () => {
+    // Regression guard for BUG-002: the toast description was rendering
+    // "[object Object]" because String({ Validation: '...' }) === '[object Object]'.
+    expect(formatTauriError({ Validation: 'x' })).not.toBe('[object Object]');
+  });
+
+  it('prioritises Validation over Internal when both are set', () => {
+    // Defensive: if the backend ever serialises into a multi-key shape, we
+    // still surface the user-actionable message rather than the internal one.
+    const v = formatTauriError({ Validation: 'expected', Internal: 'leak' });
+    expect(v).toBe('expected');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [`BUG-002`](https://github.com/alviarts/perpustakaan-offline/blob/devin/1777840131-bugs-backlog/docs/bugs/POST_V1_BUGS.md#bug-002--peminjaman-error-toast-renders-object-object) — every backend error toast was rendering `[object Object]` instead of the actual Rust validation message.

### Root cause

Tauri's `invoke()` rejects with whatever the Rust side returned via `serde_json`, **not** with an `Error` instance. Our backend returns `AppError` which serialises as an externally-tagged enum object such as `{ "Validation": "tidak ada eksemplar tersedia ..." }`. The frontend's repeated fallback `description: err instanceof Error ? err.message : String(err)` falls into the `String(err)` branch on those objects, and `String({ Validation: '...' })` returns the literal `"[object Object]"`.

### Fix

- **New** `apps/desktop/src/lib/errors.ts` exporting `formatTauriError(err: unknown): string` that:
  - Returns `err.message` for `Error` instances (preserves the existing fallback for fetch/parse failures inside the import dialogs).
  - Returns the string itself for plain string errors.
  - Iterates over the known `AppError` keys (`Validation`, `NotFound`, `Conflict`, `Internal`) and returns the first matching `string` value.
  - Falls back to `JSON.stringify(err)` so the user at least sees the shape instead of `"[object Object]"` for unknown object errors.
- Sweeps **21 call sites** across `apps/desktop/src/features/**` and `apps/desktop/src/routes/_authed/**`, replacing every `err instanceof Error ? err.message : String(err)` with `formatTauriError(err)` and adding the import.

### Files changed

- New: `apps/desktop/src/lib/errors.ts`
- New: `apps/desktop/tests/unit/errors.test.ts`
- Modified (21 files): toast/error-display call sites in features and routes (anggota, buku, peminjaman, pengembalian, kunjungan, laporan/*, master-data, dashboard).

### Definition-of-done checklist (from POST_V1_BUGS.md BUG-002)

- [x] Helper added with unit tests in `apps/desktop/tests/unit/`. (11 tests covering all four `AppError` variants, `Error`/string passthrough, primitive fallback, null/undefined, regression guard against `"[object Object]"`, and priority ordering.)
- [x] All `String(err)` and `err instanceof Error ? err.message : String(err)` patterns inside `apps/desktop/src/features/**` and `apps/desktop/src/routes/**` replaced with the helper. (`grep` after sweep returns zero hits.)
- [ ] Manual repro: trigger a peminjaman validation error → toast description shows the actual Rust message, not `[object Object]`. (Verifiable by reviewer; needs Tauri prod build.)

## Review & Testing Checklist for Human

Risk: yellow — wide sweep across 21 files but each replacement is mechanical and CI passes.

- [ ] Pull this branch, run `pnpm install && pnpm --filter @perpustakaan/desktop build && pnpm tauri:dev`, log in as `admin` / `admin123`.
- [ ] Trigger a known backend validation error (e.g. Buku → Tambah Buku → save with empty `kode_buku`, or Peminjaman → Pinjam Baru without an available eksemplar). Confirm the toast description shows the actual Rust message instead of `[object Object]`.
- [ ] Trigger a frontend-only error (e.g. ImportBukuDialog parser error on a malformed Excel file). Confirm the parse error is still surfaced unchanged.

### Notes

- 11 new unit tests pass: `cd apps/desktop && pnpm exec vitest run errors.test.ts`. Full suite: 18 files, 140 tests, all green.
- `pnpm lint && typecheck && i18n:lint && test` all green.
- Did NOT touch `setError(err instanceof Error ...)` patterns inside `KunjunganDialog` and the import dialogs — those expect a `string` for inline form messages, and `formatTauriError` returns a string, so they were swept too. Same applies to the message-property fallbacks in route files (`message: ...`).
- This unblocks the toast portion of BUG-001 verification: once the eksemplar seed PR (#55) is merged, the `tidak ada eksemplar tersedia` message it would have surfaced will now actually render in the toast for any future borrow-without-stock case.
