### PR TITLE
fix(layout): track sub-route in header breadcrumb (BUG-006)

### DIFF
--- a/apps/desktop/src/components/layout/Header.tsx
+++ b/apps/desktop/src/components/layout/Header.tsx
@@ -30,8 +30,81 @@ const ROUTE_LABELS: Record<string, string> = {
   '/settings': 'common:menu.settings',
 };
 
+/**
+ * Labels for sub-routes (depth >= 2). Keyed by the full pathname so we can
+ * pick out exact matches first; for dynamic segments like `/anggota/$id`
+ * (e.g. `/anggota/42`) we fall back to a heuristic.
+ */
+const SUB_ROUTE_LABELS: Record<string, string> = {
+  '/anggota/new': 'anggota:breadcrumb.new',
+  '/anggota/cetak-kta': 'anggota:breadcrumb.cetakKta',
+  '/buku/new': 'buku:breadcrumb.new',
+  '/peminjaman/new': 'peminjaman:breadcrumb.new',
+  '/laporan/grafik': 'laporan:nav.grafik',
+  '/laporan/top-peminjam': 'laporan:nav.topPeminjam',
+  '/laporan/top-buku': 'laporan:nav.topBuku',
+  '/laporan/kas': 'laporan:nav.kas',
+  '/laporan/backup': 'laporan:nav.backup',
+};
+
+/**
+ * Resolve a list of breadcrumb i18n keys for a pathname, e.g.
+ *   `/anggota/new` → ['common:menu.anggota', 'anggota:breadcrumb.new']
+ *   `/dashboard`   → ['common:menu.dashboard']
+ *   `/laporan/grafik` → ['common:menu.laporan', 'laporan:nav.grafik']
+ *
+ * The previous implementation only matched the full pathname against
+ * `ROUTE_LABELS`, so any deeper route fell back to `common:menu.dashboard`
+ * (BUG-006). This walks the path segment-by-segment so the section crumb is
+ * always correct, and adds a sub-segment crumb where one is known.
+ */
+export function resolveBreadcrumbKeys(pathname: string): string[] {
+  // Strip trailing slash and any query/hash already removed by the router.
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length === 0) return ['common:menu.dashboard'];
+
+  const sectionPath = `/${segments[0] ?? ''}`;
+  const sectionKey = ROUTE_LABELS[sectionPath];
+  if (!sectionKey) return ['common:menu.dashboard'];
+
+  const result = [sectionKey];
+  if (segments.length === 1) return result;
+
+  const fullPath = `/${segments.join('/')}`;
+  const exact = SUB_ROUTE_LABELS[fullPath];
+  if (exact) {
+    result.push(exact);
+    return result;
+  }
+
+  // Dynamic / parametric routes: e.g. `/anggota/42` (edit), `/buku/123`.
+  // We don't have the route-tree's staticData here, so fall back to a
+  // sensible "Edit" label when the next segment looks like an ID and we
+  // recognise the section.
+  const tail = segments[1] ?? '';
+  if (/^\d+$/.test(tail)) {
+    if (segments[0] === 'anggota') {
+      result.push('anggota:breadcrumb.edit');
+      return result;
+    }
+    if (segments[0] === 'buku') {
+      result.push('buku:breadcrumb.edit');
+      return result;
+    }
+    if (segments[0] === 'peminjaman') {
+      result.push('peminjaman:breadcrumb.detail');
+      return result;
+    }
+  }
+
+  // Unknown sub-route: surface the segment itself so the breadcrumb is at
+  // least informative rather than silently falling back to "Dashboard".
+  result.push(tail);
+  return result;
+}
+
 export function Header() {
-  const { t } = useTranslation(['common', 'auth']);
+  const { t } = useTranslation(['common', 'auth', 'anggota', 'buku', 'peminjaman', 'laporan']);
   const router = useRouter();
   const routerState = useRouterState();
   const user = useAuthStore((s) => s.user);
@@ -40,7 +113,10 @@ export function Header() {
   const [searchValue, setSearchValue] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
 
-  const currentLabelKey = ROUTE_LABELS[routerState.location.pathname] ?? 'common:menu.dashboard';
+  const breadcrumbKeys = resolveBreadcrumbKeys(routerState.location.pathname);
+  const breadcrumbLabels = breadcrumbKeys.map((key) =>
+    key.includes(':') ? t(key) : key,
+  );
 
   // Ctrl+K / Cmd+K → focus search (placeholder; akan integrasi dengan global search di sesi 4+)
   useEffect(() => {
@@ -68,7 +144,7 @@ export function Header() {
       )}
     >
       {/* Breadcrumb / current section */}
-      <div className="flex items-center gap-2 text-sm">
+      <div className="flex items-center gap-2 text-sm" data-testid="header-breadcrumb">
         <Link
           to="/dashboard"
           className="text-muted-foreground hover:text-foreground"
@@ -76,8 +152,15 @@ export function Header() {
         >
           {identity.nama}
         </Link>
-        <span className="text-muted-foreground/50">/</span>
-        <span className="font-medium">{t(currentLabelKey)}</span>
+        {breadcrumbLabels.map((label, i) => {
+          const isLast = i === breadcrumbLabels.length - 1;
+          return (
+            <span key={`${label}-${i}`} className="flex items-center gap-2">
+              <span className="text-muted-foreground/50">/</span>
+              <span className={isLast ? 'font-medium' : 'text-muted-foreground'}>{label}</span>
+            </span>
+          );
+        })}
       </div>
 
       {/* Global search slot (Devin 4+ akan isi) */}

--- a/apps/desktop/src/i18n/en/anggota.json
+++ b/apps/desktop/src/i18n/en/anggota.json
@@ -93,5 +93,10 @@
     "deleteError": "Failed to delete member: {{message}}",
     "importSuccess": "Import done: {{inserted}} members added.",
     "loadError": "Failed to load members."
+  },
+  "breadcrumb": {
+    "new": "Add",
+    "edit": "Edit",
+    "cetakKta": "Print ID Card"
   }
 }

--- a/apps/desktop/src/i18n/en/buku.json
+++ b/apps/desktop/src/i18n/en/buku.json
@@ -96,5 +96,9 @@
     "sumber": "Source",
     "eksemplarTitle": "Copies ({{count}})",
     "eksemplarEmpty": "No physical copies yet."
+  },
+  "breadcrumb": {
+    "new": "Add",
+    "edit": "Edit"
   }
 }

