### PR TITLE
fix(ui): theme-aware date inputs + responsive Peminjaman date row (v1.0.3 #4 + #5)

### DIFF
--- a/apps/desktop/src/components/ui/date-picker.tsx
+++ b/apps/desktop/src/components/ui/date-picker.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useId } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Calendar } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
@@ -47,31 +46,26 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
     const today = new Date().toISOString().slice(0, 10);
 
     return (
-      <div className={cn('flex items-center gap-2', className)}>
-        <div className="relative flex-1">
-          <Calendar
-            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-            aria-hidden
-          />
-          <input
-            ref={ref}
-            id={inputId}
-            name={name}
-            type="date"
-            value={value ?? ''}
-            min={min}
-            max={max}
-            disabled={disabled}
-            aria-label={ariaLabel}
-            onChange={(e) => onChange(e.target.value)}
-            className={cn(
-              'flex h-10 w-full rounded-md border border-input bg-background pl-9 pr-3 py-2 text-sm',
-              'ring-offset-background',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-              'disabled:cursor-not-allowed disabled:opacity-50',
-            )}
-          />
-        </div>
+      <div className={cn('flex flex-wrap items-center gap-2', className)}>
+        <input
+          ref={ref}
+          id={inputId}
+          name={name}
+          type="date"
+          value={value ?? ''}
+          min={min}
+          max={max}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          onChange={(e) => onChange(e.target.value)}
+          className={cn(
+            'flex h-10 min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm',
+            'ring-offset-background',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            'native-date-input',
+          )}
+        />
         {showToday && (
           <Button
             type="button"

--- a/apps/desktop/src/features/peminjaman/PeminjamanForm.tsx
+++ b/apps/desktop/src/features/peminjaman/PeminjamanForm.tsx
@@ -269,7 +269,7 @@ export function PeminjamanForm() {
                 {t('peminjaman:form.tanggal', { defaultValue: 'Tanggal' })}
               </CardTitle>
             </CardHeader>
-            <CardContent className="grid gap-3 sm:grid-cols-2">
+            <CardContent className="grid gap-3 xl:grid-cols-2">
               <div>
                 <label className="mb-1 block text-xs font-medium text-muted-foreground">
                   {t('peminjaman:form.tanggalPinjam', { defaultValue: 'Tanggal Pinjam' })}

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -142,6 +142,41 @@
 }
 
 /*
+ * Theme-aware native date inputs (revisi v1.0.3 #4).
+ *
+ * `color-scheme` opts native form widgets (calendar picker indicator,
+ * autofill, scrollbars) into the matching colour scheme so the calendar
+ * icon is dark on light backgrounds and light on dark backgrounds. We
+ * apply it on the root via `.dark` so every `<input type="date">` —
+ * whether it goes through the `DatePicker` wrapper or a raw `<Input>` —
+ * picks up the right colour.
+ *
+ * Fallback: explicitly invert the `::-webkit-calendar-picker-indicator`
+ * in dark mode for engines (older Linux WebKit) that don't honour
+ * `color-scheme` reliably.
+ */
+:root {
+  color-scheme: light;
+}
+.dark {
+  color-scheme: dark;
+}
+.dark input[type='date']::-webkit-calendar-picker-indicator,
+.dark input[type='time']::-webkit-calendar-picker-indicator,
+.dark input[type='datetime-local']::-webkit-calendar-picker-indicator,
+.dark input[type='month']::-webkit-calendar-picker-indicator,
+.dark input[type='week']::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+input[type='date']::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  opacity: 0.7;
+}
+input[type='date']::-webkit-calendar-picker-indicator:hover {
+  opacity: 1;
+}
+
+/*
  * Density modifier (revisi #24 — Settings → Tampilan).
  *
  * `data-density="compact"` shrinks vertical paddings on table rows and


### PR DESCRIPTION
## Summary

Fixes items #4 and #5 from the v1.0.3 backlog (`.devin/handoff/v1.0.3/backlog.md`).

vielz reported (post-v1.0.2) two related date-input issues:
- The calendar icon stayed dark grey on dark backgrounds and was almost invisible — *"saya mau putih ketika dark mode hitam ketika white mode"*.
- In the Peminjaman form the *"Tanggal Pinjam"* / *"Jatuh Tempo"* cells overflowed in windowed mode so only the first character (`H`) of *"Jatuh Tempo"* was visible.

### Changes

1. **Drops the redundant decorative Lucide `Calendar` icon** from the left of the `DatePicker` input — the actual picker trigger is the native `::-webkit-calendar-picker-indicator` on the right, so the left one was duplicated chrome. The input gets full horizontal space now.
2. **Wraps the `DatePicker` outer flex with `flex-wrap`** so the *"Hari Ini"* button drops below the input on narrow columns instead of overflowing, and gives the input `min-w-0 flex-1` so it shrinks gracefully.
3. **Adds `color-scheme: light` and `.dark { color-scheme: dark }`** in `globals.css` so the OS-rendered picker indicator follows the active theme — dark icon on light, light icon on dark. A `filter: invert(1)` fallback covers older Linux WebKit builds where `color-scheme` is honoured inconsistently. Picker indicator is also given `cursor: pointer` and a hover opacity so it feels clickable.
4. **Switches the Peminjaman date row** from `sm:grid-cols-2` to `xl:grid-cols-2`. Below 1280 px the dates stack vertically so the labels never get clipped, and at 1280 px+ they sit side-by-side as before.

Both raw `<Input type="date">` in `AnggotaForm` (*Tanggal Lahir*, *Tanggal Daftar*) inherit the theme/contrast fix automatically since the rules are global.

Quality gates run locally: 8/8 pass.

## Review & Testing Checklist for Human

Risk: **green** — UI-only.

- [ ] Toggle dark mode and confirm the calendar picker indicator is visibly **light** on dark / **dark** on light, on every page that has a date input (Peminjaman, Pengembalian, Anggota form, Laporan filters, Kunjungan).
- [ ] Resize the window from full-screen down to ~900 px and confirm the *Tanggal Pinjam* / *Jatuh Tempo* labels are no longer clipped.
- [ ] Verify the *"Hari Ini"* button is still wired up (clicking sets value to today's ISO date).
- [ ] Verify the date-range presets in `DateRangePicker` still render and trigger correctly.

### Notes

Drop-in PR per the v1.0.3 scope agreement (#1, #2, #4, #5, #8, #14 + #9 optional). Lands second after #2 because they are isolated UI fixes.