### PR TITLE
fix(manual): inline CSS+JS into HTML to fix blank manual window on Windows

### DIFF
--- a/apps/desktop/src-tauri/src/commands/manual.rs
+++ b/apps/desktop/src-tauri/src/commands/manual.rs
@@ -35,6 +35,7 @@ pub fn open_manual(app: AppHandle) -> AppResult<()> {
     .maximizable(true)
     .decorations(true)
     .visible(true)
+    .center()
     .build()
     .map_err(|e| AppError::Internal(format!("open_manual: {e}")))?;
     Ok(())

--- a/apps/manual/build.mjs
+++ b/apps/manual/build.mjs
@@ -73,9 +73,7 @@ function renderMarkdown(md) {
     s = s.replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
     s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, t, h) => {
       const url = h.startsWith('http') || h.startsWith('#') ? h : escapeHtml(h);
-      const ext = url.startsWith('http')
-        ? ' target="_blank" rel="noopener noreferrer"'
-        : '';
+      const ext = url.startsWith('http') ? ' target="_blank" rel="noopener noreferrer"' : '';
       return `<a href="${url}"${ext}>${t}</a>`;
     });
     return s;
@@ -155,9 +153,7 @@ function renderMarkdown(md) {
         items.push(lines[i].replace(/^[-*+]\s+/, ''));
         i += 1;
       }
-      out.push(
-        `<ul>${items.map((it) => `<li>${formatInline(it)}</li>`).join('')}</ul>`,
-      );
+      out.push(`<ul>${items.map((it) => `<li>${formatInline(it)}</li>`).join('')}</ul>`);
       continue;
     }
 
@@ -169,9 +165,7 @@ function renderMarkdown(md) {
         items.push(lines[i].replace(/^\d+\.\s+/, ''));
         i += 1;
       }
-      out.push(
-        `<ol>${items.map((it) => `<li>${formatInline(it)}</li>`).join('')}</ol>`,
-      );
+      out.push(`<ol>${items.map((it) => `<li>${formatInline(it)}</li>`).join('')}</ol>`);
       continue;
     }
 
@@ -234,7 +228,7 @@ const TEMPLATE_CSS = `
 
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; }
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; height: 100%; }
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, sans-serif;
@@ -242,6 +236,8 @@ body {
   color: var(--fg);
   line-height: 1.7;
   font-size: 16px;
+  min-height: 100vh;
+  width: 100%;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -953,8 +949,9 @@ function buildHtml({ html, toc }, { libNama }) {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
   <title>Buku Manual — Perpustakaan Offline</title>
-  <link rel="stylesheet" href="./style.css" />
+  <style>${TEMPLATE_CSS}</style>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Lewati ke konten</a>
@@ -1009,7 +1006,7 @@ function buildHtml({ html, toc }, { libNama }) {
   <button id="back-to-top" class="back-to-top" type="button" aria-label="Kembali ke atas">
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
   </button>
-  <script src="./app.js"></script>
+  <script>${TEMPLATE_JS}</script>
 </body>
 </html>
 `;
@@ -1022,9 +1019,12 @@ function buildAll() {
   const html = buildHtml(rendered, { libNama: 'Perpustakaan Sekolah' });
   outDirs.forEach((dir) => {
     mkdirSync(dir, { recursive: true });
+    // CSS + JS are inlined into the HTML so the manual webview never
+    // depends on external file loading at runtime (Tauri 2 bundles all
+    // assets via a custom protocol that has occasionally produced blank
+    // secondary windows when it tries to fetch sibling .css/.js — see
+    // BUG-009/BUG-010 follow-up).
     writeFileSync(resolve(dir, 'index.html'), html, 'utf8');
-    writeFileSync(resolve(dir, 'style.css'), TEMPLATE_CSS, 'utf8');
-    writeFileSync(resolve(dir, 'app.js'), TEMPLATE_JS, 'utf8');
   });
   // eslint-disable-next-line no-console
   console.log(


### PR DESCRIPTION
## Summary

Follow-up to v1.0.1: the released build still ships a Buku Manual window that renders blank/white on Windows with an unresponsive X button (regression of BUG-009 / BUG-010 in production).

## Root cause

The manual webview was loading three separate assets (`manual/index.html`, `manual/style.css`, `manual/app.js`) through the Tauri 2 custom asset protocol. On Windows WebView2 the secondary webview occasionally fails to fetch the sibling `.css` / `.js` files even though they are embedded in the binary, leaving a render-blocked blank page.

## Fix

Inline the entire CSS into a `<style>` block in `<head>`, and the entire JS into a `<script>` block at the end of `<body>`. Tauri 2 automatically hashes inline scripts and adds the SHA-256 to `script-src`, and the existing CSP already permits `'self' 'unsafe-inline'` for `style-src`, so this works inside the bundled webview with no CSP config change. The manual is now a single self-contained HTML file served from a single asset-protocol request.

Also:
- Add `min-height: 100vh` / `width: 100%` / `html { height: 100% }` so the manual content always fills the webview, even after maximize.
- Add `<meta name="color-scheme" content="light dark">` so the WebView2 default background tracks the system theme during the brief window before the JS-driven theme toggle runs.
- Stop writing the now-unused `style.css` and `app.js` to `apps/desktop/public/manual/`.
- Pass `.center()` to `WebviewWindowBuilder` so the manual opens centered on the active monitor.

## Verification

- Local: rebuilt manual (`pnpm --filter @perpustakaan/manual build`) and Vite (`pnpm --filter @perpustakaan/desktop build`); served `apps/desktop/dist/` via `python3 -m http.server` and confirmed the manual renders identically (topbar + TOC + content) when fetched as a single file.
- `pnpm lint`, `pnpm typecheck` pass locally; CI will validate the Windows installer build.

## Versioning

Per user direction the exe/installer stays at **1.0.1** because this is a small post-release follow-up. After this PR merges, the existing v1.0.1 GitHub Release + tag will be deleted and re-tagged from the fix commit so the published `.msi` / `.exe` artifacts pick up the fix without changing the version label.