### PR TITLE
fix(window): system tray + close-behavior setting + clean process exit (BUG-011)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -363,6 +363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +1913,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2324,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3076,6 +3105,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
@@ -4270,6 +4305,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni",
  "libc",
  "log",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.0", features = [] }
 
 [dependencies]
-tauri = { version = "2.2", features = [] }
+tauri = { version = "2.2", features = ["tray-icon", "image-png"] }
 tauri-plugin-dialog = "2.2"
 tauri-plugin-fs = "2.2"
 tauri-plugin-shell = "2.2"

--- a/apps/desktop/src-tauri/src/commands/close_behavior.rs
+++ b/apps/desktop/src-tauri/src/commands/close_behavior.rs
@@ -1,0 +1,174 @@
+//! Close-behavior + system-tray plumbing (BUG-011).
+//!
+//! On Windows the main library application would leave a zombie process in
+//! Task Manager after the user clicked the X button. The bug had two parts:
+//!
+//! 1. Closing the *main window* did not always tear down the WebView2
+//!    subprocess + the Tauri event loop on its own — Windows kept the
+//!    `PerpustakaanOffline.exe` process alive in some configurations,
+//!    blocking subsequent launches and risking SQLite lock contention if a
+//!    user opened a second instance.
+//! 2. There was no way to keep the app running in the background as a
+//!    minimized icon, which several pustakawan asked for so the workstation
+//!    wouldn't have to cold-start the app multiple times a day.
+//!
+//! This module exposes:
+//!
+//! * `get_close_behavior` / `set_close_behavior` — typed wrappers around the
+//!   `app.close_behavior` row in the generic `settings` k/v table. Default is
+//!   `Exit` (the historical behavior the user expected).
+//! * `close_behavior_get` / `close_behavior_set` — `#[tauri::command]` stubs
+//!   for the frontend Settings page.
+//! * `force_quit` — a Tauri command the system tray's "Keluar" menu item
+//!   invokes to force a clean shutdown regardless of the current setting.
+//!
+//! The actual `WindowEvent::CloseRequested` + tray plumbing lives in
+//! `lib.rs::run` so the close handler can intercept the event before Tauri
+//! tears the window down.
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, State};
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+/// What happens when the user clicks the X button on the main window.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CloseBehavior {
+    /// Terminate the application (default). Equivalent to "File → Keluar".
+    #[default]
+    Exit,
+    /// Hide the main window into the system tray. The app keeps running in
+    /// the background and is restored via tray icon click / "Buka" menu.
+    Tray,
+}
+
+impl CloseBehavior {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exit => "exit",
+            Self::Tray => "tray",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "tray" => Self::Tray,
+            // Anything else falls back to the safe default so a corrupt
+            // settings row never bricks the close button.
+            _ => Self::Exit,
+        }
+    }
+}
+
+pub const SETTINGS_KEY: &str = "app.close_behavior";
+
+/// Read the persisted close behavior, returning the default if the row is
+/// missing or unparseable. This helper is used both by the Tauri command and
+/// by the runtime close-event handler so they always agree.
+pub fn get_close_behavior(state: &AppState) -> AppResult<CloseBehavior> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = ?1",
+            rusqlite::params![SETTINGS_KEY],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other),
+        })?;
+    Ok(raw.as_deref().map(CloseBehavior::parse).unwrap_or_default())
+}
+
+/// Persist the close behavior using upsert semantics on the existing
+/// `settings` table.
+pub fn set_close_behavior(state: &AppState, behavior: CloseBehavior) -> AppResult<()> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![SETTINGS_KEY, behavior.as_str()],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn close_behavior_get(state: State<'_, AppState>) -> AppResult<CloseBehavior> {
+    get_close_behavior(&state)
+}
+
+#[tauri::command]
+pub fn close_behavior_set(
+    state: State<'_, AppState>,
+    behavior: CloseBehavior,
+) -> AppResult<CloseBehavior> {
+    set_close_behavior(&state, behavior)?;
+    Ok(behavior)
+}
+
+/// Tray "Keluar" menu item handler, also exposed to the frontend so a
+/// "File → Keluar" menu can use it. Tries `app.exit(0)` first (lets Tauri
+/// tear down windows cleanly) and follows up with `std::process::exit(0)`
+/// so any lingering WebView2 child process is force-terminated even if the
+/// runtime gets stuck shutting down — this is the BUG-011 root-cause fix.
+#[tauri::command]
+pub fn force_quit(app: AppHandle) {
+    log::info!("force_quit invoked — exiting application");
+    app.exit(0);
+    // BUG-011 belt-and-suspenders: a small subset of WebView2 builds on
+    // Windows do not unwind cleanly when only `app.exit(0)` is called
+    // (see https://github.com/tauri-apps/tauri/issues/8631). The hard
+    // exit guarantees the .exe disappears from Task Manager.
+    std::process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_exit() {
+        assert_eq!(CloseBehavior::default(), CloseBehavior::Exit);
+    }
+
+    #[test]
+    fn parse_known_values() {
+        assert_eq!(CloseBehavior::parse("exit"), CloseBehavior::Exit);
+        assert_eq!(CloseBehavior::parse("tray"), CloseBehavior::Tray);
+        assert_eq!(CloseBehavior::parse("TRAY"), CloseBehavior::Tray);
+        assert_eq!(CloseBehavior::parse("  Tray  "), CloseBehavior::Tray);
+    }
+
+    #[test]
+    fn parse_unknown_falls_back_to_exit() {
+        // BUG-011: a corrupted settings row must NEVER make the close button
+        // unresponsive — fall back to the safe (terminate) default.
+        assert_eq!(CloseBehavior::parse(""), CloseBehavior::Exit);
+        assert_eq!(CloseBehavior::parse("garbage"), CloseBehavior::Exit);
+        assert_eq!(CloseBehavior::parse("hide"), CloseBehavior::Exit);
+    }
+
+    #[test]
+    fn round_trip_serde() {
+        let raw = serde_json::to_string(&CloseBehavior::Tray).unwrap();
+        assert_eq!(raw, "\"tray\"");
+        let parsed: CloseBehavior = serde_json::from_str("\"exit\"").unwrap();
+        assert_eq!(parsed, CloseBehavior::Exit);
+    }
+
+    #[test]
+    fn as_str_is_stable() {
+        // Frontend stores the string verbatim — keep these literals stable
+        // so old SQLite rows keep working after upgrades.
+        assert_eq!(CloseBehavior::Exit.as_str(), "exit");
+        assert_eq!(CloseBehavior::Tray.as_str(), "tray");
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod anggota;
 pub mod auth;
 pub mod backup;
 pub mod buku;
+pub mod close_behavior;
 pub mod dashboard;
 pub mod identity;
 pub mod kta;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,12 +4,30 @@ mod error;
 
 use std::sync::Mutex;
 
-use tauri::{Manager, RunEvent};
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    Manager, RunEvent, WindowEvent,
+};
+
+use crate::commands::close_behavior::{get_close_behavior, CloseBehavior};
 
 pub struct AppState {
     pub db: Mutex<rusqlite::Connection>,
     pub current_user: Mutex<Option<commands::auth::SessionUser>>,
     pub remember_token: Mutex<Option<String>>,
+}
+
+const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Show + focus the main window. Used by the tray icon click handler and the
+/// "Buka" menu item to restore the app from minimized-to-tray state.
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(win) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = win.show();
+        let _ = win.unminimize();
+        let _ = win.set_focus();
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -31,6 +49,49 @@ pub fn run() {
                 current_user: Mutex::new(None),
                 remember_token: Mutex::new(None),
             });
