### PR TITLE
chore(release): bump versions to 1.0.2 + CHANGELOG [1.0.2] section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,118 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-05-04
+
 ### Added
 
-- `CHANGELOG.md` plus `scripts/extract-changelog.mjs` so future `vX.Y.Z` tag
-  pushes publish a curated GitHub Release body instead of auto-generated notes.
-- README "Release process" section that documents the tag-driven auto-release
-  flow end-to-end.
+- **File picker uploader** for anggota photo, buku cover, and identitas logo
+  via a reusable `FilePickerInput` component. Backed by Tauri commands
+  (`assets_save` / `assets_resolve` / `assets_delete`) with path-traversal
+  defenses, an allow-list of categories (anggota / buku / identitas) and
+  extensions (png / jpg / jpeg / webp / gif / svg / bmp), and race-protection
+  against fast successive picks. Legacy v1 absolute paths in the DB still
+  pass through without migration. (#69)
+- **Anggota Excel export** — "Ekspor Excel" button on the member list
+  respects the active filters (search / kelas / jurusan / aktif / sort) and
+  writes via a generic `export_write_bytes` Tauri command (validates
+  non-empty, ≤ 64 MiB, absolute path, parent exists). Pagination uses
+  500 items per batch with a 100 000-row hard cap. Reuses the existing
+  `xlsx` (SheetJS) dependency. (#70)
+- **Ctrl+K global search palette** — cmdk-style command palette
+  (Ctrl+K / Cmd+K) searches anggota, buku, and peminjaman in a single
+  dialog with three result groups, race-protection, `Promise.allSettled`
+  fan-out, 200 ms debounce, and a sub-2-character short-circuit. Toggling
+  Ctrl+K opens and closes the palette. (#72)
+- **Forgot password** flow via security question — two-step lookup
+  (username → security question → reset). `auth_get_security_question`
+  always returns `Ok(None)` for ineligible branches (missing user /
+  inactive / no question / blank) to defend against username enumeration.
+  Security answers are bcrypt-hashed (cost 12) after trim + whitespace
+  collapse + lowercase normalization. Wrong answers are mapped to
+  `InvalidCredentials` to reuse the existing error path. New Settings tab
+  lets users set or edit their security question. DB migration adds
+  nullable `security_question` and `security_answer_hash` columns. (#74)
+- **Backup cron scheduler** runs in a background thread that ticks every
+  60 s, reads the schedule from the `settings` table, and supports cron
+  5-field syntax (`*`, single, `M-N`, `A,B,C`, `*/N`). Auto-backups go to
+  `<app_data>/backups/`; manual backups still go to a user-picked folder.
+  Hardened with a 30 s startup grace window, an `AtomicBool` busy flag,
+  minute-slot dedupe, silent no-op on cron typos, and lazy directory
+  creation. Reuses the existing `backup_create_at` command. (#75)
+- **Manual book as Settings tab** — replaces the flaky child-window
+  WebView2 build of the manual with a `Settings → Buku Manual` tab that
+  renders `docs/manual.md` inline via `react-markdown` + `remark-gfm`,
+  with a generated table of contents. The Settings layout now has 13
+  tabs (was 12), and the header "Buku Manual" button links to
+  `/settings/manual`. (#76)
+- **Richer kunjungan illustrations** — theme-aware vector art for the
+  kunjungan empty state and supporting screens. (#71)
+- **CHANGELOG-driven auto-release** — tag pushing `vX.Y.Z` now extracts
+  the matching `## [X.Y.Z]` section from `CHANGELOG.md` via
+  `scripts/extract-changelog.mjs` and uses it as the GitHub Release body,
+  falling back to GitHub's auto-generated notes when no section matches.
+  Pre-release tags (`-alpha` / `-beta` / `-rc`) are auto-marked as
+  prereleases. README gains a "Release process" section documenting the
+  flow end-to-end. (#73)
+- **README v2 refresh** — README.md now documents the actual v2
+  Tauri / React / pnpm 9 stack, monorepo layout, per-OS Tauri prereqs,
+  build commands, data paths, and the 8 quality-gate command lineup.
+  Drops the dead `pengembalian.placeholder` i18n key. (#78)
+- **Manual.md v2 refresh** — `docs/manual.md` now documents v2 install
+  flows (MSI + NSIS on Windows, `.deb` on Linux, `.dmg` on macOS),
+  Tauri data paths, the actual Settings tab list (Identitas / KTA /
+  Akun / Hak Akses / Aturan Peminjaman / Master Data / Tampilan /
+  Bahasa / Backup / Sinkronisasi / Audit Log / Tentang), the in-app
+  "Lupa Password?" flow, and v2 troubleshooting. (#81)
+- **POST_V1_BUGS.md & PROGRESS.md status refresh** — status fields
+  flipped to DONE for fixed bugs, BUG-010 / BUG-011 added,
+  `INSTRUCTION_TEMPLATE.md` synced, and PROGRESS.md gains a
+  post-v1.0.1 status section plus a post-migration cleanup section
+  in the migration record. (#67, #82, #83)
+- **Smoke-test-v2 SKILL.md** — agent-facing skill notes for smoke
+  testing the v2 Tauri app. (#52)
 
 ### Changed
 
-- `release-v2` job in `.github/workflows/ci-v2.yml` now extracts the release
-  body from the matching `CHANGELOG.md` section before calling
-  `softprops/action-gh-release@v2`. Auto-generated notes remain the fallback
-  when the section is missing.
+- **Header search** — replaces the placeholder input that navigated to
+  `/anggota?q=...` on Enter with a `<button>` that opens the new
+  `GlobalSearchDialog` (Ctrl+K). (#72)
+- **Rust formatting** — `commands/buku.rs` and `db/mod.rs` re-formatted
+  with rustfmt; cosmetic only. (#77)
+- **Cargo.toml** — deduplicated the `[dev-dependencies]` block on `main`
+  after PR #69 and PR #70 each appended `tempfile = "3"` and squash-merge
+  produced a duplicate key that broke `cargo check` / `clippy` / `test`. (#87)
+- **Migration archive** — `docs/migration-v2/` moved to
+  `docs/archive/migration-v2/` to mark the migration as completed. (#85)
+- **`release-v2` CI job** — extracts the release body from `CHANGELOG.md`
+  before calling `softprops/action-gh-release@v2`, falling back to
+  auto-generated notes when no section matches the tag. (#73)
+
+### Fixed
+
+- **BUG-008** — Dashboard "Total Buku" KPI now shows the actual book
+  titles plus the eksemplar sub-line instead of the previous mislabeled
+  count. (#68)
+- **Manual book WebView2 child-window flakiness** — replaced the
+  child-window approach with the inline Settings tab so the manual
+  always renders, regardless of WebView2 version. (#76)
+
+### Removed
+
+- **v1 Python codebase** deleted entirely (253 files, ~24 500 lines):
+  `src/perpustakaan/` Python source, `tests/` pytest suite, `pyproject.toml`,
+  `requirements.txt`, `build.spec`, `build.bat`, `installer/` Inno Setup,
+  `assets/` v1 illustration PNGs, six Python utility scripts,
+  `scripts/migrate-v1-to-v2.mjs` and its test, the disabled v1 CI workflow,
+  and v1 docs (`quickstart.md` / `quickstart.pdf`, screenshots, smoke-test
+  report, demo screencast, google-sheets-setup). v1 history remains
+  accessible via `git log --all`. The Google Sheets sync feature is gone
+  permanently — v2 ships the backup scheduler instead. (#80)
+- **`apps/manual/` package** removed (`build.mjs`, `package.json`,
+  `commands/manual.rs`, `lib/manual.ts`, etc.) — superseded by the
+  Settings → Manual tab. (#76)
+- **Dead i18n key** `pengembalian.placeholder` removed from `id` and `en`
+  locale files. (#78)
 
 ## [1.0.1] - 2026-05-04
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2786,7 +2786,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "bcrypt",
  "chrono",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.1"
+version = "1.0.2"
 description = "Perpustakaan Offline v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanOffline",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Perpustakaan Offline v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

Release prep for **v1.0.2**:

- Bump version `1.0.1 → 1.0.2` across the four authoritative files:
  - `package.json` (root)
  - `apps/desktop/package.json`
  - `apps/desktop/src-tauri/Cargo.toml` (`Cargo.lock` updated automatically)
  - `apps/desktop/src-tauri/tauri.conf.json`
- Move the existing `## [Unreleased]` content into a new `## [1.0.2] - 2026-05-04` section in `CHANGELOG.md` and document the full set of changes that landed since `v1.0.1` (see preview below).

When this PR is merged and the `v1.0.2` tag is pushed, `.github/workflows/ci-v2.yml`'s `release-v2` job will run `node scripts/extract-changelog.mjs v1.0.2` and use the matching section as the GitHub Release body, then build + publish the Windows MSI + NSIS installers.

## Review & Testing Checklist for Human

- [ ] Confirm only the four version files + `Cargo.lock` + `CHANGELOG.md` are touched in this PR.
- [ ] Skim the new `## [1.0.2]` section in `CHANGELOG.md` and call out anything misclassified (Added / Changed / Fixed / Removed).
- [ ] Confirm the `[Unreleased]` heading is preserved (empty section is fine).

### Preview of the auto-extracted release body

`node scripts/extract-changelog.mjs v1.0.2` returns the body shown under `## [1.0.2] - 2026-05-04` in `CHANGELOG.md` (verified locally).

### Notes

Quality gates verified locally on this branch (8/8 pass):

- `pnpm i18n:lint` OK
- `pnpm typecheck` OK
- `pnpm --filter @perpustakaan/desktop lint` OK
- `pnpm --filter @perpustakaan/desktop test -- --run` OK (165/165)
- `pnpm --filter @perpustakaan/desktop build` OK
- `cargo check --all-targets` OK
- `cargo clippy --all-targets -- -D warnings` OK
- `cargo test --lib` OK (25/25)

PRs already merged into `main` for v1.0.2 (in wave order):

- Wave 1 (foundation): #78, #80, #81
- Wave 2 (post-foundation docs): #82, #85
- Wave 3 (bug fixes): #67, #68
- Wave 4 (docs): #83, #52
- Wave 5 (features): #76, #74, #69, #70, #75, #87 (hotfix), #72, #71, #73
- Wave 6 (style): #77
- Closed as obsoleted by #76: #84

Total: 18 PRs merged + 1 closed since v1.0.1.

After merge, the next steps are:

```
git checkout main && git pull
git tag v1.0.2
git push origin v1.0.2
```

CI's `release-v2` job will then publish the GitHub Release with the extracted CHANGELOG body, the Windows MSI installer, and the Windows NSIS installer (~15-20 min build).