--- a/apps/desktop/src/i18n/en/peminjaman.json
+++ b/apps/desktop/src/i18n/en/peminjaman.json
@@ -111,5 +111,9 @@
     "selectFirst": "Select a loan from search results",
     "allReturned": "All items already returned",
     "dendaPreview": "{{count}} days late · Rp {{denda}}"
+  },
+  "breadcrumb": {
+    "new": "New Loan",
+    "detail": "Details"
   }
 }

--- a/apps/desktop/src/i18n/id/anggota.json
+++ b/apps/desktop/src/i18n/id/anggota.json
@@ -93,5 +93,10 @@
     "deleteError": "Gagal menghapus anggota: {{message}}",
     "importSuccess": "Impor selesai: {{inserted}} anggota berhasil ditambahkan.",
     "loadError": "Gagal memuat data anggota."
+  },
+  "breadcrumb": {
+    "new": "Tambah",
+    "edit": "Edit",
+    "cetakKta": "Cetak KTA"
   }
 }

--- a/apps/desktop/src/i18n/id/buku.json
+++ b/apps/desktop/src/i18n/id/buku.json
@@ -96,5 +96,9 @@
     "sumber": "Sumber",
     "eksemplarTitle": "Eksemplar ({{count}})",
     "eksemplarEmpty": "Belum ada eksemplar fisik."
+  },
+  "breadcrumb": {
+    "new": "Tambah",
+    "edit": "Edit"
   }
 }

--- a/apps/desktop/src/i18n/id/peminjaman.json
+++ b/apps/desktop/src/i18n/id/peminjaman.json
@@ -111,5 +111,9 @@
     "selectFirst": "Pilih peminjaman dari hasil pencarian",
     "allReturned": "Semua item sudah dikembalikan",
     "dendaPreview": "Terlambat {{count}} hari · Rp {{denda}}"
+  },
+  "breadcrumb": {
+    "new": "Pinjam Baru",
+    "detail": "Detail"
   }
 }

