### PR TITLE
style(rust): apply rustfmt to commands/buku.rs and db/mod.rs

### DIFF
--- a/apps/desktop/src-tauri/src/commands/buku.rs
+++ b/apps/desktop/src-tauri/src/commands/buku.rs
@@ -628,8 +628,8 @@ mod tests {
     #[test]
     fn buku_create_seeds_zero_eksemplar_for_catalog_only_entry() {
         let mut conn = setup_db();
-        let buku = buku_create_inner(&mut conn, &make_input("B0001", Some(0)))
-            .expect("create buku");
+        let buku =
+            buku_create_inner(&mut conn, &make_input("B0001", Some(0))).expect("create buku");
         assert_eq!(buku.jumlah_eksemplar, 0);
         assert_eq!(count_eksemplar(&conn, buku.id), 0);
     }
@@ -637,8 +637,8 @@ mod tests {
     #[test]
     fn buku_create_seeds_one_eksemplar_with_zero_padded_kode() {
         let mut conn = setup_db();
-        let buku = buku_create_inner(&mut conn, &make_input("B0001", Some(1)))
-            .expect("create buku");
+        let buku =
+            buku_create_inner(&mut conn, &make_input("B0001", Some(1))).expect("create buku");
         assert_eq!(buku.jumlah_eksemplar, 1);
         assert_eq!(list_kode_eksemplar(&conn, buku.id), vec!["B0001-01"]);
     }
@@ -646,8 +646,8 @@ mod tests {
     #[test]
     fn buku_create_seeds_five_sequential_eksemplar() {
         let mut conn = setup_db();
-        let buku = buku_create_inner(&mut conn, &make_input("B0042", Some(5)))
-            .expect("create buku");
+        let buku =
+            buku_create_inner(&mut conn, &make_input("B0042", Some(5))).expect("create buku");
         assert_eq!(buku.jumlah_eksemplar, 5);
         assert_eq!(
             list_kode_eksemplar(&conn, buku.id),
@@ -664,8 +664,8 @@ mod tests {
     #[test]
     fn buku_create_seeded_eksemplar_are_all_tersedia() {
         let mut conn = setup_db();
-        let buku = buku_create_inner(&mut conn, &make_input("B0007", Some(3)))
-            .expect("create buku");
+        let buku =
+            buku_create_inner(&mut conn, &make_input("B0007", Some(3))).expect("create buku");
         let tersedia: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM eksemplar \
@@ -682,8 +682,7 @@ mod tests {
         // BUG-001: when frontend omits jumlahEksemplar (undefined → None),
         // the buku still gets one eksemplar so it can be borrowed.
         let mut conn = setup_db();
-        let buku = buku_create_inner(&mut conn, &make_input("B0010", None))
-            .expect("create buku");
+        let buku = buku_create_inner(&mut conn, &make_input("B0010", None)).expect("create buku");
         assert_eq!(buku.jumlah_eksemplar, 1);
         assert_eq!(count_eksemplar(&conn, buku.id), 1);
     }
@@ -691,8 +690,7 @@ mod tests {
     #[test]
     fn buku_create_rejects_duplicate_kode_buku() {
         let mut conn = setup_db();
-        buku_create_inner(&mut conn, &make_input("B0001", Some(1)))
-            .expect("create first buku");
+        buku_create_inner(&mut conn, &make_input("B0001", Some(1))).expect("create first buku");
         let err = buku_create_inner(&mut conn, &make_input("B0001", Some(2)))
             .expect_err("duplicate should fail");
         assert!(matches!(err, AppError::Validation(_)));

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -281,11 +281,7 @@ const KTA_DEFAULT_LAYOUT_JSON: &str = r##"{
 /// Without this, a fresh install opens "Cetak KTA → Pilih template" with an
 /// empty dropdown and a disabled "Cetak" button (BUG-005).
 fn seed_kta_default_template(conn: &Connection) -> AppResult<()> {
-    let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM kta_templates",
-        [],
-        |row| row.get(0),
-    )?;
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM kta_templates", [], |row| row.get(0))?;
     if count > 0 {
         return Ok(());
     }
@@ -430,16 +426,12 @@ mod tests {
         let kodes: Vec<&str> = rows.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(
             kodes,
-            vec![
-                "000", "100", "200", "300", "400", "500", "600", "700", "800", "900",
-            ],
+            vec!["000", "100", "200", "300", "400", "500", "600", "700", "800", "900",],
         );
         // Spot-check a couple of descriptions to guard against a future
         // careless edit reordering or rewriting the array.
-        let by_kode: std::collections::HashMap<&str, &str> = rows
-            .iter()
-            .map(|(k, d)| (k.as_str(), d.as_str()))
-            .collect();
+        let by_kode: std::collections::HashMap<&str, &str> =
+            rows.iter().map(|(k, d)| (k.as_str(), d.as_str())).collect();
         assert_eq!(by_kode.get("000").copied(), Some("Karya Umum"));
         assert_eq!(by_kode.get("400").copied(), Some("Bahasa"));
         assert_eq!(by_kode.get("900").copied(), Some("Sejarah & Geografi"));


### PR DESCRIPTION
## Summary

Pure formatting cleanup of two Rust files that had pre-existing `rustfmt` drift since before v1.0.0. **No logic, behavior, or test changes.**

- `apps/desktop/src-tauri/src/commands/buku.rs` — six `let buku = buku_create_inner(...).expect(...)` calls in the test module were broken across two lines; `cargo fmt` wants them compacted onto one or two lines depending on width.
- `apps/desktop/src-tauri/src/db/mod.rs` — three call sites (one `conn.query_row()` block in `seed_kta_default_template`, plus a `vec![...]` and a `.iter().map().collect()` chain inside the DDC seed test) were over-broken across multiple lines.

After this PR, `cargo fmt --all -- --check` is **clean across the entire `src-tauri` crate**, which removes the phantom diff noise that any contributor running fmt-on-save on those two files would otherwise produce.

### Why a separate PR

The previous handoff explicitly flagged: *"PENTING soal `cargo fmt`: ada pre-existing rustfmt drift di `commands/buku.rs` dan `db/mod.rs`. Kalau jalanin `cargo fmt --all`, akan ngubah file di luar scope. Cara aman: `rustfmt <specific-files>` atau `cargo fmt -- --check` per file. Kalau sengaja mau clean up rustfmt drift, bikin PR terpisah."* This PR is exactly that — opened in isolation so the diff is reviewable as pure formatting.

### What changed

- `git diff --stat`:
  ```
  apps/desktop/src-tauri/src/commands/buku.rs | 22 ++++++++++------------
  apps/desktop/src-tauri/src/db/mod.rs        | 16 ++++------------
  2 files changed, 14 insertions(+), 24 deletions(-)
  ```
- Reproduced by:
  ```bash
  rustup default stable                 # rustc 1.95.0 / rustfmt 1.9.0-stable
  rustfmt apps/desktop/src-tauri/src/commands/buku.rs \
          apps/desktop/src-tauri/src/db/mod.rs
  ```
  (deliberately **not** `cargo fmt --all`, to avoid touching anything outside scope).

### CI awareness

The `Rust check` job in `.github/workflows/ci-v2.yml` runs `cargo check --all-targets` + `cargo clippy --all-targets -- -D warnings` but **does not** run `cargo fmt --check`, so this drift was not actively breaking CI. Nothing in this PR changes the workflow surface — both required jobs (`Lint + Typecheck + Unit Test (Node 20)` and `Rust check (Tauri backend)`) are expected to pass on the same code paths as `main`.

### Local quality gates (all clean)

- `cargo fmt --all -- --check` — clean (was: 9 diffs in those 2 files)
- `cargo check --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (no new warnings)
- `cargo test --lib` — **25/25 pass**
- `pnpm typecheck` — clean
- `pnpm --filter @perpustakaan/desktop lint` — clean (`eslint --max-warnings=0`)
- `pnpm --filter @perpustakaan/desktop test -- --run` — **165/165 pass**
- `pnpm i18n:lint` — clean (id ↔ en parity unchanged; no string changes)

## Review & Testing Checklist for Human

Risk: **green** (formatting-only, narrowly scoped to two files, no logic touched).

- [ ] Skim the diff on GitHub and confirm it is purely whitespace — every changed hunk should be `let buku = ...` reflowed or `.query_row()` / `vec![...]` / `.collect()` chains compacted, with no token additions or deletions.
- [ ] Confirm CI's `Rust check` and `Lint + Typecheck + Unit Test` jobs both pass.
- [ ] (Optional) Pull the branch locally and run `cargo fmt --all -- --check` — should report no diffs.

### Notes

- Branch is `devin/1777903912-rustfmt-buku-db`, created off the latest `main` (commit `4ed1398`, tag `v1.0.1`). No conflicts expected with any other open PR.
- I deliberately did **not** run `cargo fmt --all` — only `rustfmt <specific files>` — so this PR cannot drag any other file's formatting along.
- This PR is independent of #67–#76; merge order doesn't matter.
