### PR TITLE
feat(settings): redesign Hak Akses permission matrix for readability

### DIFF
--- a/apps/desktop/src/features/settings/HakAksesPage.tsx
+++ b/apps/desktop/src/features/settings/HakAksesPage.tsx
@@ -66,45 +66,83 @@ export function HakAksesPage(): JSX.Element {
       onReset={handleReset}
       saving={saving}
     >
+      {/*
+        Two-row header groups checkboxes by role (Admin | Pustakawan), and a
+        sticky first column keeps the area label on screen while scrolling
+        the role columns horizontally on narrow displays. Zebra body rows +
+        hover highlight + vertical divider between role groups make it
+        obvious which checkbox you're toggling for which role / area.
+      */}
       <div className="overflow-x-auto rounded-md border">
-        <table className="w-full text-sm">
-          <thead className="bg-muted/40">
-            <tr>
-              <th className="px-3 py-2 text-left font-medium">
-                {t('sections.hakAkses.areas.anggota', { defaultValue: 'Area' })}
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="bg-muted/60">
+              <th
+                rowSpan={2}
+                scope="col"
+                className="bg-muted/60 sticky left-0 z-10 min-w-40 border-b border-r px-3 py-2 text-left font-semibold"
+              >
+                {t('sections.hakAkses.headerArea', { defaultValue: 'Area' })}
               </th>
-              {ROLES.flatMap((role) =>
-                PERMISSION_ACTIONS.map((act) => (
+              {ROLES.map((role, roleIdx) => (
+                <th
+                  key={role}
+                  scope="colgroup"
+                  colSpan={PERMISSION_ACTIONS.length}
+                  className={`border-b px-2 py-2 text-center font-semibold ${
+                    roleIdx > 0 ? 'border-l' : ''
+                  }`}
+                >
+                  {t(`sections.hakAkses.roles.${role}`, { defaultValue: role })}
+                </th>
+              ))}
+            </tr>
+            <tr className="bg-muted/40">
+              {ROLES.flatMap((role, roleIdx) =>
+                PERMISSION_ACTIONS.map((act, actIdx) => (
                   <th
                     key={`${role}-${act}`}
-                    className="px-2 py-2 text-center text-xs font-medium"
+                    scope="col"
+                    className={`min-w-20 border-b px-2 py-1.5 text-center text-xs font-medium ${
+                      roleIdx > 0 && actIdx === 0 ? 'border-l' : ''
+                    }`}
                     title={`${role} · ${act}`}
                   >
-                    <div className="flex flex-col">
-                      <span className="text-[0.65rem] uppercase text-muted-foreground">
-                        {t(`sections.hakAkses.roles.${role}`, { defaultValue: role })}
-                      </span>
-                      <span>{t(`sections.hakAkses.actions.${act}`, { defaultValue: act })}</span>
-                    </div>
+                    {t(`sections.hakAkses.actions.${act}`, { defaultValue: act })}
                   </th>
                 )),
               )}
             </tr>
           </thead>
           <tbody>
-            {PERMISSION_AREAS.map((area) => (
-              <tr key={area} className="border-t">
-                <td className="px-3 py-2 font-medium">
+            {PERMISSION_AREAS.map((area, rowIdx) => (
+              <tr
+                key={area}
+                className={`hover:bg-muted/40 ${rowIdx % 2 === 1 ? 'bg-muted/20' : ''}`}
+              >
+                <th
+                  scope="row"
+                  className={`bg-background sticky left-0 z-10 border-r px-3 py-2 text-left font-medium ${
+                    rowIdx % 2 === 1 ? 'bg-muted/20' : ''
+                  }`}
+                >
                   {t(`sections.hakAkses.areas.${area}`, { defaultValue: area })}
-                </td>
-                {ROLES.flatMap((role) =>
-                  PERMISSION_ACTIONS.map((act) => (
-                    <td key={`${role}-${area}-${act}`} className="px-2 py-2 text-center">
+                </th>
+                {ROLES.flatMap((role, roleIdx) =>
+                  PERMISSION_ACTIONS.map((act, actIdx) => (
+                    <td
+                      key={`${role}-${area}-${act}`}
+                      className={`px-2 py-2 text-center ${
+                        roleIdx > 0 && actIdx === 0 ? 'border-l' : ''
+                      }`}
+                    >
                       <input
                         type="checkbox"
                         checked={matrix[role][area][act]}
                         onChange={() => toggle(role, area, act)}
                         data-testid={`perm-${role}-${area}-${act}`}
+                        aria-label={`${t(`sections.hakAkses.roles.${role}`, { defaultValue: role })} · ${t(`sections.hakAkses.areas.${area}`, { defaultValue: area })} · ${t(`sections.hakAkses.actions.${act}`, { defaultValue: act })}`}
+                        className="size-4 cursor-pointer accent-primary"
                       />
                     </td>
                   )),

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -131,6 +131,7 @@
     "hakAkses": {
       "label": "Permissions",
       "summary": "Permission matrix per role (admin, librarian).",
+      "headerArea": "Area",
       "roles": {
         "admin": "Admin",
         "pustakawan": "Librarian"

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -131,6 +131,7 @@
     "hakAkses": {
       "label": "Hak Akses",
       "summary": "Matriks izin per peran (admin, pustakawan).",
+      "headerArea": "Area",
       "roles": {
         "admin": "Admin",
         "pustakawan": "Pustakawan"


### PR DESCRIPTION
## Summary

Closes v1.0.4 #7 — Hak Akses table readability.

The permission matrix in `Pengaturan → Hak Akses` was hard to scan: 8 columns of checkboxes with no visual separation between roles, no zebra rows, and the area name scrolled off-screen on narrow displays. This PR re-designs the table without changing any logic or persisted shape.

Changes:
- **Two-row header**: top row groups columns under role names (`Admin` | `Pustakawan`), bottom row labels each action (`Lihat / Tambah / Ubah / Hapus`).
- **Vertical divider** (`border-l`) at the seam between role groups so it's obvious which checkbox you're about to toggle for which role.
- **Sticky first column**: the area name (`Anggota / Buku / Peminjaman / …`) stays pinned on the left while the role columns scroll horizontally.
- **Zebra body rows** + **hover highlight** so the eye can track an area row across all 8 checkboxes without losing place.
- **Larger checkbox** (`size-4`) with `accent-primary` so the checked state matches the rest of the design system.
- **aria-label** on every checkbox so screen readers announce `Admin · Anggota · Lihat` instead of a bare unlabeled control.

i18n: one new key `sections.hakAkses.headerArea` ("Area" / "Area") added to both `id` and `en`. Existing keys (`roles.*`, `actions.*`, `areas.*`, `saveSuccess`) untouched.

No backend changes; no permission semantics changed; no migrations.

## Review & Testing Checklist for Human

- [ ] Open `Pengaturan → Hak Akses` in light mode — verify the role group header (`Admin | Pustakawan`) sits above the action labels, separated by a clear vertical line.
- [ ] Toggle dark mode — verify zebra rows, hover highlight, and the sticky-column background colour all stay legible.
- [ ] Resize the window narrow enough to force horizontal scroll on the table — verify the `Area` column stays pinned on the left and the role columns scroll under it.
- [ ] Toggle a few checkboxes and click `Simpan` — verify the toast `Matriks izin berhasil disimpan.` still fires and the values round-trip after a reload.

### Notes

- All 8 quality gates green: `ALL_GATES_OK hak-akses-readability`.
- No existing unit tests reference this page; smoke test deferred to the human reviewer because the change is purely presentational.
