### PR TITLE
docs: refresh README for v2 stack and drop dead pengembalian i18n key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,52 @@
-# Perpustakaan Offline (SIM-Perpus Reborn)
+# Perpustakaan Offline (SIM-Perpus Reborn) — v2
 
-> Aplikasi **Sistem Informasi Manajemen Perpustakaan** (SIM-Perpus) berbasis Python + SQLite yang berjalan **100% offline** dan dapat dikemas menjadi `.exe` Windows tunggal. Cocok untuk perpustakaan **sekolah / madrasah**.
+> Aplikasi **Sistem Informasi Manajemen Perpustakaan** (SIM-Perpus) berbasis **Tauri 2 + React 18 + TypeScript + SQLite** yang berjalan **100% offline** dan dapat dikemas menjadi **MSI / NSIS installer** Windows, `.deb` Linux, atau `.app` macOS. Cocok untuk perpustakaan **sekolah / madrasah**.
 
 Inspirasi: SIM-Perpus v.1.2.2 (Excel + VBA) oleh **Kang Sur**, ditulis ulang menjadi aplikasi desktop modern dengan tetap mempertahankan alur kerja yang familiar bagi pustakawan sekolah.
+
+> **Catatan:** v1 (Python + CustomTkinter, sampai `v0.6.2`) masih tersedia sebagai referensi historis di `src/perpustakaan/` plus workflow `ci-legacy-v1.yml.disabled`, tetapi sudah **tidak di-maintain**. Pengembangan aktif ada di `apps/desktop/` (v2).
 
 ---
 
 ## Fitur Utama
 
