### PR TITLE
docs(bugs): refresh POST_V1_BUGS.md status fields + add BUG-010/011 + INSTRUCTION_TEMPLATE.md sync

### DIFF
--- a/docs/bugs/INSTRUCTION_TEMPLATE.md
+++ b/docs/bugs/INSTRUCTION_TEMPLATE.md
@@ -17,10 +17,12 @@ Branch utama: main
 Bahasa komunikasi: Indonesia. Bahasa commit/PR: English (conventional commits).
 
 Migrasi v2 sudah selesai (v1.0.0, semua 12 sesi merged). Sekarang fase
-post-v1.0.0 bugfix. Ada 9 bug yang ke-discover dari smoke test + Windows
-manual install testing. Detail lengkap di repo:
+post-v1.0.0 bugfix. Ada 11 bug yang ke-discover dari smoke test + Windows
+manual install testing (BUG-001..011). Per 2026-05-04 hampir semua sudah
+resolved — hanya **BUG-008** yang masih in-flight (PR #68). Detail lengkap di
+repo:
 
-- `docs/bugs/POST_V1_BUGS.md`        → 9 bug full detail (where/trigger/observed/expected/suggested fix/DoD)
+- `docs/bugs/POST_V1_BUGS.md`        → 11 bug full detail (where/trigger/observed/expected/suggested fix/DoD)
 - `docs/bugs/PROGRESS.md`            → status table machine-parseable (OPEN/IN_PR/DONE/BLOCKED)
 - `docs/bugs/INSTRUCTION_TEMPLATE.md`→ protokol ini
 
@@ -62,9 +64,11 @@ STEP 4 — Update progress
 STEP 5 — Commit + PR
 11. Commit: `fix(<scope>): <description> (BUG-NNN)` (conventional commit).
     Contoh: `fix(buku): insert eksemplar rows on buku_create (BUG-001)`.
-12. Push branch (kalau dapat 403 dari git-manager proxy, request PAT via
-    secret form `GITHUB_PAT_PERPUSTAKAAN` dan push pakai
-    `git push https://x-access-token:${GITHUB_PAT_PERPUSTAKAAN}@github.com/alviarts/perpustakaan-offline.git <branch>`).
+12. Push branch (kalau dapat 403 dari git-manager proxy, pakai org-level
+    secret `GITHUB_PAT` yang sudah auto-inject sebagai env var:
+    `git push https://x-access-token:${GITHUB_PAT}@github.com/alviarts/perpustakaan-offline.git <branch>`).
+    Kalau token expired, request PAT baru via secret form (`GITHUB_PAT`,
+    `should_save=true`, `save_scope=org`).
 13. Bikin PR. Title: `fix(<scope>): <description> (BUG-NNN)`. Body harus
     berisi:
     - Link ke entry bug di `docs/bugs/POST_V1_BUGS.md`.

--- a/docs/bugs/POST_V1_BUGS.md
+++ b/docs/bugs/POST_V1_BUGS.md
@@ -5,6 +5,14 @@ Source of truth for all bugs found **after** the 12-session migration to v2 was 
 future Devin session (or human) can pick up the next open bug without re-discovering
 context from scratch.
 
+> **Status (2026-05-04):** All P0/P1/P2 bugs from the initial smoke test are
+> resolved (BUG-001..007, BUG-009..011 merged via PRs #55–#63 and #66). Only
+> **BUG-008** (LOW / DESIGN) remains in flight via PR
+> [#68](https://github.com/alviarts/perpustakaan-offline/pull/68). This file is
+> in maintenance mode — use it as a historical catalog. New bug discoveries
+> should append entries below + add a row to
+> [`PROGRESS.md`](./PROGRESS.md).
+
 - **Smoke test report (Linux dev, full repro details + screenshots):** session
   attachment `test-report.md` from the smoke-test session. The bug entries below
   are derived from that report and from a Windows production-installer test.
@@ -19,10 +27,10 @@ context from scratch.
 | Field | Value |
 |---|---|
 | Severity | **HIGH** |
-| Status | `OPEN` |
+| Status | `DONE` |
 | Discovered | Linux dev smoke test |
 | Reproduces in | Linux dev, presumed Windows prod (same code path) |
-| PR | none yet |
+| PR | [#55](https://github.com/alviarts/perpustakaan-offline/pull/55) (merged 2026-05-04) |
 
 **Where**
 
@@ -86,9 +94,9 @@ entries).
 | Field | Value |
 |---|---|
 | Severity | **MEDIUM** |
-| Status | `OPEN` |
+| Status | `DONE` |
 | Discovered | Linux dev smoke test |
-| PR | none yet |
+| PR | [#57](https://github.com/alviarts/perpustakaan-offline/pull/57) (merged 2026-05-04) |
 
 **Where**
 
@@ -163,9 +171,9 @@ Then sweep all `description: ... String(err)` call sites and replace with
 | Field | Value |
 |---|---|
 | Severity | **MEDIUM** |
-| Status | `OPEN` |
+| Status | `DONE` |
 | Discovered | Linux dev smoke test |
-| PR | none yet |
+| PR | [#58](https://github.com/alviarts/perpustakaan-offline/pull/58) (merged 2026-05-04) |
 
 **Where**
 
@@ -231,9 +239,9 @@ failures).
 | Field | Value |
 |---|---|
 | Severity | **MEDIUM** |
-| Status | `OPEN` |
+| Status | `DONE` |
 | Discovered | Linux dev smoke test |
-| PR | none yet |
+| PR | [#59](https://github.com/alviarts/perpustakaan-offline/pull/59) (merged 2026-05-04) |
 
 **Where**
 
@@ -290,9 +298,9 @@ master arrays (insert only if `SELECT count(*) FROM ddc` = 0).
 | Field | Value |
 |---|---|
 | Severity | **HIGH** |
-| Status | `OPEN` |
+| Status | `DONE` |
 | Discovered | Linux dev smoke test |
-| PR | none yet |
+| PR | [#56](https://github.com/alviarts/perpustakaan-offline/pull/56) (merged 2026-05-04) |
 
 **Where**
 
@@ -342,9 +350,9 @@ button in the editor restores this seed.
 | Field | Value |
 |---|---|
 | Severity | **MINOR** (cosmetic) |
-| Status | `OPEN` |
+| Status | `DONE` |
 | Discovered | Linux dev smoke test |
-| PR | none yet |
+| PR | [#60](https://github.com/alviarts/perpustakaan-offline/pull/60) (merged 2026-05-04) |
 
 **Where**
 
@@ -392,9 +400,9 @@ Then add `staticData: { crumb: 'Anggota' }` etc. on each route definition.
 | Field | Value |
 |---|---|
 | Severity | **MINOR** |
-| Status | `OPEN` |
+| Status | `DONE` |
 | Discovered | Linux dev smoke test |
-| PR | none yet |
+| PR | [#61](https://github.com/alviarts/perpustakaan-offline/pull/61) (merged 2026-05-04) |
 
 **Where**
 
@@ -475,9 +483,9 @@ separate "Total Eksemplar" KPI can be added if the user wants that visible too.
 | Field | Value |
 |---|---|
 | Severity | **HIGH** |
-| Status | `IN_PR` |
+| Status | `SUPERSEDED` |
 | Discovered | Windows production install |
-| PR | [#53](https://github.com/alviarts/perpustakaan-offline/pull/53) (pending merge) |
+| PR | [#53](https://github.com/alviarts/perpustakaan-offline/pull/53) closed without merge; superseded by **BUG-010** in [#62](https://github.com/alviarts/perpustakaan-offline/pull/62) + Windows follow-up [#66](https://github.com/alviarts/perpustakaan-offline/pull/66) (merged 2026-05-04) |
 
 **Where**
 
@@ -536,15 +544,88 @@ References:
 
 ---
 
+### BUG-010 — Buku Manual UI redesign + Tauri 2 CSP externalize
+
+| Field | Value |
+|---|---|
+| Severity | **HIGH** |
+| Status | `DONE` |
+| Discovered | Windows production install (filed during BUG-009 review) |
+| Supersedes | BUG-009 |
+| PR | [#62](https://github.com/alviarts/perpustakaan-offline/pull/62) (merged 2026-05-04); Windows follow-up [#66](https://github.com/alviarts/perpustakaan-offline/pull/66) inlined CSS+JS to fully fix the blank-window regression |
+
+**Where**
+
+- `apps/manual/build.mjs` (manual HTML generator).
+- `apps/desktop/public/manual/` (generated artefacts — gitignored).
+- `apps/desktop/src-tauri/src/commands/manual.rs` (window builder flags).
+
+**Summary**
+
+Replaces the original BUG-009 fix (PR #53, closed without merge) with a
+larger redesign of the Buku Manual surface plus the Tauri 2 production-CSP
+workaround. PR #62 splits the manual into `index.html` + external `style.css`
++ `app.js` and refreshes the visual layout. PR #66 follow-up inlines CSS/JS
+back into a single HTML to fully eliminate the Windows WebView2 blank-window
+edge case under Tauri 2's runtime CSP.
+
+**Definition of done**
+
+- [x] Manual window renders fully styled on Windows production install.
+- [x] X button closes the manual window without Task Manager.
+- [x] Theme toggle + search filter work in the manual.
+- [x] No regression to dev-mode manual rendering.
+
+---
+
+### BUG-011 — System tray + close-behavior setting + clean process exit
+
+| Field | Value |
+|---|---|
+| Severity | **HIGH** |
+| Status | `DONE` |
+| Discovered | Windows production install |
+| PR | [#63](https://github.com/alviarts/perpustakaan-offline/pull/63) (merged 2026-05-04) |
+
+**Where**
+
+- `apps/desktop/src-tauri/src/lib.rs` (window event handler, system tray).
+- `apps/desktop/src/features/settings/...` (close-behavior preference).
+
+**Summary**
+
+The Windows install left orphaned background processes when the main window
+was closed via the X button (the app icon stayed in the system tray but the
+window could not be re-opened, and Task Manager showed the process still
+running). PR #63 adds a system tray icon with a proper context menu
+(Show / Quit), introduces a close-behavior setting ("close to tray" vs.
+"quit on close"), and ensures the process exits cleanly when the user picks
+"Quit".
+
+**Definition of done**
+
+- [x] System tray icon shows on Windows + Linux with Show/Quit menu.
+- [x] Close-behavior setting persists in DB; default is "close to tray".
+- [x] Quitting via tray menu fully terminates the process (no orphans).
+- [x] Manual smoke on Windows installer confirms the regression is gone.
+
+---
+
 ## Operational note — git auth
 
-Devin's GitHub App currently lacks `Contents: write` + `Pull requests: write`
-on this repo, so PRs from a Devin session require a user-supplied PAT (sent via
-the secrets UI). The smoke-test session that produced this backlog used PAT
-`GITHUB_PAT_PERPUSTAKAAN` for PRs #52 and #53.
+Devin's GitHub App lacks `Contents: write` + `Pull requests: write` on this
+repo, so PRs from a Devin session require a user-supplied PAT (sent via the
+secrets UI). As of 2026-05-04, the org-level secret is named **`GITHUB_PAT`**
+(classic, scope `repo`) and is auto-injected as an env var into all Devin
+sessions in the org. To push or create PRs, sessions use:
 
-To unblock future sessions permanently, the user can grant the Devin GitHub
-App write access on
+```bash
+git push https://x-access-token:${GITHUB_PAT}@github.com/alviarts/perpustakaan-offline.git <branch>
+GH_TOKEN=$GITHUB_PAT gh api repos/alviarts/perpustakaan-offline/pulls -X POST ...
+```
+
+To unblock future sessions permanently without a PAT, the user can grant the
+Devin GitHub App write access at
 <https://github.com/alviarts/perpustakaan-offline> →
 Settings → Integrations → GitHub Apps → Devin → Configure.
 


### PR DESCRIPTION
## Summary

Brings `docs/bugs/POST_V1_BUGS.md` and `docs/bugs/INSTRUCTION_TEMPLATE.md` in sync with what is actually merged on `main` after the v1.0.1 bug-fix bundle. Both files still described BUG-001..007 as `OPEN` and BUG-009 as `IN_PR (#53)` even though all of them were merged via PRs #55–#63 / #66 on 2026-05-04. Pure docs change — no code, schema, or CI workflow touched.

> **Coordination with sibling PRs.** This PR intentionally avoids two areas already owned by other open PRs so they can merge in any order without conflicts:
>
> - `docs/bugs/PROGRESS.md` is owned by **PR #67** (status table refresh) and not touched here.
> - `docs/bugs/POST_V1_BUGS.md`'s **BUG-008** status block + the last bullet of `## Triage / priority` are owned by **PR #68** (stacked on #67, lands the BUG-008 dashboard fix). This PR touches neither.

## Changes

### `docs/bugs/POST_V1_BUGS.md` (+97 / −20)

- **Header callout** added below the introductory paragraph:
  > Status (2026-05-04): All P0/P1/P2 bugs from the initial smoke test are resolved (BUG-001..007, BUG-009..011 merged via PRs #55–#63 and #66). Only BUG-008 (LOW / DESIGN) remains in flight via PR #68. This file is in maintenance mode — use it as a historical catalog. New bug discoveries should append entries below + add a row to `PROGRESS.md`.
- **Status + PR fields** flipped for the closed bugs:
  | Bug | Status | PR |
  |---|---|---|
  | BUG-001 | `OPEN` → `DONE` | none yet → [#55](https://github.com/alviarts/perpustakaan-offline/pull/55) (merged 2026-05-04) |
  | BUG-002 | `OPEN` → `DONE` | none yet → [#57](https://github.com/alviarts/perpustakaan-offline/pull/57) (merged 2026-05-04) |
  | BUG-003 | `OPEN` → `DONE` | none yet → [#58](https://github.com/alviarts/perpustakaan-offline/pull/58) (merged 2026-05-04) |
  | BUG-004 | `OPEN` → `DONE` | none yet → [#59](https://github.com/alviarts/perpustakaan-offline/pull/59) (merged 2026-05-04) |
  | BUG-005 | `OPEN` → `DONE` | none yet → [#56](https://github.com/alviarts/perpustakaan-offline/pull/56) (merged 2026-05-04) |
  | BUG-006 | `OPEN` → `DONE` | none yet → [#60](https://github.com/alviarts/perpustakaan-offline/pull/60) (merged 2026-05-04) |
  | BUG-007 | `OPEN` → `DONE` | none yet → [#61](https://github.com/alviarts/perpustakaan-offline/pull/61) (merged 2026-05-04) |
  | BUG-009 | `IN_PR` → `SUPERSEDED` | [#53](.../53) (pending merge) → [#53](.../53) closed without merge; superseded by **BUG-010** in [#62](.../62) + Windows follow-up [#66](.../66) (merged 2026-05-04) |
- **New catalog entries** added (between BUG-009 and the `## Operational note` section):
  - **BUG-010** — Buku Manual UI redesign + Tauri 2 CSP externalize. Severity HIGH, status DONE, PR #62 (merged 2026-05-04) + Windows follow-up #66 (inlined CSS+JS to fully fix the WebView2 blank-window edge case). `Supersedes: BUG-009`. Includes Where / Summary / DoD checklist.
  - **BUG-011** — System tray + close-behavior setting + clean process exit. Severity HIGH, status DONE, PR #63 (merged 2026-05-04). Includes Where / Summary / DoD checklist.
- **`## Operational note — git auth`** updated:
  - Stale `GITHUB_PAT_PERPUSTAKAAN` reference replaced with the current org-level **`GITHUB_PAT`** (auto-injected env var as of 2026-05-04).
  - Added a code block showing the standard PAT-direct push + `gh api` PR-create workaround for the git-manager proxy 403.
  - Removed the dated reference to "PRs #52 and #53" (no longer informative).

**Untouched in `POST_V1_BUGS.md`:** the BUG-008 status block (PR #68 owns it), the BUG-008 "Decision needed" sub-block (PR #68 records the Opsi 3 decision), and the `## Triage / priority` section (PR #68 updates the bullet 8 wording).

### `docs/bugs/INSTRUCTION_TEMPLATE.md` (+9 / −7)

- Bug count updated from `9` → `11` (BUG-001..011) in two places (the intro paragraph and the file list bullet).
- Added a one-line status callout: "Per 2026-05-04 hampir semua sudah resolved — hanya BUG-008 yang masih in-flight (PR #68)."
- Replaced `GITHUB_PAT_PERPUSTAKAAN` references with the current `GITHUB_PAT` org secret. Added a fallback note for when the token expires: request a new one via the secret form with `should_save=true`, `save_scope=org`.

## Quality Gates Verified Locally

- `pnpm exec prettier --check docs/bugs/INSTRUCTION_TEMPLATE.md` ✓ (clean).
- `pnpm exec prettier --check docs/bugs/POST_V1_BUGS.md` — pre-existing whitespace warnings on the markdown tables, **identical to `main`**. Not introduced by this PR. Running `prettier --write` would reformat the entire file (table alignment) and conflict with PR #68's expected merge base, so deliberately not run.
- No code touched → `pnpm typecheck`, `pnpm lint`, `cargo *` skipped (out of scope).

## Review & Testing Checklist for Human

Risk: green (docs-only, no runtime impact, no CI required for this path).

- [ ] Skim the new BUG-010 / BUG-011 catalog entries — confirm the descriptions, file paths in **Where**, and the DoD checklists are accurate.
- [ ] Confirm BUG-009 should remain pinned to PR #53 (closed, superseded) for historical clarity, with the supersession pointer to PR #62 + #66 in the same line — vs. moving the canonical PR pointer to #62.
- [ ] Confirm the `## Operational note` rewrite is OK (current `GITHUB_PAT` org secret + PAT-direct workaround code block).
- [ ] Confirm the `INSTRUCTION_TEMPLATE.md` count bump and PAT name fix is OK.

### Notes

- **No CI required.** `.github/workflows/ci-v2.yml` `pull_request.paths` filter excludes `docs/**` (except `docs/legal/**`), so no CI job runs on this branch by design.
- **Targets `main` directly.** Independent of the PR #67 → #68 stack; diffs do not overlap (this PR touches POST_V1_BUGS.md and INSTRUCTION_TEMPLATE.md; PR #67 touches PROGRESS.md only; PR #68 touches the BUG-008 block in POST_V1_BUGS.md only). Merge order is flexible.
- Companion to PR #82 (post-migration cleanup section in `docs/migration-v2/PROGRESS.md`).
