### PR TITLE
fix(ddc): seed 10 DDC main classes on fresh install (BUG-004)

### DIFF
--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -114,6 +114,7 @@ fn seed_master_data(conn: &Connection) -> AppResult<()> {
         .map(|_| ())
     })?;
     seed_bahasa_if_empty(conn)?;
+    seed_ddc_if_empty(conn)?;
     Ok(())
 }
 
@@ -185,6 +186,36 @@ fn seed_bahasa_if_empty(conn: &Connection) -> AppResult<()> {
         )?;
     }
     log::info!("seeded {} default bahasa rows", BAHASA_SEED.len());
+    Ok(())
+}
+
+/// Dewey Decimal Classification — 10 main classes (000-900). Indonesian
+/// labels match the conventions used by Indonesian school libraries (BUG-004).
+const DDC_MAIN_CLASSES: &[(&str, &str)] = &[
+    ("000", "Karya Umum"),
+    ("100", "Filsafat & Psikologi"),
+    ("200", "Agama"),
+    ("300", "Ilmu Sosial"),
+    ("400", "Bahasa"),
+    ("500", "Sains Murni"),
+    ("600", "Teknologi & Sains Terapan"),
+    ("700", "Kesenian, Hiburan, Olahraga"),
+    ("800", "Sastra"),
+    ("900", "Sejarah & Geografi"),
+];
+
+fn seed_ddc_if_empty(conn: &Connection) -> AppResult<()> {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM ddc", [], |row| row.get(0))?;
+    if count > 0 {
+        return Ok(());
+    }
+    for (kode, deskripsi) in DDC_MAIN_CLASSES {
+        conn.execute(
+            "INSERT INTO ddc (kode, deskripsi, parent, depth) VALUES (?1, ?2, NULL, 0)",
+            rusqlite::params![kode, deskripsi],
+        )?;
+    }
+    log::info!("seeded {} default DDC main classes", DDC_MAIN_CLASSES.len());
     Ok(())
 }
 
