### PR TITLE
fix(anggota): source Kelas/Jurusan/Agama dropdowns from master + distinct merge (BUG-003)

### DIFF
--- a/apps/desktop/src/lib/anggota.ts
+++ b/apps/desktop/src/lib/anggota.ts
@@ -1,4 +1,54 @@
 import { isTauri } from '@/lib/auth';
+import { masterDataApi, type MasterTable } from '@/lib/masterData';
+
+export interface AnggotaFormOptions {
+  kelas: string[];
+  jurusan: string[];
+  agama: string[];
+}
+
+/**
+ * Merge a master-data list with free-text distinct values into a stable,
+ * deduplicated, alphabetically-sorted string array.
+ */
+function mergeOptionSources(master: string[], distinct: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const list of [master, distinct]) {
+    for (const v of list) {
+      if (typeof v !== 'string') continue;
+      const trimmed = v.trim();
+      if (!trimmed || seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      out.push(trimmed);
+    }
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+async function loadFieldOptions(
+  field: 'kelas' | 'jurusan' | 'agama',
+  table: MasterTable,
+): Promise<string[]> {
+  // The two RPCs are independent: a failure in one shouldn't kill the other.
+  const [masterRes, distinctRes] = await Promise.allSettled([
+    masterDataApi.list(table),
+    rpc().distinct(field),
+  ]);
+  const master =
+    masterRes.status === 'fulfilled' ? masterRes.value.map((m) => m.nama) : [];
+  const distinct = distinctRes.status === 'fulfilled' ? distinctRes.value : [];
+  return mergeOptionSources(master, distinct);
+}
+
+async function loadAnggotaFormOptions(): Promise<AnggotaFormOptions> {
+  const [kelas, jurusan, agama] = await Promise.all([
+    loadFieldOptions('kelas', 'kelas'),
+    loadFieldOptions('jurusan', 'jurusan'),
+    loadFieldOptions('agama', 'agama'),
+  ]);
+  return { kelas, jurusan, agama };
+}
 
 export interface Anggota {
   id: number;
@@ -404,6 +454,17 @@ export const anggotaApi = {
   importBatch: (items: AnggotaImportItem[]) => rpc().importBatch(items),
   distinct: (field: 'kelas' | 'jurusan' | 'agama') => rpc().distinct(field),
   kelasList: () => rpc().kelasList(),
+  /**
+   * Load Kelas / Jurusan / Agama options for the Tambah/Edit Anggota form.
+   *
+   * Source of truth is the master-data table (`master_list({ kind })`), so a
+   * fresh DB exposes the seeded entries (BUG-003). Free-text values stored on
+   * existing anggota rows are merged on top via `anggota_distinct(field)` so
+   * pre-master legacy data isn't dropped from the dropdowns. Each of the
+   * three fetches is independent: a master-data outage doesn't kill the
+   * distinct fallback, and vice versa.
+   */
+  loadFormOptions: () => loadAnggotaFormOptions(),
   // Test-only helper: reset the in-memory mock store. No-op in Tauri builds.
   __resetMock(): void {
     if (typeof window !== 'undefined' && !isTauri()) {

--- a/apps/desktop/src/routes/_authed/anggota/$id.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/$id.tsx
@@ -30,18 +30,13 @@ function EditAnggotaRoute() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    Promise.all([
-      anggotaApi.get(id),
-      anggotaApi.distinct('kelas'),
-      anggotaApi.distinct('jurusan'),
-      anggotaApi.distinct('agama'),
-    ])
-      .then(([fetched, k, j, a]) => {
+    Promise.all([anggotaApi.get(id), anggotaApi.loadFormOptions()])
+      .then(([fetched, options]) => {
         if (cancelled) return;
         setItem(fetched);
-        setKelas(k);
-        setJurusan(j);
-        setAgama(a);
+        setKelas(options.kelas);
+        setJurusan(options.jurusan);
+        setAgama(options.agama);
       })
       .catch((err) => {
         if (cancelled) return;

--- a/apps/desktop/src/routes/_authed/anggota/new.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/new.tsx
@@ -21,11 +21,14 @@ function NewAnggotaRoute() {
   const [agama, setAgama] = useState<string[]>([]);
 
   useEffect(() => {
-    void Promise.all([
-      anggotaApi.distinct('kelas').then(setKelas).catch(() => undefined),
-      anggotaApi.distinct('jurusan').then(setJurusan).catch(() => undefined),
-      anggotaApi.distinct('agama').then(setAgama).catch(() => undefined),
-    ]);
+    void anggotaApi
+      .loadFormOptions()
+      .then(({ kelas: k, jurusan: j, agama: a }) => {
+        setKelas(k);
+        setJurusan(j);
+        setAgama(a);
+      })
+      .catch(() => undefined);
   }, []);
 
   return (

--- a/apps/desktop/tests/unit/anggotaApi.test.ts
+++ b/apps/desktop/tests/unit/anggotaApi.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { anggotaApi } from '@/lib/anggota';
+import { masterDataApi } from '@/lib/masterData';
 
 describe('anggotaApi (browser mock)', () => {
   beforeEach(() => {
@@ -62,5 +63,82 @@ describe('anggotaApi (browser mock)', () => {
     ]);
     expect(result.inserted).toBe(1);
     expect(result.errors.length + result.skipped).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('anggotaApi.loadFormOptions (BUG-003)', () => {
+  beforeEach(() => {
+    anggotaApi.__resetMock();
+    masterDataApi.__resetMock();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    anggotaApi.__resetMock();
+    masterDataApi.__resetMock();
+  });
+
+  it('exposes the seeded master kelas list on a fresh DB', async () => {
+    // Fresh anggota mock has no rows, so anggota_distinct returns []. The
+    // dropdown must still show the master-seeded kelas.
+    anggotaApi.__resetMock();
+    const opts = await anggotaApi.loadFormOptions();
+    expect(opts.kelas.length).toBeGreaterThan(0);
+    expect(opts.kelas).toContain('7A');
+  });
+
+  it('exposes the seeded master jurusan list on a fresh DB', async () => {
+    anggotaApi.__resetMock();
+    const opts = await anggotaApi.loadFormOptions();
+    expect(opts.jurusan).toEqual(
+      expect.arrayContaining(['IPA', 'IPS', 'Bahasa']),
+    );
+  });
+
+  it('exposes the seeded master agama list on a fresh DB', async () => {
+    anggotaApi.__resetMock();
+    const opts = await anggotaApi.loadFormOptions();
+    expect(opts.agama).toEqual(
+      expect.arrayContaining(['Islam', 'Kristen', 'Katolik', 'Hindu', 'Buddha']),
+    );
+  });
+
+  it('merges existing free-text values from anggota_distinct on top of master', async () => {
+    // Simulate a user who already saved an anggota with a custom non-master
+    // kelas; that value must still appear in the dropdown.
+    await anggotaApi.create({
+      kodeAnggota: 'BUG3-1',
+      nama: 'Legacy Member',
+      kelas: 'Z9-CUSTOM',
+      jurusan: 'CUSTOM-JUR',
+    });
+    const opts = await anggotaApi.loadFormOptions();
+    expect(opts.kelas).toContain('Z9-CUSTOM');
+    expect(opts.jurusan).toContain('CUSTOM-JUR');
+    // Master entries are still present.
+    expect(opts.kelas).toContain('7A');
+  });
+
+  it('reflects newly added master kelas immediately', async () => {
+    await masterDataApi.create('kelas', { nama: '13-EXP' });
+    const opts = await anggotaApi.loadFormOptions();
+    expect(opts.kelas).toContain('13-EXP');
+  });
+
+  it('returns deduplicated, alphabetically sorted lists', async () => {
+    // Save an anggota with a kelas that's already in master so we exercise
+    // the dedupe path (master + distinct must collapse to a single entry).
+    await anggotaApi.create({
+      kodeAnggota: 'BUG3-DEDUPE',
+      nama: 'Dedupe Member',
+      kelas: '7A',
+    });
+    const opts = await anggotaApi.loadFormOptions();
+    const occurrences = opts.kelas.filter((k) => k === '7A').length;
+    expect(occurrences).toBe(1);
+    const kelasSet = new Set(opts.kelas);
+    expect(kelasSet.size).toBe(opts.kelas.length);
+    const sorted = [...opts.kelas].sort((a, b) => a.localeCompare(b));
+    expect(opts.kelas).toEqual(sorted);
   });
 });


### PR DESCRIPTION
## Summary

Fixes [`BUG-003`](https://github.com/alviarts/perpustakaan-offline/blob/devin/1777840131-bugs-backlog/docs/bugs/POST_V1_BUGS.md#bug-003--anggota-kelas--jurusan-dropdowns-sourced-from-anggota_distinct-not-master-tables) — Tambah/Edit Anggota's Kelas and Jurusan dropdowns rendered "Tidak ada hasil" on a fresh DB because they pulled from `anggota_distinct(field)`, which only returns values already saved on existing anggota rows. Agama only appeared to work because `AnggotaForm` has a hardcoded `FALLBACK_AGAMA` constant that masked the underlying bug.

### Root cause

`apps/desktop/src/routes/_authed/anggota/new.tsx` and `$id.tsx` called `anggotaApi.distinct('kelas' | 'jurusan' | 'agama')` to populate the autocomplete options. On a fresh install:
- `anggota` table is empty → distinct returns `[]`.
- `kelas`, `jurusan`, `agama` master tables have 18 / 6 / 6 seeded rows (from `db::seed_master_data`), but they were never queried by the form.

### Fix

`apps/desktop/src/lib/anggota.ts`:
- Add `anggotaApi.loadFormOptions(): Promise<{ kelas, jurusan, agama }>` that for each field:
  1. fetches `masterDataApi.list(table)` (the intended source of truth).
  2. fetches `anggotaApi.distinct(field)` so legacy free-text values stored on existing anggota rows merge in (no upgrade regression).
  3. runs the two RPCs via `Promise.allSettled` so a failure in one doesn't kill the other.
  4. dedupes (`Set` of trimmed strings) and alpha-sorts the result.

`apps/desktop/src/routes/_authed/anggota/new.tsx`, `$id.tsx`:
- Replace the three independent `anggotaApi.distinct(...)` calls with a single `anggotaApi.loadFormOptions()` call. The `$id.tsx` path now does `Promise.all([anggotaApi.get(id), anggotaApi.loadFormOptions()])`.

`apps/desktop/src/features/anggota/AnggotaForm.tsx`:
- Untouched. `FALLBACK_AGAMA` stays as a defence-in-depth guard for catastrophic seed failures (per the bug entry's recommendation).

### Files changed

- `apps/desktop/src/lib/anggota.ts` (+57 −0)
- `apps/desktop/src/routes/_authed/anggota/new.tsx` (+8 −5)
- `apps/desktop/src/routes/_authed/anggota/$id.tsx` (+3 −10)
- `apps/desktop/tests/unit/anggotaApi.test.ts` (+72 −0, six new test cases)

### Definition-of-done checklist (from POST_V1_BUGS.md BUG-003)

- [x] Fresh DB → Tambah Anggota → Kelas dropdown shows the seeded master list (e.g. `7A`, `7B`, …, `12-IPS`). Tested via `anggotaApi.loadFormOptions exposes the seeded master kelas list on a fresh DB`.
- [x] Adding a new kelas in Settings → Master Data → Kelas → reload Tambah Anggota → new kelas appears. Tested via `reflects newly added master kelas immediately`.
- [x] Free-text kelas values that already exist on anggota rows still appear (merged in). Tested via `merges existing free-text values from anggota_distinct on top of master`.

## Review & Testing Checklist for Human

Risk: yellow — changes form-load behavior on a critical screen but the helper is well-isolated and unit-tested.

- [ ] Pull this branch, run `pnpm install && pnpm --filter @perpustakaan/desktop build && pnpm tauri:dev`, log in as `admin` / `admin123`.
- [ ] Anggota → Tambah Anggota. Kelas, Jurusan, and Agama dropdowns should each show the seeded master rows (Kelas: `7A`–`12-IPS`, Jurusan: `IPA`/`IPS`/`Bahasa`/`TKJ`/`RPL`/`Multimedia`, Agama: `Islam`/`Kristen`/…).
- [ ] Settings → Master Data → Kelas. Add a new entry, e.g. `13-EXP`. Navigate back to Anggota → Tambah Anggota and confirm the new kelas appears.
- [ ] Edit an existing anggota whose `kelas` was free-typed before this fix (e.g. `12 IPA 3`). The dropdown should show that value alongside the master entries.
- [ ] (Optional) Disable the master-data RPC by hand to confirm distinct still works as a fallback (`Promise.allSettled` resilience).

### Notes

- 12 anggotaApi unit tests pass: `cd apps/desktop && pnpm exec vitest run anggotaApi`. Full suite: 17 files, 135 tests, all green.
- `pnpm lint && typecheck && i18n:lint && test` all green.
- The browser fallback path (`mockRpc`) backs both `master_list` and `anggota_distinct` from the same in-memory localStorage seed used by other tests, so the merge behavior reflects what the real Tauri backend will produce.
- Out of scope: the master-data RPC backend is unchanged. Master-data CRUD already works via Settings → Master Data; this PR only re-points the Anggota form at it.
