### PR TITLE
fix(ui): expand CRUD form max-width on wide windows (v1.0.3 #8)

### DIFF
--- a/apps/desktop/src/routes/_authed/anggota/$id.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/$id.tsx
@@ -57,7 +57,7 @@ function EditAnggotaRoute() {
   }, [id, navigate, showToast, t]);
 
   return (
-    <div className="container mx-auto max-w-3xl p-6 md:p-8">
+    <div className="container mx-auto max-w-3xl xl:max-w-5xl 2xl:max-w-7xl p-6 md:p-8">
       <div className="mb-6 flex items-center justify-between">
         <Button asChild variant="ghost" size="sm">
           <Link to="/anggota">

--- a/apps/desktop/src/routes/_authed/anggota/new.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/new.tsx
@@ -33,7 +33,7 @@ function NewAnggotaRoute() {
   }, []);
 
   return (
-    <div className="container mx-auto max-w-3xl p-6 md:p-8">
+    <div className="container mx-auto max-w-3xl xl:max-w-5xl 2xl:max-w-7xl p-6 md:p-8">
       <div className="mb-6 flex items-center justify-between">
         <Button asChild variant="ghost" size="sm">
           <Link to="/anggota">

--- a/apps/desktop/src/routes/_authed/buku/$id.tsx
+++ b/apps/desktop/src/routes/_authed/buku/$id.tsx
@@ -63,7 +63,7 @@ function EditBukuRoute() {
   }, [id, navigate, showToast, t]);
 
   return (
-    <div className="container mx-auto max-w-3xl p-6 md:p-8">
+    <div className="container mx-auto max-w-3xl xl:max-w-5xl 2xl:max-w-7xl p-6 md:p-8">
       <div className="mb-6 flex items-center justify-between">
         <Button asChild variant="ghost" size="sm">
           <Link to="/buku">

--- a/apps/desktop/src/routes/_authed/buku/new.tsx
+++ b/apps/desktop/src/routes/_authed/buku/new.tsx
@@ -31,7 +31,7 @@ function NewBukuRoute() {
   }, []);
 
   return (
-    <div className="container mx-auto max-w-3xl p-6 md:p-8">
+    <div className="container mx-auto max-w-3xl xl:max-w-5xl 2xl:max-w-7xl p-6 md:p-8">
       <div className="mb-6 flex items-center justify-between">
         <Button asChild variant="ghost" size="sm">
           <Link to="/buku">


### PR DESCRIPTION
## Summary

Fixes item #8 from the v1.0.3 backlog (`.devin/handoff/v1.0.3/backlog.md`).

vielz reported (post-v1.0.2) that the *Ubah Data Anggota* form is locked at ~768 px even when the window is 1920 px wide, leaving a huge dead zone of whitespace either side.

Bumps the four CRUD form route containers from a fixed `max-w-3xl` to a tiered `max-w-3xl xl:max-w-5xl 2xl:max-w-7xl` so:
- below 1280 px the layout matches the existing density (no change);
- 1280–1535 px gets max 1024 px;
- 1536 px and up gets max 1280 px.

Files touched:
- `apps/desktop/src/routes/_authed/anggota/new.tsx`
- `apps/desktop/src/routes/_authed/anggota/$id.tsx`
- `apps/desktop/src/routes/_authed/buku/new.tsx`
- `apps/desktop/src/routes/_authed/buku/$id.tsx`

The Anggota and Buku forms already have `md:grid-cols-2` internally so the extra horizontal space is filled by wider field columns rather than larger empty gutters.

## Review & Testing Checklist for Human

Risk: **green** — pure CSS class swap on container divs.

- [ ] Open Anggota → Edit on a fullscreen 1080p / 1440p / 4K display and confirm the form fills out wider than before, but still has a comfortable max-width on ultra-wide screens.
- [ ] Resize down to ~1024 px and confirm there is no horizontal overflow / regressions.
- [ ] Repeat for Buku → New / Edit.

### Notes

- **Local gates:** 1–4 (i18n-lint, typecheck, lint, vitest) passed; gate 5 (frontend build) was interrupted by a pause request before completion. CI on this PR will verify the full pipeline.
- This is the third v1.0.3 PR (after #90 tooltips, #91 dates+responsive). #14, #1, and #9 still queued — see the v1.0.3 progress doc on PR #89.