### PR TITLE
chore(release): bump versions to 1.0.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2774,7 +2774,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bcrypt",
  "chrono",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.0"
+version = "1.0.1"
 description = "Perpustakaan Offline v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanOffline",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/apps/manual/package.json
+++ b/apps/manual/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perpustakaan/manual",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generator HTML untuk Buku Manual Perpustakaan Offline (revisi #4)",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Perpustakaan Offline v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/shared",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary

Bumps the workspace version metadata from `1.0.0` to `1.0.1` across all packages so the Tauri MSI/NSIS installers built from the upcoming `v1.0.1` git tag carry the correct version number in their filenames and Windows "Apps & features" metadata.

This is a metadata-only release-prep PR. No code changes. The actual v1.0.1 content is the post-v1.0.0 bugfix batch already merged via PR #54-#63 (BUG-001..007, 009..011) — see issue #64 for the handoff.

### Files changed (7)

- `apps/desktop/src-tauri/tauri.conf.json` — drives MSI/NSIS bundle version.
- `apps/desktop/src-tauri/Cargo.toml` — Rust crate version.
- `apps/desktop/src-tauri/Cargo.lock` — kept in sync with Cargo.toml so `cargo check`'s lockfile-validation step doesn't fail on Windows CI.
- `apps/desktop/package.json`, `apps/manual/package.json`, `packages/shared/package.json`, `package.json` (workspace root) — JS workspace versions.

### Why versioning matters here

The Windows CI workflow (`.github/workflows/ci-v2.yml` `build-windows-installer` job) calls `pnpm tauri:build`, which produces `PerpustakaanOffline_<version>_x64-setup.exe` and `PerpustakaanOffline_<version>_x64_en-US.msi`. The `<version>` token is read from `tauri.conf.json` — if we tagged `v1.0.1` without bumping, end users would download files labelled `1.0.0` from a `v1.0.1` Release page, which is confusing and breaks audit trails.

## Review & Testing Checklist for Human

Risk: green — pure version-string bump, no code logic touched, all 7 changes are mechanical.

- [ ] Confirm the diff is exactly seven `1.0.0 → 1.0.1` substitutions and nothing else.
- [ ] After merge, watch the v1.0.1 tag-trigger CI run produce installer artefacts with `1.0.1` in the filename.

### Notes

- Once this PR is merged into main, the next step is `git tag -a v1.0.1 -m "..."` from main + `git push origin v1.0.1`. The tag-push triggers `build-windows-installer` (windows-latest) → `release-v2` (uploads `.msi`/`.exe` to a new GitHub Release at `https://github.com/alviarts/perpustakaan-offline/releases/tag/v1.0.1`).
- `pnpm-lock.yaml` does **not** need to be regenerated — it pins external dependency versions, not the workspace package versions.
- Did NOT touch `docs/bugs/PROGRESS.md` or any of the bug entries in this PR — keeping it scoped to release plumbing only.
