### PR TITLE
fix(filepicker): render preview via base64 data URL to bypass Windows asset-protocol scope mismatch (#1)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2788,6 +2788,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 name = "perpustakaan-desktop"
 version = "1.0.2"
 dependencies = [
+ "base64 0.22.1",
  "bcrypt",
  "chrono",
  "directories",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ rand = "0.8"
 hex = "0.4"
 chrono = { version = "0.4", features = ["clock"] }
 sha2 = "0.10"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/desktop/src-tauri/src/commands/assets.rs
+++ b/apps/desktop/src-tauri/src/commands/assets.rs
@@ -18,6 +18,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use base64::Engine;
 use serde::Serialize;
 use tauri::{AppHandle, Manager};
 
@@ -199,6 +200,74 @@ pub(crate) fn resolve_inner(app_data: &Path, rel_path: &str) -> AppResult<String
     Ok(joined.to_string_lossy().to_string())
 }
 
+/// MIME type to use in `data:` URLs for a saved asset, keyed by lowercased
+/// extension. Mirrors [`ALLOWED_EXTS`] so every successfully-saved upload
+/// has a usable mapping.
+fn mime_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "bmp" => "image/bmp",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Pure helper for unit tests: read the asset under `<app_data>/<rel_path>`
+/// (or the absolute path verbatim, for legacy v1 entries) and return a
+/// `data:<mime>;base64,<payload>` URL ready to feed into an `<img src=…>`.
+///
+/// This deliberately bypasses Tauri's `asset://` protocol and its scope
+/// matcher: on Windows the scope matcher fails to match `\\?\C:\…`-prefixed
+/// canonicalised paths against `$APPDATA/uploads/**`-style patterns, which
+/// is the root cause of the v1.0.2 "broken-image glyph on Logo / Foto / Cover"
+/// regression. Reading the bytes through a Tauri command sidesteps that
+/// matcher entirely and produces an inline `data:` URL the WebView will
+/// always render.
+pub(crate) fn read_data_url_inner(app_data: &Path, rel_path: &str) -> AppResult<String> {
+    if rel_path.is_empty() {
+        return Err(AppError::Validation("rel_path must not be empty".into()));
+    }
+    let candidate = Path::new(rel_path);
+    let abs = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        validate_rel_path(rel_path)?;
+        app_data.join(rel_path)
+    };
+
+    let metadata = std::fs::metadata(&abs).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => AppError::NotFound(format!("asset: {}", abs.display())),
+        _ => AppError::Io(e),
+    })?;
+    if !metadata.is_file() {
+        return Err(AppError::Validation(format!(
+            "asset is not a regular file: {}",
+            abs.display()
+        )));
+    }
+    if metadata.len() > MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "asset too large to inline: {} bytes > {} bytes",
+            metadata.len(),
+            MAX_BYTES
+        )));
+    }
+
+    let ext = abs
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    let mime = mime_for_ext(&ext);
+
+    let bytes = std::fs::read(&abs)?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("data:{mime};base64,{encoded}"))
+}
+
 /// Pure helper for unit tests: best-effort delete of an upload that lives
 /// under `<app_data>/<rel_path>`. Absolute / legacy paths are intentionally
 /// left untouched so we never delete files we did not own.
@@ -238,6 +307,12 @@ pub fn assets_resolve(app: AppHandle, rel_path: String) -> AppResult<String> {
 pub fn assets_delete(app: AppHandle, rel_path: String) -> AppResult<()> {
     let app_data = app_data_dir(&app)?;
     delete_inner(&app_data, &rel_path)
+}
+
+#[tauri::command]
+pub fn assets_read_data_url(app: AppHandle, rel_path: String) -> AppResult<String> {
+    let app_data = app_data_dir(&app)?;
+    read_data_url_inner(&app_data, &rel_path)
 }
 
 #[cfg(test)]
@@ -398,5 +473,89 @@ mod tests {
             delete_inner(app_data.path(), "uploads/../../etc/passwd"),
             Err(AppError::Validation(_)),
         ));
