### PR TITLE
feat(backup): cron-like auto-backup scheduler runner

### DIFF
--- a/apps/desktop/src-tauri/src/commands/backup_runner.rs
+++ b/apps/desktop/src-tauri/src/commands/backup_runner.rs
@@ -1,0 +1,369 @@
+//! Cron-like runner that triggers automatic backups based on the schedule
+//! stored in the `settings` table (PR-6).
+//!
+//! The runner is a plain `std::thread` background loop that ticks every 60s
+//! (matching the granularity of standard 5-field cron). On each tick it:
+//!
+//! 1. Reads the current schedule via `commands::backup::backup_schedule_get`.
+//! 2. Calls the pure helper [`should_run_now`] to decide whether a backup is
+//!    due. The helper compares against the stored `last_run` timestamp so a
+//!    single cron tick never fires twice within the same minute even if the
+//!    loop overshoots slightly.
+//! 3. If due, ensures `<app_data_dir>/backups/` exists, calls
+//!    `backup::backup_create_at`, and persists the new `last_run` back into
+//!    the `settings` table so subsequent ticks (and the UI's "Terakhir
+//!    berjalan" indicator) see the update.
+//!
+//! No Tauri command is exported from this module — the only public surface
+//! the rest of the crate uses is [`spawn_backup_scheduler`] (called once
+//! during `tauri::Builder::setup`) and [`should_run_now`] (used by tests).
+//! Manual `backup_create` invocations are unaffected because they target a
+//! user-picked directory that's disjoint from the auto-backup folder.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use chrono::{DateTime, Datelike, Local, NaiveDateTime, TimeZone, Timelike};
+use tauri::Manager;
+
+use crate::commands::backup::{backup_create_at, BackupSchedule};
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+/// Format string used when persisting `backup.schedule.last_run` to the
+/// settings table. ISO-8601-ish, no timezone, second precision — matches
+/// what the existing UI already renders verbatim.
+pub const LAST_RUN_FMT: &str = "%Y-%m-%d %H:%M:%S";
+
+/// Parse a `last_run` settings value back into a `DateTime<Local>`. Returns
+/// `None` if the string is empty / malformed; callers treat that as "never
+/// ran" which means the next matching tick will fire.
+pub fn parse_last_run(s: &str) -> Option<DateTime<Local>> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    NaiveDateTime::parse_from_str(trimmed, LAST_RUN_FMT)
+        .ok()
+        .and_then(|naive| Local.from_local_datetime(&naive).single())
+}
+
+/// Pure-logic "should we run a backup at `now`?" check. Extracted so the
+/// scheduler core can be unit-tested without touching the filesystem, the
+/// DB, or a Tauri AppHandle.
+pub fn should_run_now(
+    schedule: &BackupSchedule,
+    now: DateTime<Local>,
+    last_run: Option<DateTime<Local>>,
+) -> bool {
+    if !schedule.enabled {
+        return false;
+    }
+    let parts: Vec<&str> = schedule.cron.split_whitespace().collect();
+    if parts.len() != 5 {
+        return false;
+    }
+    let (min_f, hour_f, dom_f, mon_f, dow_f) = (parts[0], parts[1], parts[2], parts[3], parts[4]);
+
+    if !cron_field_matches(min_f, now.minute())
+        || !cron_field_matches(hour_f, now.hour())
+        || !cron_field_matches(dom_f, now.day())
+        || !cron_field_matches(mon_f, now.month())
+        || !cron_field_matches(dow_f, now.weekday().num_days_from_sunday())
+    {
+        return false;
+    }
+
+    // Dedupe within the same minute slot — even if the runner ticks twice
+    // inside the matching minute (e.g. the OS scheduler woke us 59s + 1s
+    // apart) we only fire once.
+    if let Some(prev) = last_run {
+        let now_slot = minute_slot(now);
+        let prev_slot = minute_slot(prev);
+        if prev_slot >= now_slot {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn minute_slot(t: DateTime<Local>) -> DateTime<Local> {
+    t.with_second(0)
+        .and_then(|d| d.with_nanosecond(0))
+        .unwrap_or(t)
+}
+
+/// Tiny in-house cron field matcher. Supports `*`, single values, ranges
+/// `M-N`, comma lists `A,B,C`, and the `*/N` step form. Anything else
+/// returns `false` and the field is treated as "never matches" — better to
+/// silently no-op than panic on the user's typo.
+fn cron_field_matches(field: &str, value: u32) -> bool {
+    if field == "*" {
+        return true;
+    }
+    field.split(',').any(|raw| {
+        let term = raw.trim();
+        if let Some(rest) = term.strip_prefix("*/") {
+            return rest
+                .parse::<u32>()
+                .ok()
+                .filter(|step| *step > 0)
+                .map(|step| value % step == 0)
+                .unwrap_or(false);
+        }
+        if let Some((lhs, rhs)) = term.split_once('-') {
+            return match (lhs.parse::<u32>(), rhs.parse::<u32>()) {
+                (Ok(lo), Ok(hi)) => lo <= value && value <= hi,
+                _ => false,
+            };
+        }
+        term.parse::<u32>().map(|n| n == value).unwrap_or(false)
+    })
+}
+
+/// Reads the schedule, decides whether to run, and on success writes a new
+/// `last_run` back into the settings table. Public-in-crate so future
+/// integration tests can drive a single tick deterministically.
+pub fn run_tick_once(
+    state: &AppState,
+    backup_dir: &std::path::Path,
+    db_src: &std::path::Path,
+    now: DateTime<Local>,
+) -> AppResult<bool> {
+    let (schedule, last_run) = read_schedule_and_last_run(state)?;
+    if !should_run_now(&schedule, now, last_run) {
+        return Ok(false);
+    }
+
+    if !backup_dir.exists() {
+        std::fs::create_dir_all(backup_dir).map_err(|e| AppError::Internal(e.to_string()))?;
+    }
+    let stamp = now.format("%Y%m%d-%H%M%S").to_string();
+    let _result = backup_create_at(db_src, backup_dir, &stamp)?;
+
+    let stamp_str = now.format(LAST_RUN_FMT).to_string();
+    write_last_run(state, &stamp_str)?;
+
+    Ok(true)
+}
+
+fn read_schedule_and_last_run(
+    state: &AppState,
+) -> AppResult<(BackupSchedule, Option<DateTime<Local>>)> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let read = |key: &str| -> Option<String> {
+        conn.query_row("SELECT value FROM settings WHERE key = ?1", [key], |r| {
+            r.get::<_, String>(0)
+        })
+        .ok()
+    };
+
+    let enabled = read("backup.schedule.enabled")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+    let cron = read("backup.schedule.cron").unwrap_or_else(|| "0 2 * * *".to_string());
+    let last_run_raw = read("backup.schedule.last_run");
+    let last_run = last_run_raw.as_deref().and_then(parse_last_run);
+
+    Ok((
+        BackupSchedule {
+            enabled,
+            cron,
+            last_run: last_run_raw,
+        },
+        last_run,
+    ))
+}
+
+fn write_last_run(state: &AppState, stamp: &str) -> AppResult<()> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES ('backup.schedule.last_run', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
+        [stamp],
+    )
+    .map_err(AppError::from)?;
+    Ok(())
+}
+
+/// Resolve `<app_data_dir>/backups/` — the default landing zone for files
+/// produced by the auto-backup runner. The directory is created lazily
+/// inside `run_tick_once` so a freshly-installed app doesn't pre-create it
+/// before the user has even opted in.
+fn resolve_default_backup_dir(app: &tauri::AppHandle) -> AppResult<PathBuf> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(base.join("backups"))
+}
+
+/// Spawn the background runner. Idempotent in the sense that callers should
+/// only invoke this once per `tauri::Builder::setup`; the function does not
+/// guard against multiple invocations because the existing setup is single-
+/// threaded.
+pub fn spawn_backup_scheduler(app: &tauri::AppHandle) {
+    let app_handle = app.clone();
+    let busy = Arc::new(AtomicBool::new(false));
+    thread::Builder::new()
+        .name("backup-scheduler".into())
+        .spawn(move || {
+            // Initial grace period so app startup doesn't immediately do IO.
+            thread::sleep(Duration::from_secs(30));
+            loop {
+                if busy
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    if let Err(err) = tick(&app_handle) {
+                        log::error!("backup-scheduler tick failed: {err}");
+                    }
+                    busy.store(false, Ordering::SeqCst);
+                }
+                thread::sleep(Duration::from_secs(60));
+            }
+        })
+        .expect("spawn backup-scheduler thread");
+}
+
+fn tick(app: &tauri::AppHandle) -> AppResult<()> {
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let backup_dir = resolve_default_backup_dir(app)?;
+    let db_src = crate::db::resolve_db_path(app)?;
+    let did_run = run_tick_once(&state, &backup_dir, &db_src, Local::now())?;
+    if did_run {
+        log::info!(
+            "backup-scheduler: wrote auto-backup to {}",
+            backup_dir.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(s: &str) -> DateTime<Local> {
+        let naive = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").unwrap();
+        Local.from_local_datetime(&naive).single().unwrap()
+    }
+
+    fn schedule(cron: &str) -> BackupSchedule {
+        BackupSchedule {
+            enabled: true,
+            cron: cron.into(),
+            last_run: None,
+        }
+    }
+
+    #[test]
+    fn should_run_skips_when_disabled() {
+        let mut s = schedule("0 2 * * *");
+        s.enabled = false;
+        assert!(!should_run_now(&s, at("2026-05-04 02:00:30"), None));
+    }
+
+    #[test]
+    fn should_run_skips_when_cron_invalid() {
+        let s = schedule("not a cron");
+        assert!(!should_run_now(&s, at("2026-05-04 02:00:30"), None));
+    }
+
+    #[test]
+    fn should_run_fires_at_matching_minute() {
+        let s = schedule("0 2 * * *");
+        // First time the runner sees the matching minute.
+        assert!(should_run_now(&s, at("2026-05-04 02:00:00"), None));
+        assert!(should_run_now(&s, at("2026-05-04 02:00:45"), None));
+    }
+
+    #[test]
+    fn should_run_skips_non_matching_minute() {
+        let s = schedule("0 2 * * *");
+        assert!(!should_run_now(&s, at("2026-05-04 02:01:30"), None));
+        assert!(!should_run_now(&s, at("2026-05-04 03:00:30"), None));
+    }
+
+    #[test]
+    fn should_run_dedupes_within_same_minute_slot() {
+        let s = schedule("0 2 * * *");
+        let now = at("2026-05-04 02:00:30");
+        let last = at("2026-05-04 02:00:05");
+        assert!(!should_run_now(&s, now, Some(last)));
+    }
+
+    #[test]
+    fn should_run_fires_again_on_next_match() {
+        let s = schedule("0 2 * * *");
+        let last = at("2026-05-04 02:00:05");
+        let next = at("2026-05-05 02:00:10");
+        assert!(should_run_now(&s, next, Some(last)));
+    }
+
+    #[test]
+    fn should_run_supports_step_minute() {
+        let s = schedule("*/15 * * * *");
+        assert!(should_run_now(&s, at("2026-05-04 03:00:00"), None));
+        assert!(should_run_now(&s, at("2026-05-04 03:15:00"), None));
+        assert!(should_run_now(&s, at("2026-05-04 03:30:00"), None));
+        assert!(!should_run_now(&s, at("2026-05-04 03:01:00"), None));
+        assert!(!should_run_now(&s, at("2026-05-04 03:14:00"), None));
+    }
+
+    #[test]
+    fn should_run_supports_dow_range() {
+        // Every weekday (Mon..Fri) at 02:00.
+        let s = schedule("0 2 * * 1-5");
+        // Sunday 2026-05-03 → don't fire.
+        assert!(!should_run_now(&s, at("2026-05-03 02:00:00"), None));
+        // Monday 2026-05-04 → fire.
+        assert!(should_run_now(&s, at("2026-05-04 02:00:00"), None));
+        // Saturday 2026-05-09 → don't fire.
+        assert!(!should_run_now(&s, at("2026-05-09 02:00:00"), None));
+    }
+
+    #[test]
+    fn should_run_supports_comma_list_hour() {
+        let s = schedule("0 2,14 * * *");
+        assert!(should_run_now(&s, at("2026-05-04 02:00:00"), None));
+        assert!(should_run_now(&s, at("2026-05-04 14:00:00"), None));
+        assert!(!should_run_now(&s, at("2026-05-04 08:00:00"), None));
+    }
+
+    #[test]
+    fn parse_last_run_round_trip() {
+        let now = at("2026-05-04 02:00:00");
+        let stamp = now.format(LAST_RUN_FMT).to_string();
+        let parsed = parse_last_run(&stamp).unwrap();
+        assert_eq!(parsed, now);
+    }
+
+    #[test]
+    fn parse_last_run_handles_blank() {
+        assert!(parse_last_run("").is_none());
+        assert!(parse_last_run("   ").is_none());
+        assert!(parse_last_run("not-a-date").is_none());
+    }
+
+    #[test]
+    fn cron_field_matches_handles_singletons_and_lists() {
+        assert!(cron_field_matches("*", 0));
+        assert!(cron_field_matches("*", 59));
+        assert!(cron_field_matches("0", 0));
+        assert!(!cron_field_matches("0", 1));
+        assert!(cron_field_matches("0,15,30,45", 30));
+        assert!(!cron_field_matches("0,15,30,45", 31));
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod anggota;
 pub mod auth;
 pub mod backup;
+pub mod backup_runner;
 pub mod buku;
 pub mod close_behavior;
 pub mod dashboard;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -92,6 +92,11 @@ pub fn run() {
                 })
                 .build(app)?;
 
+            // PR-6: spawn the backup-scheduler runner. It ticks every 60s,
+            // reads the schedule from settings, and writes auto-backups into
+            // <app_data_dir>/backups/. No-op if the schedule is disabled.
+            commands::backup_runner::spawn_backup_scheduler(app.handle());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src/features/laporan/BackupSubPage.tsx
+++ b/apps/desktop/src/features/laporan/BackupSubPage.tsx
@@ -46,7 +46,11 @@ export function LaporanBackup() {
     try {
       let target: string;
       if (isTauri()) {
-        const picked = await openDialog({ directory: true, multiple: false, title: t('laporan:backup.pickFolder', { defaultValue: 'Pilih folder backup' }) });
+        const picked = await openDialog({
+          directory: true,
+          multiple: false,
+          title: t('laporan:backup.pickFolder', { defaultValue: 'Pilih folder backup' }),
+        });
         if (!picked || Array.isArray(picked)) {
           setBusy(false);
           return;
@@ -146,10 +150,10 @@ export function LaporanBackup() {
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           <div className="grid gap-2 text-sm">
-            <Label className="text-xs uppercase tracking-wider text-muted-foreground">
+            <Label className="text-muted-foreground text-xs uppercase tracking-wider">
               {t('laporan:backup.currentDb', { defaultValue: 'File DB Aktif' })}
             </Label>
-            <code className="overflow-x-auto whitespace-nowrap rounded-md bg-muted px-2 py-1.5 text-xs">
+            <code className="bg-muted overflow-x-auto whitespace-nowrap rounded-md px-2 py-1.5 text-xs">
               {dbPath || '...'}
             </code>
           </div>
@@ -159,7 +163,12 @@ export function LaporanBackup() {
               <FolderOpen className="mr-2 h-4 w-4" />
               {t('laporan:backup.createBtn', { defaultValue: 'Backup Sekarang' })}
             </Button>
-            <Button variant="outline" onClick={handleRestore} disabled={busy} data-testid="backup-restore">
+            <Button
+              variant="outline"
+              onClick={handleRestore}
+              disabled={busy}
+              data-testid="backup-restore"
+            >
               <Upload className="mr-2 h-4 w-4" />
               {t('laporan:backup.restoreBtn', { defaultValue: 'Restore dari File' })}
             </Button>
@@ -170,7 +179,7 @@ export function LaporanBackup() {
               <div className="font-medium text-emerald-700 dark:text-emerald-300">
                 {t('laporan:backup.lastBackup', { defaultValue: 'Backup terakhir' })}
               </div>
-              <div className="mt-1 break-all text-muted-foreground">{lastBackup.path}</div>
+              <div className="text-muted-foreground mt-1 break-all">{lastBackup.path}</div>
               <div className="text-muted-foreground">
                 SHA256: <code className="text-[10px]">{lastBackup.checksum}</code>
               </div>
@@ -189,7 +198,8 @@ export function LaporanBackup() {
           </CardTitle>
           <CardDescription>
             {t('laporan:backup.scheduleHint', {
-              defaultValue: 'Cron 5-field. Devin 12 akan menambahkan runner cron-like.',
+              defaultValue:
+                'Cron 5-field (mis. "0 2 * * *"). Runner berjalan di latar belakang dan menyimpan backup ke folder data aplikasi.',
             })}
           </CardDescription>
         </CardHeader>
@@ -210,7 +220,10 @@ export function LaporanBackup() {
                 </Label>
               </div>
               <div className="grid gap-1.5">
-                <Label htmlFor="cron-input" className="text-xs uppercase tracking-wider text-muted-foreground">
+                <Label
+                  htmlFor="cron-input"
+                  className="text-muted-foreground text-xs uppercase tracking-wider"
+                >
                   {t('laporan:backup.cron', { defaultValue: 'Cron Expression' })}
                 </Label>
                 <Input
@@ -221,11 +234,12 @@ export function LaporanBackup() {
                   className="font-mono text-sm"
                   data-testid="schedule-cron"
                 />
-                <p className="text-xs text-muted-foreground">{describeCron(cronInput)}</p>
+                <p className="text-muted-foreground text-xs">{describeCron(cronInput)}</p>
               </div>
               {schedule.lastRun && (
-                <div className="text-xs text-muted-foreground">
-                  {t('laporan:backup.lastRun', { defaultValue: 'Terakhir berjalan' })}: {schedule.lastRun}
+                <div className="text-muted-foreground text-xs">
+                  {t('laporan:backup.lastRun', { defaultValue: 'Terakhir berjalan' })}:{' '}
+                  {schedule.lastRun}
                 </div>
               )}
               <Button onClick={handleScheduleSave} disabled={saving} data-testid="schedule-save">

--- a/apps/desktop/src/i18n/en/laporan.json
+++ b/apps/desktop/src/i18n/en/laporan.json
@@ -63,7 +63,7 @@
     "restoreFailed": "Restore failed",
     "lastBackup": "Last backup",
     "scheduleTitle": "Auto Backup Schedule",
-    "scheduleHint": "5-field cron. Session 12 adds the cron-like runner.",
+    "scheduleHint": "5-field cron (e.g. \"0 2 * * *\"). The runner ticks in the background and writes backups to the app data folder.",
     "enableSchedule": "Enable schedule",
     "cron": "Cron Expression",
     "scheduleSave": "Save Schedule",

--- a/apps/desktop/src/i18n/id/laporan.json
+++ b/apps/desktop/src/i18n/id/laporan.json
@@ -63,7 +63,7 @@
     "restoreFailed": "Restore gagal",
     "lastBackup": "Backup terakhir",
     "scheduleTitle": "Jadwal Backup Otomatis",
-    "scheduleHint": "Cron 5-field. Devin 12 akan menambahkan runner cron-like.",
+    "scheduleHint": "Cron 5-field (mis. \"0 2 * * *\"). Runner berjalan di latar belakang dan menyimpan backup ke folder data aplikasi.",
     "enableSchedule": "Aktifkan jadwal otomatis",
     "cron": "Cron Expression",
     "scheduleSave": "Simpan Jadwal",


### PR DESCRIPTION
## Summary

Adds the cron-like background runner that the existing Backup tab schedule was implicitly waiting for (PR-6 in the migration-v2 deferred-feature set). Previously, schedules saved via `backup_schedule_set` were persisted to the `settings` table but no backend code ever read them and triggered an actual backup — the form silently did nothing. This PR plugs that gap.

**Backend (Rust)**
- New `src-tauri/src/commands/backup_runner.rs` module split into a pure-logic core + an IO core + a thread-spawn entry point so the cron arithmetic can be unit-tested without an `AppHandle`.
  - `should_run_now(&schedule, now, last_run) -> bool`: pure check that decodes a 5-field cron string (`*`, single values, `M-N` ranges, `*/N` steps, and comma lists like `0,15,30,45`), then dedupes against the previous run by minute slot so a single matching minute can never fire two backups even if the runner loop overshoots slightly.
  - `run_tick_once(&state, &backup_dir, &db_src, now)`: reads the schedule + `backup.schedule.last_run` from `settings`, asks `should_run_now`, and if due, ensures `<app_data_dir>/backups/` exists, calls the existing `backup::backup_create_at` (so we re-use the SHA-256 sidecar + filename convention from PR-23), then writes the new `last_run` timestamp back.
  - `spawn_backup_scheduler(app)`: spawns a named `std::thread` that ticks every 60s after a 30s startup grace period. An `AtomicBool` guard makes overlapping ticks coalesce into one in case the OS scheduler ever wakes us back-to-back.
- Wired into `tauri::Builder::setup` once, right after the tray is built. No new commands are exported — the runner is purely a side-effecting background task.
- 12 inline cargo tests cover the cron field matcher edge cases (steps, ranges, lists, day-of-week, comma hours), the minute-slot dedupe, the disabled / invalid-cron short-circuits, and the `parse_last_run` round-trip + blank handling.

**Frontend**
- The Backup tab already renders `schedule.lastRun` so the runner's writes show up automatically in the UI under "Terakhir berjalan".
- Drop the placeholder `Devin 12 akan menambahkan runner cron-like` copy from `backup.scheduleHint` (id + en) and replace it with a real explanation that points users at the app data folder. `pnpm i18n:lint` reports parity OK.

**Tests + quality gates**
- Cargo: 37 tests pass (was 25 baseline + 12 new).
- Cargo clippy `--all-targets -- -D warnings`: clean.
- `pnpm typecheck`, `pnpm i18n:lint`, `pnpm --filter @perpustakaan/desktop lint`, and `pnpm --filter @perpustakaan/desktop test -- --run` (165 tests): all green.

## Review & Testing Checklist for Human

- [ ] In the running app, set a schedule of `*/2 * * * *` (every 2 minutes), enable it, save, and verify a `perpustakaan-<stamp>.db` + `.db.sha256` pair appears under `<app data dir>/backups/` within ~3 minutes. The "Terakhir berjalan" line should also update.
- [ ] Disable the schedule and confirm no further files appear.
- [ ] Verify a malformed cron value (e.g. `not a cron`) is rejected at save-time by the existing `backup_schedule_set` validator (5-field check) — the runner additionally short-circuits to no-op if it ever sees an invalid value at tick-time.
- [ ] Confirm the runner's auto-backups land in the app data dir, not the user-picked dir from the manual `Backup Sekarang` button (these flows are intentionally disjoint).

### Notes

- The runner uses `std::thread` rather than a tokio runtime to avoid pulling tokio into the dependency graph. Granularity is 60s which matches standard 5-field cron — sub-minute schedules are not supported by design.
- Non-existent target dir is handled by lazily creating `<app_data_dir>/backups/` inside `run_tick_once`, so a freshly-installed app doesn't pre-create the folder before the user has even opted in.
- Independent of PR-7 (release workflow) and PR-5 (forgot password) — branched directly from `main`. No conflicts expected.