@@ -381,5 +412,98 @@ mod tests {
             .query_row("SELECT nama FROM kta_templates", [], |r| r.get(0))
             .unwrap();
         assert_eq!(nama, "Custom");
+    }
+
+    #[test]
+    fn fresh_install_seeds_ten_ddc_main_classes() {
+        let conn = fresh_conn();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM ddc", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 10);
+    }
+
+    #[test]
+    fn ddc_seed_includes_canonical_kode_and_deskripsi() {
+        let conn = fresh_conn();
+        let mut stmt = conn
+            .prepare("SELECT kode, deskripsi FROM ddc ORDER BY kode")
+            .unwrap();
+        let rows: Vec<(String, String)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        let kodes: Vec<&str> = rows.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(
+            kodes,
+            vec![
+                "000", "100", "200", "300", "400", "500", "600", "700", "800", "900",
+            ],
+        );
+        // Spot-check a couple of descriptions to guard against a future
+        // careless edit reordering or rewriting the array.
+        let by_kode: std::collections::HashMap<&str, &str> = rows
+            .iter()
+            .map(|(k, d)| (k.as_str(), d.as_str()))
+            .collect();
+        assert_eq!(by_kode.get("000").copied(), Some("Karya Umum"));
+        assert_eq!(by_kode.get("400").copied(), Some("Bahasa"));
+        assert_eq!(by_kode.get("900").copied(), Some("Sejarah & Geografi"));
+    }
+
+    #[test]
+    fn ddc_seed_rows_are_main_classes_at_depth_zero() {
+        let conn = fresh_conn();
+        let depths: Vec<i64> = conn
+            .prepare("SELECT depth FROM ddc")
+            .unwrap()
+            .query_map([], |r| r.get::<_, i64>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert!(depths.iter().all(|d| *d == 0));
+        let parent_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM ddc WHERE parent IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(parent_count, 0);
+    }
+
+    #[test]
+    fn ddc_seed_is_idempotent_across_runs() {
+        let conn = fresh_conn();
+        run_migrations(&conn).unwrap();
+        run_migrations(&conn).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM ddc", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 10);
+    }
+
+    #[test]
+    fn ddc_seed_skips_when_user_already_has_rows() {
+        // Simulate a v1.0.0 user who manually inserted DDC entries before
+        // upgrading. Seeding must NOT duplicate or override them.
+        let conn = fresh_conn();
+        conn.execute("DELETE FROM ddc", []).unwrap();
+        conn.execute(
+            "INSERT INTO ddc (kode, deskripsi, parent, depth)
+             VALUES ('CUSTOM', 'My local class', NULL, 0)",
+            [],
+        )
+        .unwrap();
+        seed_ddc_if_empty(&conn).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM ddc", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let kode: String = conn
+            .query_row("SELECT kode FROM ddc", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(kode, "CUSTOM");
     }
 }


### PR DESCRIPTION
## Summary

Fixes [`BUG-004`](https://github.com/alviarts/perpustakaan-offline/blob/devin/1777840131-bugs-backlog/docs/bugs/POST_V1_BUGS.md#bug-004--ddc-master-table-is-empty-on-fresh-install) — Tambah Buku → "Kode DDC" picker rendered "Tidak ada hasil" on a fresh DB because the `ddc` master table was never seeded.

### Root cause

`db::seed_master_data` covered `agama`, `kategori`, `kelas`, `jurusan`, and `bahasa`, but DDC was missing from the seed pipeline entirely. Session 5's deliverable promised "Master Data komplit (DDC/Kategori/Bahasa/Jurusan/Kelas/Agama)" with seeded values; only DDC slipped through.

### Fix

`apps/desktop/src-tauri/src/db/mod.rs`:

- Add `DDC_MAIN_CLASSES: &[(&str, &str)]` with the 10 Dewey main classes (`000`–`900`), using the Indonesian school-library labels listed in the bug entry's "Suggested fix" block (e.g. `000 — Karya Umum`, `400 — Bahasa`).
- Add `seed_ddc_if_empty(conn)` that idempotently inserts each row at `depth = 0`, `parent = NULL` (matching the schema comment at `db/schema.sql:51-58`).
- Hook into `seed_master_data` alongside the existing `seed_*_if_empty` calls so it runs on every DB open via `run_migrations`.

### Files changed

- `apps/desktop/src-tauri/src/db/mod.rs` (+139 −0)

### Definition-of-done checklist (from POST_V1_BUGS.md BUG-004)

- [x] Fresh install → `SELECT count(*) FROM ddc >= 10`. Tested via `fresh_install_seeds_ten_ddc_main_classes`.
- [ ] Buku form → Kode DDC → list shows the 10 main classes. (Verifiable by reviewer; the seeded data is asserted by `ddc_seed_includes_canonical_kode_and_deskripsi`.)
- [x] Idempotency: re-running `seed_default_data` does not duplicate rows. Tested via `ddc_seed_is_idempotent_across_runs`.

## Review & Testing Checklist for Human

Risk: green — small, additive seed change with idempotency tests.

- [ ] Pull this branch, run `pnpm install && pnpm --filter @perpustakaan/desktop build && pnpm tauri:dev`, log in as `admin` / `admin123`.
- [ ] Buku → Tambah Buku → Kode DDC. The picker should now show the 10 main classes (`000` Karya Umum, `100` Filsafat & Psikologi, …, `900` Sejarah & Geografi). Pick one and confirm it saves to the buku row.
- [ ] (Upgrade smoke) On a v1.0.0 DB that already has custom DDC rows from manual SQLite editing or session 5 testing: open the app and confirm those rows are preserved (the seed is skipped when the table is non-empty).

### Notes

- 5 new unit tests pass: `cd apps/desktop/src-tauri && cargo test --lib db::tests`. They cover row count, exact kode set + spot-checked deskripsi, depth/parent invariants, idempotency, and skip-when-non-empty.
- `pnpm lint && typecheck && i18n:lint && test` all green; `cargo check --all-targets` and `cargo clippy --all-targets -- -D warnings` both green.
- Out of scope: this seeds only the 10 main classes (depth=0). The 100 divisions / 1000 sections require a separate dataset and an explicit decision on whether to ship them in-tree or fetch on demand. Tracked separately if needed.
