### PR TITLE
chore(release): v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,45 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-05-04
+
+### Fixed
+
+- **FilePickerInput preview broken on Windows** — Logo Perpustakaan,
+  Foto Anggota, and Cover Buku previews rendered the broken-image
+  glyph after a successful upload because Tauri 2's asset-protocol
+  scope matcher failed to match canonicalised `\\?\C:\…` paths against
+  the `$APPDATA/uploads/**` pattern. Replaced the `convertFileSrc`
+  round-trip with a new `assets_read_data_url` Tauri command that
+  reads the bytes through the IPC bridge and returns a
+  `data:<mime>;base64,<payload>` URL the WebView always renders.
+  Works identically on Linux, macOS, and Windows. (#94)
+- **Date input contrast in dark mode** — native calendar / time inputs
+  now inherit the theme via `color-scheme`, so the icon and value
+  remain readable on dark backgrounds. Filter-invert fallback applied
+  to browsers that ignore `color-scheme`. (#91)
+- **Form layout cramped on wide windows** — Anggota / Buku create &
+  edit routes now expand to `max-w-3xl xl:max-w-5xl 2xl:max-w-7xl`
+  instead of clipping at the smaller container width. (#92)
+
+### Changed
+
+- **Per-aspect-ratio Windows installer artwork** — re-exported the
+  four BMPs (`nsis-sidebar.bmp` 164×314, `nsis-header.bmp` 150×57,
+  `wix-banner.bmp` 493×58, `wix-dialog.bmp` 493×312) from per-target
+  SVG sources rendered at the exact target resolution. The previous
+  v1.0.2 installer stretched a single source across all four aspect
+  ratios, producing distorted art. Sources, regen script, and an
+  install-artwork README live in `apps/desktop/src-tauri/installer/`.
+  (#93)
+- **Tooltips on icon-only buttons** — global tooltip wrapper sweep
+  over 7 components so every icon-only button surfaces its label on
+  hover, improving keyboard / screen-reader navigation. (#90)
+- **Responsive Peminjaman date pickers** — flex-wrap "Hari Ini"
+  shortcut so it drops below the date inputs on narrow widths, and
+  promote Peminjaman date pickers to `xl:grid-cols-2` on wide
+  windows. (#91)
+
 ## [1.0.2] - 2026-05-04
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2786,7 +2786,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.2"
+version = "1.0.3"
 description = "Perpustakaan Offline v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanOffline",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Perpustakaan Offline v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

Releases v1.0.3 — bumps versions in the four canonical locations and moves the previous `## [Unreleased]` content under `## [1.0.3] - 2026-05-04` in `CHANGELOG.md`.

### Bumps

- `package.json` (root) 1.0.2 → 1.0.3
- `apps/desktop/package.json` 1.0.2 → 1.0.3
- `apps/desktop/src-tauri/Cargo.toml` 1.0.2 → 1.0.3
- `apps/desktop/src-tauri/Cargo.lock` (regenerated to match)
- `apps/desktop/src-tauri/tauri.conf.json` 1.0.2 → 1.0.3

### Shipping in 1.0.3

- Fix: FilePickerInput preview broken on Windows (#94)
- Fix: Date input contrast in dark mode (#91)
- Fix: Form layout cramped on wide windows (#92)
- Change: Per-aspect-ratio Windows installer artwork (#93)
- Change: Tooltips on icon-only buttons (#90)
- Change: Responsive Peminjaman date pickers (#91)

### Deferred to v1.0.4

- Item #9 — Cetak KTA "Buka Folder Hasil" button. The current Cetak KTA flow runs `window.print()` against an inline HTML window; there is no result file written to disk and therefore no folder to open. Implementing it requires first adding a Tauri save-to-PDF command, which is out of scope for v1.0.3.

## Review & Testing Checklist for Human

- [ ] After merge, tag `v1.0.3` and push — the `release-v2` workflow auto-publishes a GitHub Release whose body is whatever `scripts/extract-changelog.mjs v1.0.3` returns. Confirm the resulting Release contains the full Fixed / Changed sections and attaches the Windows MSI + NSIS installers.
- [ ] Spot-check `CHANGELOG.md` to confirm no item from 1.0.2 was accidentally moved into 1.0.3 and that the date matches the planned release day.
- [ ] After the GitHub Release is published, install the Windows artifact and verify the four FilePickerInput fixes (Logo, Foto Anggota, Cover Buku, plus the responsive date / form layouts) work in the actual installed binary.

### Notes

- All 8 quality gates green locally (`/home/ubuntu/run-gates.sh release-1.0.3`).
- `scripts/extract-changelog.mjs v1.0.3` returns a clean Fixed + Changed extract with no trailing whitespace, ready for the GitHub Release body.
- This PR contains *no* code changes — only metadata (versions + changelog). The actual fixes / changes already landed in PRs #90, #91, #92, #93, #94.