+
+            // BUG-011: build the system tray once at setup. The tray is
+            // ALWAYS created (regardless of the user's close-behavior
+            // preference) so that a freshly-installed app already has the
+            // icon when the user later opens Setting → Aplikasi and toggles
+            // "Minimize ke tray".
+            let buka_item =
+                MenuItem::with_id(app, "tray.buka", "Buka Perpustakaan", true, None::<&str>)?;
+            let keluar_item = MenuItem::with_id(app, "tray.keluar", "Keluar", true, None::<&str>)?;
+            let tray_menu = Menu::with_items(app, &[&buka_item, &keluar_item])?;
+
+            let _tray = TrayIconBuilder::with_id("po-main")
+                .tooltip("Perpustakaan Offline")
+                .icon(
+                    app.default_window_icon()
+                        .cloned()
+                        .ok_or_else(|| tauri::Error::AssetNotFound("default window icon".into()))?,
+                )
+                .menu(&tray_menu)
+                .show_menu_on_left_click(false)
+                .on_menu_event(|app, event| match event.id.as_ref() {
+                    "tray.buka" => show_main_window(app),
+                    "tray.keluar" => {
+                        log::info!("tray: keluar clicked");
+                        app.exit(0);
+                        // BUG-011 belt-and-suspenders — guarantee process
+                        // exit even if WebView2 hangs during shutdown.
+                        std::process::exit(0);
+                    }
+                    _ => {}
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if let TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    } = event
+                    {
+                        show_main_window(tray.app_handle());
+                    }
+                })
+                .build(app)?;
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -105,7 +166,47 @@ pub fn run() {
             commands::settings::settings_permissions_save,
             commands::settings::settings_audit_log_query,
             commands::manual::open_manual,
+            commands::close_behavior::close_behavior_get,
+            commands::close_behavior::close_behavior_set,
+            commands::close_behavior::force_quit,
         ])
