### PR TITLE
fix(cargo): deduplicate [dev-dependencies] section in Cargo.toml

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -38,6 +38,3 @@ tempfile = "3"
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
-
-[dev-dependencies]
-tempfile = "3"


### PR DESCRIPTION
## Summary

`apps/desktop/src-tauri/Cargo.toml` on `main` has **two** `[dev-dependencies]` sections, both declaring `tempfile = "3"`. Cargo rejects this and fails every Rust build:

```
error: duplicate key
  --> Cargo.toml:42:2
   |
42 | [dev-dependencies]
   |  ^^^^^^^^^^^^^^^^
```

Root cause: PR #69 (uploader) and PR #70 (anggota Excel) each independently appended a `[dev-dependencies]` block to the bottom of `Cargo.toml`. Squash-merging #69 first added the first block; squash-merging #70 a few minutes later appended a second one. GitHub's text-level merge sees no overlap, but Cargo's TOML parser does.

This drift slipped through earlier per-PR quality gates because each PR's branch was based on a `main` that did not yet contain the other PR's `Cargo.toml` change.

This PR removes the trailing duplicate block. The remaining `[dev-dependencies] tempfile = "3"` above `[features]` is preserved.

## Review & Testing Checklist for Human

- [ ] Confirm only `[features]` and the trailing duplicate block were removed (3 lines deleted, no other changes).
- [ ] Run `cd apps/desktop/src-tauri && cargo check --all-targets` locally and confirm it succeeds.

### Notes

Quality gates verified locally (8/8 pass):

- `pnpm i18n:lint` OK
- `pnpm typecheck` OK
- `pnpm --filter @perpustakaan/desktop lint` OK
- `pnpm --filter @perpustakaan/desktop test -- --run` OK (165/165)
- `pnpm --filter @perpustakaan/desktop build` OK
- `cargo check --all-targets` OK
- `cargo clippy --all-targets -- -D warnings` OK
- `cargo test --lib` OK (25/25)

Unblocks the remaining v1.0.2 merge waves (#71, #72, #73, #77) — they were all failing local cargo check after rebasing onto current main.