-- **Login multi-user** (admin + pustakawan) dengan hashing bcrypt
-- **Dashboard** real-time: total anggota, buku, dipinjam, dikembalikan, terlambat, hilang
-- **Master Data Anggota**: input/edit/hapus/import Excel, foto KTA, sort, **Naik Kelas**, **Surat Bebas Pustaka**
-- **Master Data Buku**: input/edit/hapus/import Excel, cover, klasifikasi DDC, sort, **Cetak Label & Barcode** per eksemplar, transfer penerbit (dedupe)
-- **Transaksi**: Kunjungan, Peminjaman, Pengembalian, Buku Hilang — semua mendukung **barcode scanner**
-- **Laporan**: Backup/Reset DB, **Grafik Kunjungan** (tahunan/bulanan), **Top Peminjam**, **Top Buku**, **Kas** (otomatis dari denda + manual)
-- **Setting**: identitas perpustakaan + logo, teks kartu anggota, jatuh tempo, denda, kategori, kelas
-- **Bilingual**: Indonesia / English (toggle di Settings)
-- **Export Google Sheets** (manual): push semua data ke spreadsheet pribadi user di Google Drive
-- **Build .exe Windows** dengan satu klik (`build.bat`)
+- **Login multi-user** (admin + pustakawan + role custom) dengan hashing bcrypt
+- **Lupa password offline** via security question (PR #74)
+- **Dashboard** real-time: total anggota, total buku (titles + eksemplar), buku dipinjam, kunjungan hari ini, distribusi DDC (donut + bar), kunjungan harian (line)
+- **Master Data Anggota**: input/edit/hapus, **import/export Excel**, foto profil (file picker), filter & sort, **Naik Kelas batch**, **Surat Bebas Pustaka**, cetak KTA per anggota / batch
+- **Master Data Buku**: input/edit/hapus, **import Excel**, cover (file picker), klasifikasi DDC (seeded), filter & sort, **cetak label & barcode** per eksemplar
+- **Transaksi**: Kunjungan, Peminjaman, Pengembalian, Buku Hilang — lengkap dengan **riwayat per anggota** dan dukungan barcode scanner
+- **Laporan**: Backup manual + **scheduler cron-like** (PR #75), Top Peminjam, Top Buku, **Grafik Kunjungan** (harian / bulanan / tahunan), **Kas** (otomatis dari denda + entry manual)
+- **Settings (12 tab)**: Identitas + logo, Akun + security question, Hak Akses (RBAC), Aturan Peminjaman, Tampilan (theme + bahasa), Master Data (kelas / jurusan / agama / kategori / penerbit / DDC override), Backup, Sinkronisasi, Audit Log, Manual book inline (PR #76), Tentang
+- **Bilingual full**: Indonesia / English — toggle live di Settings → Tampilan, parity dijaga oleh `pnpm i18n:lint`
+- **Header tools**: Ctrl+K **global search palette** (anggota + buku + peminjaman, PR #72), bantuan inline, theme toggle
+- **System tray** + close-behavior setting (minimize-to-tray vs close)
+- **Build native** untuk Windows (MSI + NSIS), Linux (.deb), macOS (.app) lewat `tauri build`
 
 ---
 
-## Persyaratan
+## Stack Tech
 
-- Python **3.11+**
-- Windows / Linux / macOS untuk pengembangan
-- Windows untuk build `.exe` final (PyInstaller cross-build tidak didukung)
-- (Opsional) **IDAutomation HC39M Code 39** font untuk render barcode di label cetak
+- **Backend:** Rust 1.95.0 + Tauri 2.11 + rusqlite 0.32 + bcrypt 0.16 + sha2 + chrono
+- **Frontend:** React 18 + TypeScript 5 + Vite 5 + Tailwind 3 + shadcn/ui (Radix primitives) + Zustand + TanStack Router (file-based) + React Hook Form + Vitest
+- **i18n:** i18next + react-i18next, locale di `apps/desktop/src/i18n/{id,en}/*.json`
+- **Charts:** Recharts (dashboard + laporan)
+- **Excel:** `xlsx` (SheetJS)
+- **Markdown:** `react-markdown` + `remark-gfm` (manual book inline)
+- **Workspace:** pnpm 9 monorepo (`apps/desktop/`, `apps/desktop/src-tauri/`, `apps/manual/`, `packages/shared/`)
+- **Identifier:** `id.alviarts.perpustakaan` (`apps/desktop/src-tauri/tauri.conf.json`)
+
+---
+
+## Persyaratan Development
+
+- **Node.js** ≥ 20.0.0
+- **pnpm** ≥ 9.0.0 (`corepack enable && corepack prepare pnpm@9.15.1 --activate`)
+- **Rust** stable ≥ 1.95.0 (`rustup update stable`) — required for `edition2024` di transitive deps
+- **OS-specific Tauri prereqs:**
+  - **Linux (Ubuntu 22.04+):** `sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev pkg-config`
+  - **macOS:** Xcode Command Line Tools (`xcode-select --install`)
+  - **Windows:** WebView2 (sudah ada di Windows 11), [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
 
 ---
 
@@ -37,49 +57,62 @@ Inspirasi: SIM-Perpus v.1.2.2 (Excel + VBA) oleh **Kang Sur**, ditulis ulang men
 git clone https://github.com/alviarts/perpustakaan-offline.git
 cd perpustakaan-offline
 
-# 2. Buat virtual environment
-python -m venv .venv
-# Windows
-.venv\Scripts\activate
-# Linux / macOS
-source .venv/bin/activate
+# 2. Install dependencies (semua workspace)
+pnpm install --frozen-lockfile
 
-# 3. Install dependencies
-pip install -r requirements.txt
-
-# 4. Jalankan aplikasi (DB + seed data otomatis dibuat saat pertama jalan)
-python -m perpustakaan
-
-# Atau dengan demo data (5 anggota + 10 buku + 2 peminjaman aktif)
-# berguna untuk training / demo tanpa input data manual
-python -m perpustakaan --demo
+# 3. Jalankan dev server (hot reload + Tauri devtools)
+pnpm tauri:dev
 ```
 
-Database (SQLite) akan dibuat otomatis di:
+`pnpm tauri:dev` akan:
+1. Bundle frontend Vite di `http://localhost:1420`
+2. Compile backend Rust + Tauri runtime
+3. Buka window aplikasi langsung — DB SQLite + seed data otomatis dibuat saat pertama jalan
 
-- **Windows:** `%APPDATA%\PerpustakaanOffline\perpustakaan.db`
-- **macOS:** `~/Library/Application Support/PerpustakaanOffline/perpustakaan.db`
-- **Linux:** `~/.local/share/PerpustakaanOffline/perpustakaan.db`
+**Login default:** `admin` / `admin123` (wajib diubah saat login pertama).
 
-**Login default:** `admin` / `admin123` (wajib diubah saat pertama kali login).
+### Alternatif: dev frontend saja (browser-mode mock)
+
+Untuk iterasi cepat di UI tanpa compile Rust:
+
+```bash
+pnpm --filter @perpustakaan/desktop dev
+# buka http://localhost:1420 di browser
+```
+
+Browser-mode akan otomatis pakai `mockRpc` di tiap `lib/<feature>.ts` — RPC ke Tauri di-stub dengan in-memory state, jadi sebagian besar UI bisa dieksplorasi tanpa backend.
 
 ---
 
-## Build ke `.exe` Windows
-
-Jalankan di Windows:
-
-```bat
-build.bat
-```
-
-Hasil ada di `dist\PerpustakaanOffline.exe` — siap distribusi (single-file, ~40-60 MB termasuk semua dependency).
-
-Atau manual:
+## Build Production
 
 ```bash
-pyinstaller build.spec --clean --noconfirm
+# Build native installer (Windows: MSI+NSIS, Linux: .deb, macOS: .app)
+pnpm tauri:build
 ```
+
+Output ada di `apps/desktop/src-tauri/target/release/bundle/`:
+
+- **Windows:** `msi/PerpustakaanOffline_<version>_x64_en-US.msi` + `nsis/PerpustakaanOffline_<version>_x64-setup.exe`
+- **Linux:** `deb/perpustakaan-offline_<version>_amd64.deb` + `appimage/perpustakaan-offline_<version>_amd64.AppImage`
+- **macOS:** `dmg/PerpustakaanOffline_<version>_aarch64.dmg`
+
+Cross-build tidak didukung Tauri — build di OS target masing-masing (atau pakai CI matrix).
+
+---
+
+## Database & Data Files
+
+SQLite database + asset files dibuat otomatis di app data dir:
+
+- **Linux:** `~/.local/share/id.alviarts.perpustakaan/`
+- **Windows:** `%APPDATA%\id.alviarts.perpustakaan\`
+- **macOS:** `~/Library/Application Support/id.alviarts.perpustakaan/`
+
+Isi:
+- `perpustakaan-v2.db` — main SQLite database
+- `uploads/{anggota,buku,identitas}/` — foto anggota, cover buku, logo perpus (PR #69)
+- `backups/perpustakaan-<timestamp>.db[.sha256]` — output backup manual + scheduler
 
 ---
 
@@ -87,113 +120,130 @@ pyinstaller build.spec --clean --noconfirm
 
 ```
 perpustakaan-offline/
-├── assets/                 # DDC reference, logo placeholder, font barcode
-├── scripts/                # Init DB, migrasi, utilitas
-├── src/perpustakaan/
-│   ├── __main__.py         # entry: python -m perpustakaan
-│   ├── app.py              # bootstrap aplikasi
-│   ├── config.py           # path, default, konstanta
-│   ├── i18n.py             # bilingual ID/EN
-│   ├── db/                 # connection, schema.sql, seed
-│   ├── models/             # CRUD per domain (anggota, buku, peminjaman, ...)
-│   ├── services/           # auth, barcode, pdf, excel, sheets, report
-│   └── gui/                # CustomTkinter views (login, dashboard, master, transaksi, laporan, settings)
-├── tests/                  # pytest
-├── .vscode/                # debug config + tasks
-├── build.spec              # PyInstaller config
-├── build.bat               # one-click build .exe (Windows)
-├── pyproject.toml
-├── requirements.txt
+├── apps/
+│   ├── desktop/                  # Frontend React + backend Tauri
+│   │   ├── src/                  # React + TypeScript
+│   │   │   ├── components/       # shadcn/ui primitives + layout
+│   │   │   ├── features/         # Feature modules (anggota, buku, dashboard, ...)
+│   │   │   ├── i18n/{id,en}/     # JSON locale files (parity-checked)
+│   │   │   ├── lib/              # RPC wrappers (Tauri impl + browser-mode mock)
+│   │   │   ├── routes/           # TanStack Router file-based routes
+│   │   │   └── stores/           # Zustand global stores
+│   │   ├── src-tauri/            # Rust backend
+│   │   │   ├── src/
+│   │   │   │   ├── commands/     # Tauri commands per fitur
+│   │   │   │   ├── db/           # SQLite schema + migrations
+│   │   │   │   ├── error.rs      # AppError enum
+│   │   │   │   └── lib.rs        # Tauri::Builder + invoke_handler
+│   │   │   ├── capabilities/     # Tauri 2 capability allowlists
+│   │   │   ├── icons/            # App icons (.ico/.icns/.png)
+│   │   │   └── tauri.conf.json   # Tauri runtime config
+│   │   └── tests/unit/           # Vitest tests
+│   └── manual/                   # (legacy v0.1, scheduled to be removed in PR #76)
+├── packages/shared/              # Shared TS types between frontend & dev tooling
+├── docs/
+│   ├── manual.md                 # End-user manual (rendered inline by PR #76)
+│   ├── bugs/                     # Post-v1 bug tracker (POST_V1_BUGS.md, PROGRESS.md)
+│   └── migration-v2/             # Sesi 1–12 migration notes (REVISION_BACKLOG.md, PROGRESS.md)
+├── scripts/                      # Dev tooling: i18n-lint, extract-changelog
+├── src/perpustakaan/             # ⚠️ v1 Python codebase (frozen, not built/tested)
+├── tests/                        # ⚠️ v1 Python pytest suite (CI disabled)
+├── pyproject.toml                # ⚠️ v1 Python config
+├── requirements.txt              # ⚠️ v1 Python deps
+├── build.spec / build.bat        # ⚠️ v1 PyInstaller config
+├── package.json                  # v2 root: workspace scripts
+├── pnpm-workspace.yaml
+├── pnpm-lock.yaml
+├── CHANGELOG.md                  # Keep-a-Changelog format (PR #73)
 └── README.md
 ```
 
 ---
 
-## Roadmap
+## Quality Gates (run sebelum commit / push)
 
-Roadmap dikelompokkan ke dalam **4 jalur kerja paralel** supaya gampang diambil
-sebagian-sebagian (oleh kontributor manusia maupun AI agent seperti Devin).
-Tiap item bisa dikerjakan tanpa menunggu jalur lain selesai.
+```bash
+# Frontend (root + apps/desktop)
+pnpm i18n:lint                                                # id ↔ en parity
+pnpm typecheck                                                # tsc --noEmit semua workspace
+pnpm --filter @perpustakaan/desktop lint                      # eslint --max-warnings=0
+pnpm --filter @perpustakaan/desktop test -- --run             # Vitest semua
+pnpm --filter @perpustakaan/desktop build                     # produce dist/ (dipakai Tauri)
+pnpm exec prettier --write <files-yang-diubah>                # format
 
-### Jalur A — Hardening & Validasi (highest ROI, ~1 hari)
+# Backend (apps/desktop/src-tauri)
+cd apps/desktop/src-tauri
+cargo check --all-targets
+cargo clippy --all-targets -- -D warnings
+cargo test --lib
+rustfmt src/path/to/changed.rs                                # format per-file (lihat catatan di bawah)
+```
 
-Pastikan release yang sudah keluar benar-benar tahan dipakai user awam.
+> ℹ️ **Catatan rustfmt:** Hindari `cargo fmt --all` kecuali kamu memang mau bersihkan drift di seluruh repo. Per file lebih aman supaya scope diff tetap jelas.
 
-- [x] End-to-end smoke test: jalankan app di Xvfb, klik semua menu, verifikasi tiap CRUD + peminjaman + dashboard, dokumentasikan bug → `tests/test_smoke_gui.py` + `docs/smoke-test/REPORT.md`
-- [x] Tambah **seed demo data** (5 anggota dummy + 10 buku dummy) di `src/perpustakaan/db/seed.py` flag `--demo`, sehingga user yang baru download bisa langsung coba alur peminjaman tanpa input data dulu
-- [x] **Polish error handling** — banyak `try/except` yang masih silent; ganti jadi toast notification user-friendly via `gui/widgets.show_toast(...)`
-- [x] **Auto-release workflow** — tambah job di `.github/workflows/ci.yml` yang trigger `on: push: tags: ['v*']` → otomatis bikin GitHub Release + upload `.exe` + installer. Tinggal `git tag v0.x.0 && git push --tags`
-- [x] CI matrix tambahin Linux build (untuk distribusi non-Windows). macOS di-skip karena tkinter issues di GitHub Actions runner
-
-### Jalur B — Lengkapi Fitur Skeleton (~2-3 hari)
-
-Beberapa flow di v0.1 cuma ada di backend; UI-nya belum lengkap.
-
-- [x] **UI Naik Kelas batch** — dialog mapping kelas lama → baru di toolbar Anggota (PR #9)
-- [x] **Bebas Pustaka full flow** — validasi otomatis: blokir kalau ada peminjaman aktif (PR #10)
-- [x] **Cetak Nota peminjaman/pengembalian dari UI** — prompt cetak nota PDF setelah simpan/proses (PR #11)
-- [x] **Cek Data Ganda** — deteksi duplikat anggota (nama+kelas) dan buku (ISBN/judul+pengarang); UI di Settings → Tools (PR #12)
-- [x] **Reminder jatuh tempo otomatis** — toast popup di dashboard saat login, list H+0 s/d H+3 (PR #13)
-- [x] **Audit log viewer** — tab Audit Log di Settings: siapa-melakukan-apa-kapan dengan search (PR #14)
-
-### Jalur C — Dokumentasi & Onboarding (~0.5 hari)
-
-- [ ] **User manual** lengkap di `docs/manual.md` (bilingual ID/EN) dengan screenshot tiap menu
-- [ ] **Setup guide Google Sheets** di `docs/google-sheets-setup.md` (langkah dapatkan `client_secret.json` dari Google Cloud Console)
-- [ ] **Demo screencast** 3-5 menit (alur peminjaman end-to-end) di-attach ke release page
-- [ ] **Quickstart** untuk pustakawan yang gak technical (1-pager PDF)
-- [ ] **Inno Setup installer** (`installer/installer.iss`) — Windows installer dengan Setup wizard, Start Menu shortcut, registered uninstaller
-
-### Jalur D — Fitur Lanjutan (~3-5 hari, opsional)
-
-- [ ] **Opsi A: Sync 2-arah Google Sheets** — auto-sync background, conflict resolution last-write-wins by `updated_at`. Sebagai upgrade dari Opsi C yang sudah ada
-- [ ] **Multi-perpustakaan / multi-cabang** — kalau sekolah punya >1 perpus
-- [ ] **Mobile companion (PWA)** — siswa lihat status peminjaman sendiri, scan QR untuk pinjam mandiri
-- [x] **Backup terjadwal** — auto-backup harian/mingguan ke folder lokal (v0.4.0)
-- [ ] **Import dari SIM-Perpus.xlsb asli** — script konversi data lama → SQLite untuk migrasi user existing
-- [ ] **Code signing certificate** — sign `.exe` supaya Windows Defender / SmartScreen tidak warning
-
-### Versi yang sudah dirilis
-
-| Versi | Tanggal | Highlights |
-|-------|---------|-----------|
-| **v0.6.2** | 2026-05-03 | feat(ui): **PR-V4c — Phosphor Icons + 2 illustrations baru** · feat(phosphor): bundle Phosphor Fill TTF (`assets/fonts/Phosphor-Fill.ttf`, 449 KB, MIT lisensi termasuk) dengan 66 icon name → Unicode codepoint mapping di `gui/phosphor.py` (extracted dari `@phosphor-icons/web@2.1.0` style.css). Icon di-render runtime via `PIL.ImageFont.truetype()` + `ImageDraw.text()` lalu di-recolor untuk theme awareness — full anti-aliasing terjaga, no extra dependency · feat(widgets): `widgets.icon_button(phosphor=...)` + `widgets.permission_button(phosphor=...)` parameter baru — Phosphor Fill icon priority lebih tinggi dari Lucide (graceful fallback kalau Phosphor unavailable) · feat(cta): primary CTA buttons (Tambah, Update/Simpan, Hapus, Cetak, Import) di buku/anggota/peminjaman/pengembalian/laporan/settings/kunjungan view sekarang pakai Phosphor Fill — hierarki visual jelas vs Lucide monoweight subtle · feat(illustrations): 2 illustration baru di `scripts/gen_illustrations.py` — `empty-laporan` (bar chart growing trend + donut chart amber accent) + `empty-pengaturan` (gear ganda meshed + sliders amber); total 9 illustration ter-bundle · test: 20 test baru di `test_phosphor.py` (TTF magic, license bundle, codepoint Private Use Area validation, glyph render visibility/color, lru_cache hit detection); +1 update di `test_widgets_visual.py` untuk verify 9 illustrations |
-| **v0.6.1** | 2026-05-03 | feat(ui): **PR-V4b — Procedural animations** (\"Lottie-like\" tanpa dependency Lottie/cairo) · feat(scripts): `scripts/gen_animations.py` procedural generator pakai Pillow — 4 animasi siap pakai: `loader_dots` (24 frame, circular dots fade trailing), `success_check` (15 frame, lingkaran fill + checkmark drawn), `pulse_heart` (10 frame, scale 1.0→1.15→1.0 sin wave), `bounce_book` (12 frame, bouncing dengan squash & stretch + ground shadow) · feat(animation_player): widget baru `gui/animation_player.py` `AnimationPlayer(name=, size=, fps=, loop=, on_done=)` — cycle PNG frames via `after()`, frame cache by (name, size), defensive cleanup pada `<Destroy>` event · feat(empty_state): `EmptyState` widget extend dengan param `animation`, `animation_size`, `animation_fps` — priority animasi > illustration > Lucide icon · feat(toast): `show_toast(kind=\"success\")` sekarang prepend animated checkmark `success_check` di sisi kiri pesan · feat(empty_buku): empty state Buku (saat tidak filter search) tampilkan `bounce_book` animation 120×120, 20fps · feat(installer): folder `assets/animations/` otomatis ter-bundle via `build.spec` `(ASSETS, \"assets\")` — tidak perlu update Inno Setup script · test: 21 test baru di `test_animation_player.py` (frame count, size match, pixel verification untuk merah/non-empty, easing curve symmetry, registry completeness, asset bundle integrity); total 199 passed |
-| **v0.6.0** | 2026-05-03 | feat(ui): **PR-V4a — Microinteractions + Drop Shadow + Gradient** (foundation, no new dependency selain Pillow yang sudah dipakai) · feat(animations): 5 helper baru di `gui/animations.py` — `lerp_color` interpolasi RGB hex, `animate_color` smooth fg_color/border_color transition via easing curve, `slide_to_y` animate place(y=), `apply_dialog_appear` fade-in + slide kecil dari atas untuk modal CTkToplevel, `attach_press_feedback` tactile feedback (border_width pulse) saat tombol di-klik, `attach_hover_lift` smooth color cross-fade saat hover · feat(effects): module baru `gui/effects.py` — `make_drop_shadow` PNG drop shadow lembut via Pillow Gaussian blur, `make_linear_gradient` 2-color gradient any angle, `make_radial_gradient` soft glow spotlight; semua di-cache via `lru_cache` per parameter tuple · feat(modal): semua modal (`HelpDialog`, `ChangePasswordDialog`, `ResetPasswordDialog`, `FirstLoginSecuritySetupDialog`, `RegisterDialog`, dialog Anggota / Pengembalian / Settings / Laporan) sekarang appear dengan fade-in 180ms + slide-in 12px dari atas, ease-out cubic · feat(button): tombol header utama (Bantuan, Ganti Password, "?", Login submit) punya tactile feedback saat di-klik · feat(sidebar): active menu indicator + button bg cross-fade smooth saat switch menu — tidak instant snap · feat(login): background gradient radial subtle (indigo center spotlight) di login screen · feat(card): `StatCard` di Dashboard hover lift sekarang smooth color interpolation, bukan instant configure · test: 45 test baru untuk pure functions (33 lerp/easing/color helpers + 12 effects PIL pixel sampling), total 178 passed, lint clean |
-| **v0.5.3** | 2026-05-03 | feat(help): menu **Bantuan** baru di header window — modal dialog 3 tab (FAQ + Video Tutorial + Tentang) · feat(help): **18 entri FAQ** bilingual (login default, lupa/ganti password, tambah anggota, import Excel, cetak KTA, peminjaman/pengembalian, bebas pustaka, naik kelas, cek data ganda, backup manual/terjadwal, lokasi DB, DDC, ekspor Sheets, lapor bug) · feat(help): tab **Video Tutorial** auto-discover MP4 di `docs/demo/` — tombol "Buka Video" pakai default media player OS (cross-platform: Windows `os.startfile`, macOS `open`, Linux `xdg-open`); empty-state dengan link GitHub Releases kalau bundle tidak ada · feat(help): tab **Tentang** — versi aplikasi, lisensi MIT, kredit Kang Sur (SIM-Perpus v.1.2.2), tombol link ke GitHub repo / releases / issues (lapor bug) · installer: bundle `docs/demo/*.mp4` ke installer Windows supaya video tutorial offline-ready setelah install |
-| **v0.5.2** | 2026-05-02 | feat(auth): tombol **Ganti Password** di header window — modal validasi password lama → password baru → konfirmasi · feat(auth): **Lupa Password?** di layar login — flow 2-step (username → tampilkan pertanyaan keamanan → jawab + set password baru), jawaban di-hash bcrypt, error message generik untuk hindari user enumeration · feat(auth): **First-login wizard wajib** untuk user lama (v0.4.0–v0.4.3) yang belum punya pertanyaan keamanan — modal tidak bisa di-skip, dropdown 5 pertanyaan default + opsi kustom, jawaban minimal 2 karakter (case + whitespace insensitive) · feat(audit): entry `password_changed`, `password_reset_via_security_question`, `security_question_set` di audit log · refactor(db): kolom `security_question` + `security_answer_hash` ditambah ke tabel `users` via idempotent ALTER (helper `_ensure_columns`) — DB existing otomatis ter-upgrade tanpa migration script |
-| **v0.5.1** | 2026-05-02 | feat(ui): bundle **7 procedural empty-state illustration** (PNG 1024×640) di-generate via `scripts/gen_illustrations.py` dengan Pillow — palette indigo (`#4f46e5`) + indigo-soft (`#a5b4fc`) + amber accent (`#f59e0b`) + warm cream bg (`#fef9f3`), satu master style anchor sehingga 7 illustration kelihatan satu keluarga · feat(ui): `EmptyState` widget gain param `illustration` + `illustration_size` — load dari `assets/illustrations/<name>.png`, fallback ke Lucide icon kalau file tidak ada · feat(ui): Anggota, Buku, Kunjungan empty state pakai illustration baru (dengan search-aware variant untuk Anggota & Buku) · feat(tokens): `design_tokens.py` extends dgn `ILLUSTRATION` (palette utk image-gen), `SHADOW` (specs utk PNG drop-shadow layer recipe), `MOTION` (durasi animasi standar 0/120/200/320/480 ms) · scripts: `gen_illustrations.py` idempotent procedural generator (re-run safe untuk re-style atau regen) · test: 4 test baru utk illustration loader + EmptyState illustration param + bundle integrity |
-| **v0.5.0** | 2026-05-02 | feat(ui): visual overhaul major — design system foundation dengan `gui/design_tokens.py` (palette, spacing, radius, icon sizes) · feat(ui): bundle **56 ikon Lucide** di `assets/icons/lucide/` (MIT) + loader recolor PIL theme-aware via `gui/icons.py` · feat(ui): widget baru `EmptyState` (icon + title + description + optional action) untuk placeholder list/dashboard kosong · feat(ui): widget baru `Tooltip` (hover label borderless ala native) · feat(ui): helper `widgets.icon_button(...)` untuk CTkButton dengan ikon Lucide kiri text · feat(ui): sidebar menu + tombol header (theme toggle, help, logout) migrasi ke ikon Lucide (sun/moon/monitor, layout-dashboard, users, book-open, calendar-days, arrow-right-left, rotate-ccw, chart-bar, settings, log-out, circle-question-mark) · feat(ui): toolbar tiap view (anggota, buku, peminjaman, pengembalian, laporan, settings) migrasi ke ikon Lucide (plus, save, trash-2, x, refresh-cw, search, printer, upload, download, file-text) · feat(ui): empty state ditampilkan di Anggota / Buku / Kunjungan saat data kosong (search-aware) · feat(ui): stub `gui/illustrations.py` + folder `assets/illustrations/` siap untuk unDraw illustration berikutnya · feat(auth): tombol "Ganti Password Saya" + flow forgot password via security question (PR-C) · feat(rbac): granular permission per fitur dgn UI Edit Hak Akses (PR-B) · ci: PR sekarang trigger ke branch manapun (sebelumnya hanya `main`) supaya stacked PR bisa di-test |
-| **v0.4.3** | 2026-05-02 | feat(rbac): **Manajemen hak akses granular** — schema baru `permissions` + `user_permissions`, registry 33 permission key per area (anggota / buku / kunjungan / peminjaman / pengembalian / laporan / setting / audit_log) · feat(ui): dialog **Edit Hak Akses** di Setting → Manajemen Akun dengan checkbox grouped per area + tombol preset (Default Admin / Pustakawan / Siswa / Kosongkan) · feat(rbac): tombol aksi protected otomatis ter-disable kalau user tidak punya hak (toast "Akses ditolak" sebagai defense-in-depth) · feat(rbac): default preset per role + auto-grant migration utk user existing dari v0.4.0–v0.4.2 (admin: semua, pustakawan: operasional sehari-hari, siswa: read-only) · feat(audit): entry `permission_granted` / `permission_revoked` setiap perubahan grant · refactor(db): schema selalu di-run idempotent agar upgrade dari versi lama otomatis dapat tabel baru tanpa migration script terpisah |
-| **v0.4.2** | 2026-05-02 | feat(ui): bundle font modern **Inter** (Regular/Medium/SemiBold/Bold OTF, ~1.1 MB) + auto-install via Inno Setup ke per-user fonts directory (no admin required) · feat(ui): heading bar konsisten di tiap menu dengan tombol bulat **`?`** **inline di samping judul** (Data Anggota / Data Buku / Kunjungan / Peminjaman / Pengembalian / Laporan / Setting / Dashboard) — replay tutorial menu itu kapan saja · refactor(ui): widget `HeadingBar` baru dengan deteksi font system otomatis (Inter → Segoe UI Variable / Cantarell / Helvetica / Arial → Tk default) · refactor: StatCard Dashboard pakai font helper (lebih konsisten + jelas) |
-| **v0.4.1** | 2026-05-02 | feat(ui): tutorial **kontekstual per-menu** — first-run cuma intro singkat di Dashboard, lalu tiap user buka menu (Anggota, Buku, Peminjaman, Pengembalian, Kunjungan, Laporan, Setting) pertama kali, panduan khusus menu itu auto-muncul · feat(ui): tombol bulat **`?`** mengambang di pojok kanan-atas (sebelahan toggle tema) untuk **memutar ulang tutorial menu yang sedang dibuka** kapan saja · feat(ui): UI/UX modern — sidebar dengan **indicator bar** di item aktif, **hover lift** halus di kartu Dashboard, ikon dalam lingkaran berwarna · feat(ui): animasi sederhana — toast **slide-in / slide-out** dari kanan, popup tutorial **fade-in** + **spotlight ring** di sekitar widget target |
-| **v0.4.0** | 2026-05-02 | feat(backup): backup terjadwal harian/mingguan dengan retensi otomatis, catch-up saat startup, audit log + toast tiap selesai backup · feat(ui): tombol toggle tema **Sistem / Terang / Gelap** mengambang di pojok kanan atas — selalu visible di menu manapun · feat(ui): tutorial / guided tour interaktif yang muncul otomatis di first-run dengan tombol Lewati / Sebelumnya / Berikutnya, juga bisa diulang dari Setting → Bahasa & Tema |
-| **v0.3.1** | 2026-05-02 | docs: manual.md update + 4 screenshot fitur v0.3.0 · docs: review Google Sheets setup guide · docs: demo screencast 4 menit (`docs/demo/`) · docs: quickstart 1-pager PDF (`docs/quickstart.pdf`) · installer: bump Inno Setup AppVersion ke v0.3.1 + bundle quickstart docs |
-| **v0.3.0** | 2026-05-02 | feat(gui): UI Naik Kelas batch · feat(gui): Bebas Pustaka validasi peminjaman aktif · feat(gui): Cetak Nota di Peminjaman & Pengembalian · feat(gui): Cek Data Ganda (Settings → Tools) · feat(gui): Reminder jatuh tempo otomatis saat login · feat(gui): Audit Log viewer (Settings → Audit Log) |
-| **v0.2.0** | 2026-05-02 | feat(seed): `--demo` flag untuk seed 5 anggota + 10 buku + 2 peminjaman aktif · feat(gui): toast notification non-blocking + exception reporter dengan log ke `app.log` · test: full GUI smoke test passed di Xvfb (17 test cases) · fix: StyledTreeview crash pada duplicate iid · ci: Linux build artifact ditambahkan ke release |
-| **v0.1.1** | 2026-05-02 | docs: user manual + Google Sheets setup guide + Inno Setup installer |
-| **v0.1.0** | 2026-05-02 | Initial scaffold lengkap, semua menu functional, DB SQLite + seed DDC, .exe Windows tersedia di [Releases](https://github.com/alviarts/perpustakaan-offline/releases) |
+CI (`.github/workflows/ci-v2.yml`) menjalankan:
+- **Lint + Typecheck + Unit Test (Node 20)** — required untuk semua PR
+- **Rust check (Tauri backend)** — required untuk semua PR
+- **Build Windows installer** — hanya di tag push (skip di PR)
+- **Publish v2 GitHub Release** — hanya di tag push (skip di PR)
 
 ---
 
 ## Untuk Kontributor / AI Agent
 
-Kalau kamu meneruskan kerjaan dari titik ini:
+Kalau kamu mengerjakan task baru:
 
-1. **Baca dulu** `docs/manual.md` (kalau sudah ada) atau eksplor `src/perpustakaan/` untuk paham struktur
-2. **Pilih satu item** dari roadmap di atas (preferensi: Jalur A → B → C → D), atau buat issue baru
-3. **Setup environment**: `python -m venv .venv && pip install -r requirements.txt`
-4. **Run tests**: `pytest tests/ -q` (harus all green sebelum & sesudah perubahan)
-5. **Lint**: `ruff check src/ tests/` (harus clean)
-6. **Run app lokal**: `python -m perpustakaan` (login `admin` / `admin123`)
-7. **PR** ke `main` dengan deskripsi yang jelas dan checkbox testing — CI di `.github/workflows/ci.yml` otomatis verify lint + pytest + Windows build
-8. **Tag baru**: setelah merge, kalau perlu rilis: `git tag vX.Y.Z && git push --tags` lalu manual upload `.exe` ke Release page (auto-release workflow di Jalur A masih TODO)
+1. **Baca dulu** `docs/manual.md` (end-user) dan `docs/migration-v2/PROGRESS.md` (engineering history)
+2. **Pull latest main** dan buat branch baru: `git checkout -b devin/$(date +%s)-<short-name>`
+3. **Setup environment**: `pnpm install --frozen-lockfile` (lihat Persyaratan Development di atas untuk Tauri prereqs per OS)
+4. **Run dev**: `pnpm tauri:dev` (untuk full Tauri experience) atau `pnpm --filter @perpustakaan/desktop dev` (browser-mode mock)
+5. **Tulis tests**: Vitest di `apps/desktop/tests/unit/`, cargo `#[cfg(test)] mod tests` inline di file Rust
+6. **Run quality gates** (lihat section di atas) — semua harus pass sebelum commit
+7. **i18n parity**: kalau ada string baru, tambah di `i18n/id/<ns>.json` **dan** `i18n/en/<ns>.json`. `pnpm i18n:lint` harus clean.
+8. **PR ke `main`** dengan deskripsi yang jelas + Review Checklist for Human. CI di `ci-v2.yml` otomatis verify lint + typecheck + vitest + rust-check
+9. **Tag baru → auto-release**: lihat section [Release process](#release-process) di bawah
 
 Konvensi:
-- Tanggal/waktu disimpan sebagai TEXT ISO-8601, uang INTEGER rupiah
-- Kode anggota auto `A0001`, kode buku auto `B0001`, kode eksemplar `B0001-01`/`-02`/...
-- DB path runtime: lihat `src/perpustakaan/config.py::_user_data_root()` (handles Windows/macOS/Linux)
-- **JANGAN commit** `client_secret.json`, `token.json`, `*.db`, atau file binary apa pun
+
+- **Conventional commits** (English): `<type>(<scope>): <description>` — `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+- **Branch naming:** `devin/<unix-timestamp>-<short-kebab-name>` (timestamp prevents collisions)
+- **Tanggal/waktu** disimpan sebagai TEXT ISO-8601 di SQLite, uang INTEGER rupiah
+- **Kode anggota** auto `A0001`, kode buku auto `B0001`, eksemplar `B0001-01`/`-02`/...
+- **DB path runtime** ditentukan di `apps/desktop/src-tauri/src/db/mod.rs::resolve_db_path()` (cross-platform via `directories::ProjectDirs`)
+- **JANGAN commit** `*.db`, `target/`, `node_modules/`, file binary, atau secret apa pun
+- **Path-traversal safety** wajib di tiap command yang nerima path user — lihat `commands/assets.rs` sebagai pola
+
+---
+
+## Release process
+
+Versi v2 (Tauri) dirilis dari tag `vX.Y.Z` melalui workflow
+`.github/workflows/ci-v2.yml`. Alurnya end-to-end:
+
+1. **Tambah section di `CHANGELOG.md`** untuk versi baru, mengikuti format
+   `## [X.Y.Z] - YYYY-MM-DD` plus sub-section `### Added` / `### Changed` /
+   `### Fixed` (lihat versi sebelumnya sebagai contoh).
+2. **Bump versi** di `package.json`, `apps/desktop/package.json`,
+   `apps/desktop/src-tauri/Cargo.toml`, dan
+   `apps/desktop/src-tauri/tauri.conf.json` supaya konsisten dengan tag.
+3. **Merge PR** ke `main`.
+4. **Push tag** dari `main` sesudah merge:
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+5. CI mendeteksi tag `v*`, kemudian:
+   - `lint-typecheck-test` + `rust-check` jalan seperti biasa.
+   - `build-windows-installer` build `.exe` + `.msi` di `windows-latest`.
+   - `release-v2` (di `ubuntu-latest`) menjalankan
+     `node scripts/extract-changelog.mjs vX.Y.Z` untuk membaca section
+     `## [X.Y.Z]` dari `CHANGELOG.md`, lalu menggunakannya sebagai body
+     GitHub Release via `softprops/action-gh-release@v2`. Kalau section
+     tidak ada, workflow fallback ke `generate_release_notes: true` dan
+     mencatat warning di summary CI.
+
+Tag `vX.Y.Z-alpha`/`-beta`/`-rc` otomatis ditandai sebagai pre-release.
 
 ---
 
@@ -205,4 +255,4 @@ Konvensi:
 
 - **SIM-Perpus original** oleh Kang Sur (Excel + VBA)
 - **DDC (Dewey Decimal Classification)** — public domain
-- Built with [CustomTkinter](https://customtkinter.tomschimansky.com/), [ReportLab](https://www.reportlab.com/), [python-barcode](https://github.com/WhyNotHugo/python-barcode), [matplotlib](https://matplotlib.org/), [openpyxl](https://openpyxl.readthedocs.io/), [gspread](https://gspread.readthedocs.io/)
+- Built with [Tauri](https://tauri.app/), [React](https://react.dev/), [Vite](https://vite.dev/), [Tailwind CSS](https://tailwindcss.com/), [shadcn/ui](https://ui.shadcn.com/), [TanStack Router](https://tanstack.com/router), [Recharts](https://recharts.org/), [SheetJS](https://sheetjs.com/), [react-markdown](https://github.com/remarkjs/react-markdown)

--- a/apps/desktop/src/i18n/en/pengembalian.json
+++ b/apps/desktop/src/i18n/en/pengembalian.json
@@ -1,4 +1,3 @@
 {
-  "title": "Returns",
-  "placeholder": "Returns module will be built in Devin Session 6."
+  "title": "Returns"
 }

--- a/apps/desktop/src/i18n/id/pengembalian.json
+++ b/apps/desktop/src/i18n/id/pengembalian.json
@@ -1,4 +1,3 @@
 {
-  "title": "Pengembalian",
-  "placeholder": "Modul pengembalian akan dibuat di Devin Session 6."
+  "title": "Pengembalian"
 }


### PR DESCRIPTION
## Summary

Two unrelated docs/i18n cleanups bundled into one PR:

### 1. README.md rewrite — describe v2 (Tauri/React) instead of v1 (Python)

The previous README still documented the legacy v1 Python + CustomTkinter app: `python -m perpustakaan`, `pip install -r requirements.txt`, `pyinstaller build.spec`, `src/perpustakaan/` structure, etc. None of this matches the actual v1.0.1 release, which is a Tauri 2 + React 18 + TypeScript app under `apps/desktop/`.

This PR replaces the README with v2-accurate content:

- **Fitur Utama** reflects what the Tauri app actually ships (Ctrl+K palette, security-question reset, RBAC settings, backup scheduler, manual book inline, system tray, etc.)
- **Stack Tech** lists Rust 1.95 / Tauri 2.11 / rusqlite / bcrypt + React 18 / Vite 5 / Tailwind / shadcn-ui / TanStack Router / Vitest, plus monorepo layout (`apps/desktop`, `apps/desktop/src-tauri`, `apps/manual`, `packages/shared`)
- **Persyaratan Development** lists Node 20+, pnpm 9+, Rust 1.95+ stable, plus per-OS Tauri prereqs (`libgtk-3-dev libwebkit2gtk-4.1-dev …` on Linux, etc.)
- **Quick Start** uses `pnpm install --frozen-lockfile` + `pnpm tauri:dev` (with browser-mode mock fallback via `pnpm --filter @perpustakaan/desktop dev`)
- **Build Production** documents `pnpm tauri:build` artifact paths per OS
- **Database & Data Files** lists v2 paths (`~/.local/share/id.alviarts.perpustakaan/perpustakaan-v2.db`, etc.)
- **Struktur Project** shows the actual monorepo tree, with v1 Python files explicitly tagged `⚠️ frozen, not built/tested`
- **Quality Gates** lists the exact command lineup (`pnpm i18n:lint` / `typecheck` / `lint` / `test` / `build`, `cargo check` / `clippy` / `test`) plus the rustfmt-per-file caveat
- **Untuk Kontributor / AI Agent** rewritten for the v2 workflow (branch naming, conventional commits, i18n parity)
- **Release process** section preserved verbatim from PR #73 so the two PRs do not conflict on this section

A leading note explicitly calls out that the legacy v1 Python sources still live under `src/perpustakaan/` for historical reference but are no longer maintained. (No file moves in this PR.)

### 2. Drop dead `pengembalian.placeholder` i18n key

`apps/desktop/src/i18n/{id,en}/pengembalian.json` both shipped a `placeholder` key:
- id: `"Modul pengembalian akan dibuat di Devin Session 6."`
- en: `"Returns module will be built in Devin Session 6."`

The pengembalian module has been fully built since v1.0.0 (`features/pengembalian/PengembalianPage.tsx`, ~300 lines). A repo-wide grep for `pengembalian:placeholder` returns zero hits — the key is unused. This PR removes it from both locale files. Parity is preserved.

## Review & Testing Checklist for Human

This is docs + dead-key cleanup with no behavior change, so the risk is **green**:

- [ ] Skim the new README and confirm the feature list, build commands, file paths, and structure tree match how you actually use the repo
- [ ] Confirm the v1 Python "frozen" framing matches your intent — if you instead want v1 deleted or moved to `legacy/`, that's a separate PR
- [ ] Verify the "Release process" section is byte-identical to the one PR #73 adds, so merging both in any order will not produce a conflict on that section

## Notes

- Locally: `pnpm i18n:lint` clean, `pnpm typecheck` clean (`apps/manual` + `packages/shared` + `apps/desktop`), `pnpm --filter @perpustakaan/desktop lint` clean, vitest 165/165 pass, frontend build clean, `cargo check` / `cargo clippy --all-targets -- -D warnings` / `cargo test --lib` 25/25 pass.
- No code touched outside `README.md` and the two locale JSONs. No Rust changes.
- This PR branches from `main` (independent of #52, #67–#76, and #77).
- If PR #73 merges first, the only place this PR could conflict is the "Release process" section — and that section was copied verbatim from #73's branch, so the merge should be clean.
- If this PR merges first, PR #73's diff to README will become trivial (the surrounding rewrite already includes the same Release section), but a small rebase may be needed.