--- a/apps/desktop/tests/unit/headerBreadcrumb.test.ts
+++ b/apps/desktop/tests/unit/headerBreadcrumb.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBreadcrumbKeys } from '@/components/layout/Header';
+
+/**
+ * Regression tests for BUG-006 — header breadcrumb stayed on "Dashboard"
+ * for any sub-route because the resolver only matched the full pathname
+ * against ROUTE_LABELS.
+ */
+describe('resolveBreadcrumbKeys', () => {
+  it('returns the dashboard crumb for /dashboard', () => {
+    expect(resolveBreadcrumbKeys('/dashboard')).toEqual(['common:menu.dashboard']);
+  });
+
+  it('falls back to the dashboard crumb for an empty / root path', () => {
+    expect(resolveBreadcrumbKeys('/')).toEqual(['common:menu.dashboard']);
+    expect(resolveBreadcrumbKeys('')).toEqual(['common:menu.dashboard']);
+  });
+
+  it('returns the section crumb for top-level list routes', () => {
+    expect(resolveBreadcrumbKeys('/anggota')).toEqual(['common:menu.anggota']);
+    expect(resolveBreadcrumbKeys('/buku')).toEqual(['common:menu.buku']);
+    expect(resolveBreadcrumbKeys('/peminjaman')).toEqual(['common:menu.peminjaman']);
+    expect(resolveBreadcrumbKeys('/laporan')).toEqual(['common:menu.laporan']);
+    expect(resolveBreadcrumbKeys('/settings')).toEqual(['common:menu.settings']);
+  });
+
+  it('appends a sub-route crumb for /anggota/new', () => {
+    expect(resolveBreadcrumbKeys('/anggota/new')).toEqual([
+      'common:menu.anggota',
+      'anggota:breadcrumb.new',
+    ]);
+  });
+
+  it('appends a sub-route crumb for /buku/new', () => {
+    expect(resolveBreadcrumbKeys('/buku/new')).toEqual([
+      'common:menu.buku',
+      'buku:breadcrumb.new',
+    ]);
+  });
+
+  it('appends a sub-route crumb for /peminjaman/new', () => {
+    expect(resolveBreadcrumbKeys('/peminjaman/new')).toEqual([
+      'common:menu.peminjaman',
+      'peminjaman:breadcrumb.new',
+    ]);
+  });
+
+  it('appends a sub-route crumb for /anggota/cetak-kta', () => {
+    expect(resolveBreadcrumbKeys('/anggota/cetak-kta')).toEqual([
+      'common:menu.anggota',
+      'anggota:breadcrumb.cetakKta',
+    ]);
+  });
+
+  it('appends laporan tab crumbs for /laporan/grafik etc.', () => {
+    expect(resolveBreadcrumbKeys('/laporan/grafik')).toEqual([
+      'common:menu.laporan',
+      'laporan:nav.grafik',
+    ]);
+    expect(resolveBreadcrumbKeys('/laporan/top-peminjam')).toEqual([
+      'common:menu.laporan',
+      'laporan:nav.topPeminjam',
+    ]);
+    expect(resolveBreadcrumbKeys('/laporan/top-buku')).toEqual([
+      'common:menu.laporan',
+      'laporan:nav.topBuku',
+    ]);
+    expect(resolveBreadcrumbKeys('/laporan/kas')).toEqual([
+      'common:menu.laporan',
+      'laporan:nav.kas',
+    ]);
+    expect(resolveBreadcrumbKeys('/laporan/backup')).toEqual([
+      'common:menu.laporan',
+      'laporan:nav.backup',
+    ]);
+  });
+
+  it('treats numeric anggota detail routes as edit', () => {
+    expect(resolveBreadcrumbKeys('/anggota/42')).toEqual([
+      'common:menu.anggota',
+      'anggota:breadcrumb.edit',
+    ]);
+  });
+
+  it('treats numeric buku detail routes as edit', () => {
+    expect(resolveBreadcrumbKeys('/buku/123')).toEqual([
+      'common:menu.buku',
+      'buku:breadcrumb.edit',
+    ]);
+  });
+
+  it('treats numeric peminjaman detail routes as detail', () => {
+    expect(resolveBreadcrumbKeys('/peminjaman/9')).toEqual([
+      'common:menu.peminjaman',
+      'peminjaman:breadcrumb.detail',
+    ]);
+  });
+
+  it('falls back to the raw segment for unknown sub-routes', () => {
+    // Surfaces the segment instead of regressing back to "Dashboard" so the
+    // breadcrumb is still informative.
+    expect(resolveBreadcrumbKeys('/buku/unknown-action')).toEqual([
+      'common:menu.buku',
+      'unknown-action',
+    ]);
+  });
+
+  it('falls back to dashboard for unknown top-level routes', () => {
+    expect(resolveBreadcrumbKeys('/totally-unknown')).toEqual(['common:menu.dashboard']);
+  });
+
+  it('never returns a label key prefix that the previous implementation would have hit', () => {
+    // Regression guard: every sub-route MUST produce more than one crumb when
+    // it has a known section. Catches a future regression to the old "exact
+    // match only" behaviour where /anggota/new collapsed to ['…dashboard'].
+    const subRoutes = [
+      '/anggota/new',
+      '/anggota/cetak-kta',
+      '/buku/new',
+      '/peminjaman/new',
+      '/laporan/grafik',
+      '/laporan/top-peminjam',
+      '/laporan/kas',
+    ];
+    for (const route of subRoutes) {
+      const crumbs = resolveBreadcrumbKeys(route);
+      expect(crumbs.length, `expected >1 crumb for ${route}`).toBeGreaterThan(1);
+      expect(crumbs[0], `expected section crumb for ${route}`).not.toBe(
+        'common:menu.dashboard',
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [`BUG-006`](https://github.com/alviarts/perpustakaan-offline/blob/devin/1777840131-bugs-backlog/docs/bugs/POST_V1_BUGS.md#bug-006--header-breadcrumb-stays-on-dashboard-for-sub-routes) — the header breadcrumb stayed on `Dashboard` for any deeper route (`/anggota/new`, `/laporan/grafik`, `/peminjaman/42`, …) while the page heading correctly displayed the actual screen name.

### Root cause

`apps/desktop/src/components/layout/Header.tsx` resolved the current crumb with a single exact-match lookup against `ROUTE_LABELS`:

```ts
const currentLabelKey = ROUTE_LABELS[routerState.location.pathname] ?? 'common:menu.dashboard';
```

Since `ROUTE_LABELS` only had entries for the top-level section paths (`/anggota`, `/buku`, …), a path like `/anggota/new` missed the map and fell into the `'common:menu.dashboard'` fallback.

### Fix

`apps/desktop/src/components/layout/Header.tsx`:

- Add `resolveBreadcrumbKeys(pathname): string[]` (exported for testing) that walks the path segment-by-segment:
  - Top segment hits `ROUTE_LABELS` for the section crumb.
  - A curated `SUB_ROUTE_LABELS` map handles known sub-routes:
    - `/anggota/new`, `/anggota/cetak-kta`
    - `/buku/new`
    - `/peminjaman/new`
    - All five `/laporan/<tab>` paths (`grafik`, `top-peminjam`, `top-buku`, `kas`, `backup`).
  - Numeric IDs in `/anggota/$id`, `/buku/$id`, `/peminjaman/$id` are surfaced as edit/detail crumbs.
  - Unknown sub-routes surface the raw segment instead of regressing to `Dashboard`.
  - Empty / root paths still resolve to `common:menu.dashboard`.
- Render the multi-level chain in JSX with the last crumb as the emphasised label, matching the previous look for single-segment routes.

`apps/desktop/src/i18n/{id,en}/{anggota,buku,peminjaman}.json`:

- Add a `breadcrumb` bundle with `new` / `edit` / `detail` / `cetakKta` keys.

### Files changed

- `apps/desktop/src/components/layout/Header.tsx` (+89 −7)
- `apps/desktop/tests/unit/headerBreadcrumb.test.ts` (new, 14 cases)
- `apps/desktop/src/i18n/{id,en}/anggota.json` (`breadcrumb` bundle)
- `apps/desktop/src/i18n/{id,en}/buku.json` (`breadcrumb` bundle)
- `apps/desktop/src/i18n/{id,en}/peminjaman.json` (`breadcrumb` bundle)

### Definition-of-done checklist (from POST_V1_BUGS.md BUG-006)

- [x] On `/anggota/new`, breadcrumb is `<identitas> / Anggota / Tambah`.
- [x] On `/laporan/grafik`, breadcrumb is `<identitas> / Laporan / Grafik`.
- [x] On `/dashboard`, breadcrumb is unchanged (`<identitas> / Dashboard`).

All three assertions are covered by `headerBreadcrumb.test.ts` plus a regression guard that any known sub-route always produces more than one crumb (i.e. never collapses back to a sole "Dashboard" item).

## Review & Testing Checklist for Human

Risk: green — Header.tsx is the only render-path change; the i18n additions are additive (lint passes).

- [ ] Pull this branch, run `pnpm install && pnpm --filter @perpustakaan/desktop build && pnpm tauri:dev`, log in as `admin` / `admin123`.
- [ ] Visit `/dashboard` — breadcrumb should read `<identitas> / Dashboard` (unchanged).
- [ ] Visit `/anggota/new` — breadcrumb should read `<identitas> / Anggota / Tambah`.
- [ ] Visit `/laporan/grafik` (and the other tabs) — breadcrumb should read `<identitas> / Laporan / Grafik` (etc.).
- [ ] Edit an existing anggota — breadcrumb should read `<identitas> / Anggota / Edit`.
- [ ] Switch language to English — sub-route crumbs translate (`Add`, `Print ID Card`, `New Loan`, …).

### Notes

- 14 new unit tests pass: `cd apps/desktop && pnpm exec vitest run headerBreadcrumb`. Full suite: 18 files, 143 tests, all green.
- `pnpm lint && typecheck && i18n:lint && test` all green.
- Out of scope: `/settings/<sub>` is left alone for now since the existing in-page sidebar already shows where you are. Easy to extend later by adding more entries to `SUB_ROUTE_LABELS`.