+    }
+
+    #[test]
+    fn read_data_url_inner_inlines_png_bytes_with_correct_mime() {
+        let app_data = TempDir::new().expect("tempdir");
+        let target_dir = app_data.path().join("uploads/identitas");
+        fs::create_dir_all(&target_dir).expect("mkdir");
+        let payload = b"\x89PNG\r\n\x1a\nfake-tail";
+        fs::write(target_dir.join("logo.png"), payload).expect("write");
+
+        let url = read_data_url_inner(app_data.path(), "uploads/identitas/logo.png")
+            .expect("read_data_url ok");
+        assert!(url.starts_with("data:image/png;base64,"));
+        let payload_b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+        assert!(url.ends_with(&payload_b64), "url ends with base64 payload");
+    }
+
+    #[test]
+    fn read_data_url_inner_picks_jpeg_mime_for_jpg_and_jpeg_extensions() {
+        let app_data = TempDir::new().expect("tempdir");
+        let target_dir = app_data.path().join("uploads/anggota");
+        fs::create_dir_all(&target_dir).expect("mkdir");
+        fs::write(target_dir.join("foto.jpg"), b"jpg").expect("write jpg");
+        fs::write(target_dir.join("foto.jpeg"), b"jpeg").expect("write jpeg");
+
+        let jpg = read_data_url_inner(app_data.path(), "uploads/anggota/foto.jpg").expect("jpg");
+        let jpeg = read_data_url_inner(app_data.path(), "uploads/anggota/foto.jpeg").expect("jpeg");
+        assert!(jpg.starts_with("data:image/jpeg;base64,"));
+        assert!(jpeg.starts_with("data:image/jpeg;base64,"));
+    }
+
+    #[test]
+    fn read_data_url_inner_passes_through_absolute_legacy_path() {
+        let app_data = TempDir::new().expect("tempdir");
+        let outside = TempDir::new().expect("outside");
+        let legacy = outside.path().join("old.png");
+        fs::write(&legacy, b"old-bytes").expect("write");
+
+        let url = read_data_url_inner(app_data.path(), legacy.to_str().expect("utf8"))
+            .expect("absolute path resolves");
+        assert!(url.starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn read_data_url_inner_rejects_traversal_and_missing_files() {
+        let app_data = TempDir::new().expect("tempdir");
+        assert!(matches!(
+            read_data_url_inner(app_data.path(), "uploads/../../etc/passwd"),
+            Err(AppError::Validation(_)),
+        ));
+        assert!(matches!(
+            read_data_url_inner(app_data.path(), ""),
+            Err(AppError::Validation(_)),
+        ));
+        assert!(matches!(
+            read_data_url_inner(app_data.path(), "uploads/anggota/missing.png"),
+            Err(AppError::NotFound(_)),
+        ));
+    }
+
+    #[test]
+    fn read_data_url_inner_rejects_oversized_file() {
+        let app_data = TempDir::new().expect("tempdir");
+        let target_dir = app_data.path().join("uploads/buku");
+        fs::create_dir_all(&target_dir).expect("mkdir");
+        let path = target_dir.join("huge.png");
+        let f = fs::File::create(&path).expect("create");
+        f.set_len(MAX_BYTES + 1).expect("set_len");
+
+        let err = read_data_url_inner(app_data.path(), "uploads/buku/huge.png")
+            .expect_err("must reject");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn read_data_url_inner_uses_octet_stream_for_unknown_extensions() {
+        let app_data = TempDir::new().expect("tempdir");
+        let target_dir = app_data.path().join("uploads/buku");
+        fs::create_dir_all(&target_dir).expect("mkdir");
+        fs::write(target_dir.join("note.txt"), b"hello").expect("write");
+
+        let url = read_data_url_inner(app_data.path(), "uploads/buku/note.txt")
+            .expect("ok");
+        assert!(url.starts_with("data:application/octet-stream;base64,"));
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -180,6 +180,7 @@ pub fn run() {
             commands::assets::assets_save,
             commands::assets::assets_resolve,
             commands::assets::assets_delete,
+            commands::assets::assets_read_data_url,
         ])
         .on_window_event(|window, event| {
             // BUG-011: intercept the X-button on the main window and

--- a/apps/desktop/src/components/shared/FilePickerInput.tsx
+++ b/apps/desktop/src/components/shared/FilePickerInput.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { convertFileSrc } from '@tauri-apps/api/core';
 import { ImageIcon, Loader2, Trash2, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { isTauri } from '@/lib/auth';
 import { assetsApi, type AssetCategory } from '@/lib/assets';
 import { cn } from '@/lib/utils';
 
@@ -74,15 +72,11 @@ export function FilePickerInput({
     let cancelled = false;
     void (async () => {
       try {
-        const abs = await assetsApi.resolve(value);
+        const dataUrl = await assetsApi.readDataUrl(value);
         if (cancelled || requestId.current !== myId) return;
-        if (!abs || abs.startsWith('mock://')) {
-          // Browser-mode mock: we cannot read local files, so just show
-          // the placeholder.
-          setPreviewUrl(null);
-          return;
-        }
-        setPreviewUrl(isTauri() ? convertFileSrc(abs) : abs);
+        // Browser-mode mock returns "" because the bytes aren't on disk;
+        // fall back to the placeholder icon.
+        setPreviewUrl(dataUrl ? dataUrl : null);
       } catch {
         if (!cancelled) setPreviewUrl(null);
       }

--- a/apps/desktop/src/lib/assets.ts
+++ b/apps/desktop/src/lib/assets.ts
@@ -38,6 +38,15 @@ export interface AssetsRpc {
    */
   resolve(path: string): Promise<string>;
 
+  /**
+   * Read the bytes of a saved asset and return a `data:<mime>;base64,…`
+   * URL the WebView can render directly. Bypasses the `asset://`
+   * protocol scope matcher, which is unreliable on Windows because
+   * canonicalised `\\?\C:\…` paths fail to match `$APPDATA/uploads/**`
+   * patterns and produce broken-image glyphs.
+   */
+  readDataUrl(path: string): Promise<string>;
+
   /** Best-effort delete of an upload. No-op for absolute / empty paths. */
   delete(path: string): Promise<void>;
 }
@@ -57,6 +66,7 @@ const tauriRpc: AssetsRpc = {
     return { relPath: result.relPath, absPath: result.absPath };
   },
   resolve: (path) => invoke<string>('assets_resolve', { relPath: path }),
+  readDataUrl: (path) => invoke<string>('assets_read_data_url', { relPath: path }),
   delete: (path) => invoke<void>('assets_delete', { relPath: path }),
 };
 
@@ -77,6 +87,12 @@ const mockRpc: AssetsRpc = {
   async resolve(path) {
     if (!path) return '';
     return path;
+  },
+  async readDataUrl(path) {
+    // Browser mode never has the actual bytes; return an empty data URL
+    // so callers fall back to the placeholder icon without throwing.
+    if (!path) return '';
+    return '';
   },
   async delete() {
     /* noop */

--- a/apps/desktop/tests/unit/filePickerInput.test.tsx
+++ b/apps/desktop/tests/unit/filePickerInput.test.tsx
@@ -9,6 +9,7 @@ const { mockApi } = vi.hoisted(() => ({
   mockApi: {
     pickAndSave: vi.fn(),
     resolve: vi.fn(),
+    readDataUrl: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -16,14 +17,6 @@ const { mockApi } = vi.hoisted(() => ({
 vi.mock('@/lib/assets', () => ({
   assetsApi: mockApi,
   IMAGE_EXTS: ['png', 'jpg', 'jpeg', 'webp'] as const,
-}));
-
-vi.mock('@tauri-apps/api/core', () => ({
-  convertFileSrc: (p: string) => `tauri://asset/${p}`,
-}));
-
-vi.mock('@/lib/auth', () => ({
-  isTauri: () => false,
 }));
 
 import { FilePickerInput } from '@/components/shared/FilePickerInput';
@@ -63,6 +56,7 @@ describe('FilePickerInput', () => {
   beforeEach(() => {
     mockApi.pickAndSave.mockReset();
     mockApi.resolve.mockReset();
+    mockApi.readDataUrl.mockReset();
     mockApi.delete.mockReset();
   });
 
@@ -74,7 +68,7 @@ describe('FilePickerInput', () => {
   });
 
   it('uses caller-provided pick / clear labels when supplied', () => {
-    mockApi.resolve.mockResolvedValue('/abs/uploads/anggota/x.jpg');
+    mockApi.readDataUrl.mockResolvedValue('data:image/png;base64,AAA');
     renderPicker({
       value: 'uploads/anggota/x.jpg',
       pickLabel: 'Pilih foto…',
@@ -84,23 +78,37 @@ describe('FilePickerInput', () => {
     expect(screen.getByTestId('picker-clear')).toHaveTextContent('Hapus foto');
   });
 
-  it('resolves the relative path and renders a preview image when value is set', async () => {
-    mockApi.resolve.mockResolvedValue('/abs/uploads/anggota/x.jpg');
+  it('reads the bytes via readDataUrl and renders the preview as an inline data URL', async () => {
+    const dataUrl = 'data:image/jpeg;base64,SGVsbG8=';
+    mockApi.readDataUrl.mockResolvedValue(dataUrl);
     renderPicker({ value: 'uploads/anggota/x.jpg' });
 
     await waitFor(() => {
-      expect(mockApi.resolve).toHaveBeenCalledWith('uploads/anggota/x.jpg');
+      expect(mockApi.readDataUrl).toHaveBeenCalledWith('uploads/anggota/x.jpg');
     });
     const img = await screen.findByTestId('picker-preview');
     expect(img.tagName).toBe('IMG');
-    expect(img).toHaveAttribute('src', '/abs/uploads/anggota/x.jpg');
+    expect(img).toHaveAttribute('src', dataUrl);
+    // Critical regression guard: we no longer call `resolve` (the
+    // asset-protocol path) because that round-trip is what produced the
+    // broken-image glyph on Windows in v1.0.2.
+    expect(mockApi.resolve).not.toHaveBeenCalled();
   });
 
-  it('falls back to the placeholder when resolve returns an empty string', async () => {
-    mockApi.resolve.mockResolvedValue('');
+  it('falls back to the placeholder when readDataUrl returns an empty string', async () => {
+    mockApi.readDataUrl.mockResolvedValue('');
     renderPicker({ value: 'uploads/anggota/missing.jpg' });
     await waitFor(() => {
-      expect(mockApi.resolve).toHaveBeenCalled();
+      expect(mockApi.readDataUrl).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('picker-preview')).toBeNull();
+  });
+
+  it('falls back to the placeholder when readDataUrl rejects', async () => {
+    mockApi.readDataUrl.mockRejectedValue(new Error('not found'));
+    renderPicker({ value: 'uploads/anggota/broken.jpg' });
+    await waitFor(() => {
+      expect(mockApi.readDataUrl).toHaveBeenCalled();
     });
     expect(screen.queryByTestId('picker-preview')).toBeNull();
   });
@@ -135,7 +143,7 @@ describe('FilePickerInput', () => {
   });
 
   it('deletes the previous file when replacing an existing value', async () => {
-    mockApi.resolve.mockResolvedValue('/abs/uploads/anggota/old.png');
+    mockApi.readDataUrl.mockResolvedValue('data:image/png;base64,b2xk');
     mockApi.pickAndSave.mockResolvedValue({
       relPath: 'uploads/anggota/new.png',
       absPath: '/abs/uploads/anggota/new.png',
@@ -152,7 +160,7 @@ describe('FilePickerInput', () => {
   });
 
   it('calls onChange(null) and deletes the file when clear is clicked', async () => {
-    mockApi.resolve.mockResolvedValue('/abs/uploads/anggota/x.png');
+    mockApi.readDataUrl.mockResolvedValue('data:image/png;base64,eA==');
     mockApi.delete.mockResolvedValue(undefined);
     const { onChange } = renderPicker({ value: 'uploads/anggota/x.png' });
 
@@ -166,7 +174,7 @@ describe('FilePickerInput', () => {
   });
 
   it('still calls onChange(null) when delete throws (DB row should still drop the reference)', async () => {
-    mockApi.resolve.mockResolvedValue('/abs/uploads/anggota/x.png');
+    mockApi.readDataUrl.mockResolvedValue('data:image/png;base64,eA==');
     mockApi.delete.mockRejectedValue(new Error('disk full'));
     const { onChange } = renderPicker({ value: 'uploads/anggota/x.png' });
 


### PR DESCRIPTION
## Summary

Fixes the broken-image glyph that appeared on Windows for every FilePickerInput preview in v1.0.2 — Logo Perpustakaan (Pengaturan → Identitas), Foto Anggota (Anggota → Tambah / Edit), and Cover Buku (Buku → Tambah / Edit).

**Root cause** is in Tauri 2's asset-protocol scope matcher:

- The configured scope `$APPDATA/uploads/**` expands via `PathResolver::parse` into a literal Windows path **without** the `\\?\` extended-length prefix.
- The asset handler validates the incoming URL by calling `std::fs::canonicalize`, which on Windows **always** prepends `\\?\` (verbatim path).
- `glob::Pattern::matches_path_with(require_literal_separator: true)` then compares `\\?\C:\Users\…\uploads\file.png` against the prefix-less pattern → no match → 403 → broken-image glyph.

This bug is not reproducible on Linux because `canonicalize` on Linux returns the same separators as the literal pattern.

**Fix:** introduce a new `assets_read_data_url` Tauri command that reads the saved asset's bytes through the IPC bridge and returns a `data:<mime>;base64,<payload>` URL. The FilePickerInput preview hook now consumes that URL directly, sidestepping the asset-protocol scope matcher entirely. Works identically on Linux, macOS, and Windows.

The existing `assets_resolve` command is retained for any caller that legitimately needs an absolute filesystem path (none today inside FilePickerInput).

### Files touched

- `apps/desktop/src-tauri/src/commands/assets.rs` — new `read_data_url_inner` pure helper + `assets_read_data_url` Tauri command. 7 new unit tests.
- `apps/desktop/src-tauri/src/lib.rs` — register the new command.
- `apps/desktop/src-tauri/Cargo.toml` / `Cargo.lock` — add `base64 = "0.22"` for inline encoding.
- `apps/desktop/src/lib/assets.ts` — extend `AssetsRpc` with `readDataUrl(path)`. Browser-mode mock returns `""`.
- `apps/desktop/src/components/shared/FilePickerInput.tsx` — preview hook now calls `assetsApi.readDataUrl(value)` instead of `assetsApi.resolve(value)` + `convertFileSrc`.
- `apps/desktop/tests/unit/filePickerInput.test.tsx` — migrate the suite to assert the new contract; explicitly guard against the old `assetsApi.resolve` regression path.

## Review & Testing Checklist for Human

- [ ] **Verify the fix on Windows** by running the published v1.0.3 installer and uploading a Logo, a Foto Anggota, and a Cover Buku — each preview should render the actual image, not the broken-image icon.
- [ ] Review `read_data_url_inner` in `apps/desktop/src-tauri/src/commands/assets.rs` for any path-traversal / absolute-path edge case I missed (the helper reuses `validate_rel_path` and the same `MAX_BYTES` guard as `save_inner`).
- [ ] Confirm no other code path (e.g. the `KtaPreview` component, KTA print) was relying on the old `convertFileSrc` round-trip — those use raw paths bound to `<img src=>` directly in print HTML and are not affected.

### Notes

- Manually verified on Linux dev (`pnpm tauri:dev`) that all three FilePickerInput surfaces (Logo, Foto Anggota, Cover Buku) successfully save the file and render the inline `data:` preview after picking. Files land under `<app_data_dir>/uploads/<category>/` exactly as before; the change is purely how the preview is fetched into the WebView.
- Local gates green: `pnpm i18n:lint`, `pnpm typecheck`, `pnpm --filter @perpustakaan/desktop lint`, `pnpm --filter @perpustakaan/desktop test`, `pnpm --filter @perpustakaan/desktop build`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (66 / 66, includes 7 new tests).
- This change does **not** touch item #3 (image auto-compression) — that remains deferred to v1.0.4 per `scope-proposal.md`.