+        .on_window_event(|window, event| {
+            // BUG-011: intercept the X-button on the main window and
+            // either (a) hide it into the tray when the user has opted
+            // in, or (b) let Tauri tear it down and then guarantee the
+            // process actually exits (some WebView2 builds otherwise leave
+            // a zombie .exe in Task Manager).
+            if let WindowEvent::CloseRequested { api, .. } = event {
+                if window.label() != MAIN_WINDOW_LABEL {
+                    return;
+                }
+                let app = window.app_handle();
+                let behavior = app
+                    .try_state::<AppState>()
+                    .and_then(|state| get_close_behavior(&state).ok())
+                    .unwrap_or_default();
+                match behavior {
+                    CloseBehavior::Tray => {
+                        log::info!("close_requested: hiding main window to tray");
+                        api.prevent_close();
+                        let _ = window.hide();
+                    }
+                    CloseBehavior::Exit => {
+                        log::info!("close_requested: exiting application");
+                        // Let Tauri unwind the window first, then guarantee
+                        // the process exits — see force_quit for rationale.
+                        let app_handle = app.clone();
+                        std::thread::spawn(move || {
+                            // Tiny delay so the window event loop can flush
+                            // the WindowEvent::Destroyed before we hard-exit.
+                            std::thread::sleep(std::time::Duration::from_millis(150));
+                            app_handle.exit(0);
+                            std::process::exit(0);
+                        });
+                    }
+                }
+            }
+        })
         .build(tauri::generate_context!())
         .expect("failed to build tauri app")
         .run(|_app_handle, event| {

--- a/apps/desktop/src/features/settings/TampilanPage.tsx
+++ b/apps/desktop/src/features/settings/TampilanPage.tsx
@@ -10,7 +10,9 @@ import {
 import { useToast } from '@/components/ui/toast-manager';
 import { useThemeStore, type Theme } from '@/stores/themeStore';
 import {
+  DEFAULT_CLOSE_BEHAVIOR,
   DEFAULT_DISPLAY_PREFS,
+  type CloseBehavior,
   type DisplayPrefs,
   settingsApi,
 } from '@/lib/settings';
@@ -31,13 +33,30 @@ export function TampilanPage(): JSX.Element {
   const { showToast } = useToast();
   const { theme, setTheme } = useThemeStore();
   const [prefs, setPrefs] = React.useState<DisplayPrefs>(DEFAULT_DISPLAY_PREFS);
+  const [closeBehavior, setCloseBehavior] = React.useState<CloseBehavior>(
+    DEFAULT_CLOSE_BEHAVIOR,
+  );
 
   React.useEffect(() => {
     settingsApi.getDisplayPrefs().then((p) => {
       setPrefs(p);
       applyDisplayPrefs(p);
     });
+    settingsApi.getCloseBehavior().then(setCloseBehavior).catch(() => undefined);
   }, []);
+
+  const handleSaveCloseBehavior = async (next: CloseBehavior): Promise<void> => {
+    setCloseBehavior(next);
+    try {
+      await settingsApi.saveCloseBehavior(next);
+    } catch (e) {
+      showToast({
+        title: t('sections.identitas.saveError', { defaultValue: 'Gagal menyimpan' }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    }
+  };
 
   const handleSavePrefs = async (next: DisplayPrefs): Promise<void> => {
     setPrefs(next);
@@ -113,6 +132,45 @@ export function TampilanPage(): JSX.Element {
               </SelectItem>
             </SelectContent>
           </Select>
+        </FieldRow>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 mt-2">
+        <FieldRow
+          label={t('sections.tampilan.fields.closeBehavior', {
+            defaultValue: 'Saat tombol X diklik',
+          })}
+        >
+          <Select
+            value={closeBehavior}
+            onValueChange={(v) => handleSaveCloseBehavior(v as CloseBehavior)}
+          >
+            <SelectTrigger data-testid="tampilan-close-behavior">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="exit">
+                {t('sections.tampilan.closeBehavior.exit', {
+                  defaultValue: 'Tutup aplikasi sepenuhnya',
+                })}
+              </SelectItem>
+              <SelectItem value="tray">
+                {t('sections.tampilan.closeBehavior.tray', {
+                  defaultValue: 'Minimize ke system tray',
+                })}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {closeBehavior === 'tray'
+              ? t('sections.tampilan.closeBehavior.trayHint', {
+                  defaultValue:
+                    'Aplikasi tetap berjalan di tray; klik ikon untuk membuka kembali.',
+                })
+              : t('sections.tampilan.closeBehavior.exitHint', {
+                  defaultValue: 'Aplikasi benar-benar keluar dari Task Manager.',
+                })}
+          </p>
         </FieldRow>
       </div>
     </SettingsSection>

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -56,11 +56,19 @@
       "fields": {
         "theme": "Theme",
         "fontScale": "Font scale",
-        "density": "Density"
+        "density": "Density",
+        "closeBehavior": "When the X button is clicked",
+        "closeBehaviorHint": "Choose what happens when you close the main window."
       },
       "density": {
         "compact": "Compact",
         "comfortable": "Comfortable"
+      },
+      "closeBehavior": {
+        "exit": "Quit the application",
+        "tray": "Minimize to system tray",
+        "exitHint": "The app fully exits from Task Manager.",
+        "trayHint": "The app keeps running in the tray; click the icon to restore."
       }
     },
     "bahasa": {

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -56,11 +56,19 @@
       "fields": {
         "theme": "Tema",
         "fontScale": "Skala font",
-        "density": "Kerapatan"
+        "density": "Kerapatan",
+        "closeBehavior": "Saat tombol X diklik",
+        "closeBehaviorHint": "Atur perilaku aplikasi ketika kamu menutup window utama."
       },
       "density": {
         "compact": "Padat",
         "comfortable": "Nyaman"
+      },
+      "closeBehavior": {
+        "exit": "Tutup aplikasi sepenuhnya",
+        "tray": "Minimize ke system tray",
+        "exitHint": "Aplikasi benar-benar keluar dari Task Manager.",
+        "trayHint": "Aplikasi tetap berjalan di tray; klik ikon untuk membuka kembali."
       }
     },
     "bahasa": {

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -58,6 +58,16 @@ export const DEFAULT_DISPLAY_PREFS: DisplayPrefs = {
 };
 
 // ---------------------------------------------------------------------------
+// Close behavior (BUG-011: tray vs exit on X-button click)
+// ---------------------------------------------------------------------------
+
+export type CloseBehavior = 'exit' | 'tray';
+
+export const DEFAULT_CLOSE_BEHAVIOR: CloseBehavior = 'exit';
+
+const CLOSE_BEHAVIOR_KEY = 'app.close_behavior';
+
+// ---------------------------------------------------------------------------
 // Sync configuration
 // ---------------------------------------------------------------------------
 
@@ -197,6 +207,7 @@ const MOCK_KEYS = {
   permissions: 'po:settings:permissions',
   audit: 'po:settings:audit-log',
   identity: 'po:settings:identity',
+  closeBehavior: 'po:settings:close-behavior',
 };
 
 const readMock = <T,>(key: string, fallback: T): T => {
@@ -275,6 +286,10 @@ export interface SettingsApi {
   getDisplayPrefs(): Promise<DisplayPrefs>;
   saveDisplayPrefs(prefs: DisplayPrefs): Promise<DisplayPrefs>;
   resetDisplayPrefs(): Promise<DisplayPrefs>;
+
+  getCloseBehavior(): Promise<CloseBehavior>;
+  saveCloseBehavior(behavior: CloseBehavior): Promise<CloseBehavior>;
+  forceQuit(): Promise<void>;
 
   getSyncConfig(): Promise<SyncConfig>;
   saveSyncConfig(cfg: SyncConfig): Promise<SyncConfig>;
@@ -386,6 +401,17 @@ const mockApi: SettingsApi = {
   async resetDisplayPrefs() {
     writeMock(MOCK_KEYS.display, DEFAULT_DISPLAY_PREFS);
     return DEFAULT_DISPLAY_PREFS;
+  },
+
+  async getCloseBehavior() {
+    return readMock<CloseBehavior>(MOCK_KEYS.closeBehavior, DEFAULT_CLOSE_BEHAVIOR);
+  },
+  async saveCloseBehavior(behavior) {
+    writeMock(MOCK_KEYS.closeBehavior, behavior);
+    return behavior;
+  },
+  async forceQuit() {
+    // No-op in browser/dev mock — there's no .exe to quit.
   },
 
   async getSyncConfig() {
@@ -583,6 +609,21 @@ const tauriApi: SettingsApi = {
     return tauriApi.saveDisplayPrefs(DEFAULT_DISPLAY_PREFS);
   },
 
+  async getCloseBehavior() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const raw = await invoke<string>('close_behavior_get');
+    return raw === 'tray' ? 'tray' : 'exit';
+  },
+  async saveCloseBehavior(behavior) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const raw = await invoke<string>('close_behavior_set', { behavior });
+    return raw === 'tray' ? 'tray' : 'exit';
+  },
+  async forceQuit() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('force_quit');
+  },
+
   async getSyncConfig() {
     const { invoke } = await import('@tauri-apps/api/core');
     const rows = await invoke<Record<string, string>>('settings_get_many', {
@@ -676,6 +717,9 @@ export const settingsApi: SettingsApi = {
   getDisplayPrefs: () => rpc().getDisplayPrefs(),
   saveDisplayPrefs: (prefs) => rpc().saveDisplayPrefs(prefs),
   resetDisplayPrefs: () => rpc().resetDisplayPrefs(),
+  getCloseBehavior: () => rpc().getCloseBehavior(),
+  saveCloseBehavior: (b) => rpc().saveCloseBehavior(b),
+  forceQuit: () => rpc().forceQuit(),
   getSyncConfig: () => rpc().getSyncConfig(),
   saveSyncConfig: (cfg) => rpc().saveSyncConfig(cfg),
   resetSyncConfig: () => rpc().resetSyncConfig(),

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -65,8 +65,6 @@ export type CloseBehavior = 'exit' | 'tray';
 
 export const DEFAULT_CLOSE_BEHAVIOR: CloseBehavior = 'exit';
 
-const CLOSE_BEHAVIOR_KEY = 'app.close_behavior';
-
 // ---------------------------------------------------------------------------
 // Sync configuration
 // ---------------------------------------------------------------------------

--- a/apps/desktop/tests/unit/closeBehavior.test.ts
+++ b/apps/desktop/tests/unit/closeBehavior.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CLOSE_BEHAVIOR,
+  settingsApi,
+  type CloseBehavior,
+} from '@/lib/settings';
+
+describe('settingsApi.closeBehavior (browser mock — BUG-011)', () => {
+  beforeEach(() => {
+    settingsApi.__resetMock?.();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    settingsApi.__resetMock?.();
+    window.localStorage.clear();
+  });
+
+  it('defaults to "exit" before any value is saved', async () => {
+    expect(DEFAULT_CLOSE_BEHAVIOR).toBe('exit');
+    const got = await settingsApi.getCloseBehavior();
+    expect(got).toBe('exit');
+  });
+
+  it('persists "tray" through save → get round trip', async () => {
+    const saved = await settingsApi.saveCloseBehavior('tray');
+    expect(saved).toBe('tray');
+    const got = await settingsApi.getCloseBehavior();
+    expect(got).toBe('tray');
+  });
+
+  it('persists "exit" through save → get round trip', async () => {
+    // Switch to tray first to make sure 'exit' is an actual write, not the
+    // default fallback.
+    await settingsApi.saveCloseBehavior('tray');
+    const saved = await settingsApi.saveCloseBehavior('exit');
+    expect(saved).toBe('exit');
+    const got = await settingsApi.getCloseBehavior();
+    expect(got).toBe('exit');
+  });
+
+  it('forceQuit is a no-op in the browser mock and resolves cleanly', async () => {
+    // Asserting that no exception leaks from the mock — in production the
+    // Tauri impl invokes `force_quit` which std::process::exit's.
+    await expect(settingsApi.forceQuit()).resolves.toBeUndefined();
+  });
+
+  it('round-trips both sides of the union via the typed API surface', async () => {
+    const cases: CloseBehavior[] = ['exit', 'tray'];
+    for (const c of cases) {
+      await settingsApi.saveCloseBehavior(c);
+      expect(await settingsApi.getCloseBehavior()).toBe(c);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **BUG-011** — the Windows app would leave a zombie `PerpustakaanOffline.exe` process in Task Manager after the user clicked the X button, which risked SQLite lock contention if the user opened a second instance. Adds an opt-in **"minimize to system tray"** option requested in the same report so the librarian can keep the app warm in the background.

The bug had two parts:

1. **Process did not always terminate cleanly.** A small subset of WebView2 builds on Windows do not unwind cleanly when only `app.exit(0)` is called (cf. tauri-apps/tauri#8631), leaving a lingering child process.
2. **No way to keep the app running minimized.** Pustakawan asked for a tray-icon mode so the workstation does not have to cold-start the app multiple times a day.

### Backend (Rust)

* New `commands::close_behavior` module:
  * `CloseBehavior` enum (`Exit` | `Tray`, default `Exit`) persisted into the existing `settings` k/v table under key `app.close_behavior`.
  * `close_behavior_get` / `close_behavior_set` Tauri commands.
  * `force_quit` Tauri command used by the tray "Keluar" menu item — calls `app.exit(0)` followed by `std::process::exit(0)` to guarantee the `.exe` actually disappears from Task Manager.
* `lib.rs`:
  * Builds a system tray icon at setup with menu items "Buka Perpustakaan" + "Keluar". Left-click on the tray icon restores the main window.
  * `on_window_event` hooks `WindowEvent::CloseRequested` on the **main** window (manual / KTA preview windows are not affected): when behavior is `Tray` we `prevent_close` + `hide`; when `Exit` we spawn a worker that gives the WebView2 a 150 ms grace period and then hard-exits.
* Enables Tauri features `tray-icon` and `image-png` in `Cargo.toml`.

### Frontend

* `apps/desktop/src/lib/settings.ts` — `CloseBehavior` type, `DEFAULT_CLOSE_BEHAVIOR='exit'`, mock + Tauri implementations for `getCloseBehavior` / `saveCloseBehavior` / `forceQuit`, plumbed through the `settingsApi` facade.
* `apps/desktop/src/features/settings/TampilanPage.tsx` — new **"Saat tombol X diklik"** Select with two options + helper text, autosave on change.
* `apps/desktop/src/i18n/{id,en}/settings.json` — added 4 new keys under `sections.tampilan` (`closeBehavior`, `closeBehaviorHint`, plus `exit/tray/exitHint/trayHint` labels).

### Tests

* **5 new Rust unit tests** in `commands/close_behavior.rs` (default, parse known values, parse unknown falls back to Exit, serde round-trip, `as_str` stability).
* **5 new Vitest tests** in `apps/desktop/tests/unit/closeBehavior.test.ts` covering the browser-mock round trip + `forceQuit` no-op.

Verified: `pnpm lint && pnpm typecheck && pnpm i18n:lint && pnpm test` (134 frontend tests pass) + `cargo fmt --check src/lib.rs src/commands/close_behavior.rs src/commands/mod.rs && cargo clippy --all-targets --all-features -- -D warnings && cargo test --lib` (all green).

## Review & Testing Checklist for Human

This is a **YELLOW** risk PR — it adds platform-level shutdown logic and a system tray. The Linux runners can compile the code but cannot exercise the Windows-specific zombie-process fix; that needs a Windows installer build before final verification.

- [ ] **(Windows only)** Install the next `v1.0.x` build, leave default setting, click X. Confirm `PerpustakaanOffline.exe` disappears from Task Manager within ~5 seconds.
- [ ] **(Windows only)** Switch Setting → Tampilan → "Saat tombol X diklik" to **"Minimize ke system tray"**. Click X. Confirm the window hides and a tray icon is visible in the notification area; left-clicking the tray icon restores the window; "Keluar" from the tray menu fully terminates the process.
- [ ] (Any platform) Open Setting → Tampilan, switch the new option, restart the app, confirm the chosen value is persisted across restarts.
- [ ] Sanity check: opening / closing the **manual** window does not accidentally hide the main window in tray mode (the close-event handler scopes itself to `MAIN_WINDOW_LABEL` only).

### Notes

* The tray icon is **always** built at setup, regardless of the user's current preference, so toggling to tray mode after a fresh install does not require a restart.
* The `force_quit` command is exposed to the frontend in case a future "File → Keluar" menu wants to use the same hard-exit guarantee. Not wired into UI yet.
* Linked bug entry will move from **OPEN → IN_PR** in `docs/bugs/PROGRESS.md` once PR #54 (the bug backlog itself) is merged into main; until then this branch cannot edit those files without conflicting with #54.
* Related branches still open for review: PR #55, #56, #57, #58, #59, #60, #61, #62 (BUG-001..007 + BUG-009/010 manual UX). After all merge + this one merges, ready for `v1.0.1` tag.
