### PR TITLE
chore(brand): rename product Perpustakaan Offline -> Perpustakaan Nusantara

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Perpustakaan Offline (SIM-Perpus Reborn) — v2
+# Perpustakaan Nusantara (SIM-Perpus Reborn) — v2
 
 > Aplikasi **Sistem Informasi Manajemen Perpustakaan** (SIM-Perpus) berbasis **Tauri 2 + React 18 + TypeScript + SQLite** yang berjalan **100% offline** dan dapat dikemas menjadi **MSI / NSIS installer** Windows, `.deb` Linux, atau `.app` macOS. Cocok untuk perpustakaan **sekolah / madrasah**.
 
@@ -91,9 +91,9 @@ pnpm tauri:build
 
 Output ada di `apps/desktop/src-tauri/target/release/bundle/`:
 
-- **Windows:** `msi/PerpustakaanOffline_<version>_x64_en-US.msi` + `nsis/PerpustakaanOffline_<version>_x64-setup.exe`
+- **Windows:** `msi/PerpustakaanNusantara_<version>_x64_en-US.msi` + `nsis/PerpustakaanNusantara_<version>_x64-setup.exe`
 - **Linux:** `deb/perpustakaan-offline_<version>_amd64.deb` + `appimage/perpustakaan-offline_<version>_amd64.AppImage`
-- **macOS:** `dmg/PerpustakaanOffline_<version>_aarch64.dmg`
+- **macOS:** `dmg/PerpustakaanNusantara_<version>_aarch64.dmg`
 
 Cross-build tidak didukung Tauri — build di OS target masing-masing (atau pakai CI matrix).
 

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0f172a" />
-    <title>Perpustakaan Offline</title>
+    <title>Perpustakaan Nusantara</title>
     <script>
       // Anti-FOUC: apply theme before React mounts (revisi #8)
       (function () {

--- a/apps/desktop/public/illustrations/CREDITS.md
+++ b/apps/desktop/public/illustrations/CREDITS.md
@@ -1,6 +1,6 @@
 # Illustration credits
 
-Illustrations bundled with Perpustakaan Offline v2 are sourced from the
+Illustrations bundled with Perpustakaan Nusantara v2 are sourced from the
 following CC0 / royalty-free libraries. Replace any of these files with
 final hand-picked artwork from unDraw / Storyset / DrawKit before the
 public release.

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "perpustakaan-desktop"
 version = "1.0.3"
-description = "Perpustakaan Offline v2 desktop (Tauri 2)"
+description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capabilities default untuk Perpustakaan Offline v2 (sesi 2 baseline).",
+  "description": "Capabilities default untuk Perpustakaan Nusantara v2 (sesi 2 baseline).",
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/apps/desktop/src-tauri/src/commands/close_behavior.rs
+++ b/apps/desktop/src-tauri/src/commands/close_behavior.rs
@@ -5,7 +5,7 @@
 //!
 //! 1. Closing the *main window* did not always tear down the WebView2
 //!    subprocess + the Tauri event loop on its own — Windows kept the
-//!    `PerpustakaanOffline.exe` process alive in some configurations,
+//!    `PerpustakaanNusantara.exe` process alive in some configurations,
 //!    blocking subsequent launches and risking SQLite lock contention if a
 //!    user opened a second instance.
 //! 2. There was no way to keep the app running in the background as a

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -61,7 +61,7 @@ pub fn run() {
             let tray_menu = Menu::with_items(app, &[&buka_item, &keluar_item])?;
 
             let _tray = TrayIconBuilder::with_id("po-main")
-                .tooltip("Perpustakaan Offline")
+                .tooltip("Perpustakaan Nusantara")
                 .icon(
                     app.default_window_icon()
                         .cloned()

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "PerpustakaanOffline",
+  "productName": "PerpustakaanNusantara",
   "version": "1.0.3",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Perpustakaan Offline",
+        "title": "Perpustakaan Nusantara",
         "width": 1280,
         "height": 800,
         "minWidth": 800,
@@ -37,8 +37,8 @@
     "copyright": "© 2026 alvi arts / vwrks",
     "publisher": "alvi arts",
     "homepage": "https://github.com/alviarts/perpustakaan-offline",
-    "shortDescription": "Sistem Manajemen Perpustakaan Offline",
-    "longDescription": "Perpustakaan Offline v2 — modern offline-first library management system built with Tauri 2 + React 18.",
+    "shortDescription": "Sistem Manajemen Perpustakaan Nusantara",
+    "longDescription": "Perpustakaan Nusantara v2 — modern offline-first library management system built with Tauri 2 + React 18.",
     "targets": "all",
     "licenseFile": "../../../docs/legal/LICENSE-installer.txt",
     "icon": [

--- a/apps/desktop/src/components/layout/TitleBar.tsx
+++ b/apps/desktop/src/components/layout/TitleBar.tsx
@@ -48,7 +48,7 @@ interface TitleBarProps {
 export function TitleBar({ appName }: TitleBarProps): JSX.Element {
   const { t } = useTranslation(['common']);
   const [maximized, setMaximized] = useState(false);
-  const label = appName ?? t('common:appName', { defaultValue: 'Perpustakaan Offline' });
+  const label = appName ?? t('common:appName', { defaultValue: 'Perpustakaan Nusantara' });
 
   // Sync the maximize-button icon with the actual window state, including
   // when the user drags-to-edge or hits the OS shortcut (Super+Up on GNOME,

--- a/apps/desktop/src/i18n/en/common.json
+++ b/apps/desktop/src/i18n/en/common.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Perpustakaan Offline",
+  "appName": "Perpustakaan Nusantara",
   "tagline": "Modern, Offline-first Library Management System",
   "actions": {
     "save": "Save",

--- a/apps/desktop/src/i18n/id/common.json
+++ b/apps/desktop/src/i18n/id/common.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Perpustakaan Offline",
+  "appName": "Perpustakaan Nusantara",
   "tagline": "Sistem Manajemen Perpustakaan Modern, Offline-first",
   "actions": {
     "save": "Simpan",

--- a/apps/desktop/tests/unit/manualPage.test.tsx
+++ b/apps/desktop/tests/unit/manualPage.test.tsx
@@ -35,7 +35,7 @@ describe('ManualPage', () => {
   it('renders the manual title from docs/manual.md as an h1', () => {
     renderManual();
     expect(
-      screen.getByRole('heading', { name: /Manual Pengguna — Perpustakaan Offline/i, level: 1 }),
+      screen.getByRole('heading', { name: /Manual Pengguna — Perpustakaan Nusantara/i, level: 1 }),
     ).toBeInTheDocument();
   });
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,4 +1,4 @@
-# Manual Pengguna — Perpustakaan Offline
+# Manual Pengguna — Perpustakaan Nusantara
 
 > **English version below** — scroll ke bawah untuk versi Bahasa Inggris.
 
@@ -42,15 +42,15 @@ Tersedia **dua format installer**, pilih salah satu:
 
 | Format | File                                              | Catatan                                                  |
 |--------|---------------------------------------------------|----------------------------------------------------------|
-| MSI    | `PerpustakaanOffline_<versi>_x64_en-US.msi`       | Standar Windows Installer; cocok untuk deployment massal |
-| NSIS   | `PerpustakaanOffline_<versi>_x64-setup.exe`       | Wizard interaktif; cocok untuk install di 1 PC           |
+| MSI    | `PerpustakaanNusantara_<versi>_x64_en-US.msi`       | Standar Windows Installer; cocok untuk deployment massal |
+| NSIS   | `PerpustakaanNusantara_<versi>_x64-setup.exe`       | Wizard interaktif; cocok untuk install di 1 PC           |
 
 1. Download salah satu file di atas dari halaman Releases
 2. Klik 2x → ikuti wizard (Next → Next → Install)
-3. Aplikasi terinstall ke `C:\Program Files\PerpustakaanOffline\` (atau lokasi lain yang dipilih)
+3. Aplikasi terinstall ke `C:\Program Files\PerpustakaanNusantara\` (atau lokasi lain yang dipilih)
 4. Shortcut otomatis dibuat di **Start Menu**
-5. Klik shortcut **"PerpustakaanOffline"** untuk menjalankan — saat pertama kali dibuka, database SQLite + seed data otomatis dibuat
-6. Untuk uninstall: Control Panel → Programs → PerpustakaanOffline → Uninstall
+5. Klik shortcut **"PerpustakaanNusantara"** untuk menjalankan — saat pertama kali dibuka, database SQLite + seed data otomatis dibuat
+6. Untuk uninstall: Control Panel → Programs → PerpustakaanNusantara → Uninstall
 
 ### Linux (Ubuntu/Debian)
 
@@ -60,9 +60,9 @@ Tersedia **dua format installer**, pilih salah satu:
 
 ### macOS
 
-1. Download `PerpustakaanOffline_<versi>_x64.dmg` (Intel) atau `_aarch64.dmg` (Apple Silicon)
+1. Download `PerpustakaanNusantara_<versi>_x64.dmg` (Intel) atau `_aarch64.dmg` (Apple Silicon)
 2. Buka `.dmg` → drag aplikasi ke folder Applications
-3. Buka via Launchpad atau Spotlight ("PerpustakaanOffline")
+3. Buka via Launchpad atau Spotlight ("PerpustakaanNusantara")
 
 ### Catatan Windows Defender / SmartScreen
 
@@ -74,7 +74,7 @@ Klik **"More info"** → **"Run anyway"**. Ini normal untuk software open-source
 
 ### macOS Gatekeeper
 
-Kalau muncul *"PerpustakaanOffline can't be opened because Apple cannot check it for malicious software"*, klik kanan icon aplikasi → **Open** → konfirmasi **Open** sekali lagi. Setelah itu bisa dibuka normal.
+Kalau muncul *"PerpustakaanNusantara can't be opened because Apple cannot check it for malicious software"*, klik kanan icon aplikasi → **Open** → konfirmasi **Open** sekali lagi. Setelah itu bisa dibuka normal.
 
 ---
 
@@ -753,9 +753,9 @@ This is a translated short version of the manual. Indonesian version above is mo
 ## Quick Start
 
 1. Download the latest installer for your OS from [Releases](https://github.com/alviarts/perpustakaan-offline/releases):
-   - **Windows:** `PerpustakaanOffline_<version>_x64-setup.exe` (NSIS) or `..._x64_en-US.msi` (MSI)
+   - **Windows:** `PerpustakaanNusantara_<version>_x64-setup.exe` (NSIS) or `..._x64_en-US.msi` (MSI)
    - **Linux:** `perpustakaan-offline_<version>_amd64.deb`
-   - **macOS:** `PerpustakaanOffline_<version>_x64.dmg` or `_aarch64.dmg`
+   - **macOS:** `PerpustakaanNusantara_<version>_x64.dmg` or `_aarch64.dmg`
 2. Install → launch → login with `admin` / `admin123` → **change password immediately** (Setting → Akun)
 3. Switch UI language: **Setting → Bahasa → `en — English`**
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "perpustakaan-offline",
   "private": true,
   "version": "1.0.3",
-  "description": "Perpustakaan Offline v2 — Tauri 2 + React 18 + TypeScript",
+  "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",
   "engines": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,4 +12,4 @@ export interface AppErrorPayload {
   message: string;
 }
 
-export const APP_NAME = 'Perpustakaan Offline' as const;
+export const APP_NAME = 'Perpustakaan Nusantara' as const;


### PR DESCRIPTION
## Summary

Closes v1.0.4 #15 — Brand rename "Perpustakaan Offline" → "Perpustakaan Nusantara".

User asked:

> "ganti nama dengan perpustakaan offline menjadi perpustakaan nusantara di instaler atau pun software"

This PR renames every operator-visible reference to the app's brand name. The bundle identifier (`id.alviarts.perpustakaan`), Cargo package name, and GitHub repo slug are intentionally **unchanged** so that existing v1.0.x users on a given machine continue to share the same SQLite database and uploads directory under `<APPDATA>/<bundle-id>/` with no manual migration.

### Files renamed

**Tauri config:**
- `tauri.conf.json` — `productName: "PerpustakaanOffline"` → `"PerpustakaanNusantara"`, window title, short/long descriptions.
- `capabilities/default.json` — description string only.

**Frontend:**
- `index.html` — `<title>`.
- `common.json` (id + en) — `appName`.
- `TitleBar.tsx` — fallback label used when i18n hasn't loaded yet.
- `packages/shared/src/index.ts` — `APP_NAME` constant.

**Backend (Rust):**
- `src-tauri/src/lib.rs` — system tray tooltip.
- `src-tauri/src/commands/close_behavior.rs` — doc comment referring to the Windows binary name.
- `src-tauri/Cargo.toml` — `description` field.

**Docs / repo metadata:**
- `docs/manual.md` — H1 + every install/uninstall snippet (Windows MSI/NSIS filename, install dir, uninstall control panel, macOS DMG name, Spotlight shortcut, Gatekeeper warning).
- `README.md` — top heading + installer-asset filename references.
- `apps/desktop/public/illustrations/CREDITS.md`.
- `package.json` — `description`.

**Tests:**
- `apps/desktop/tests/unit/manualPage.test.tsx` — updated to track the renamed H1 so the manual-page test doesn't regress.

### What is intentionally NOT renamed

- **Bundle identifier** `id.alviarts.perpustakaan` — stays so existing user databases are preserved.
- **Cargo package name** `perpustakaan-desktop` — stays so build artifacts and cargo workspace paths don't churn.
- **GitHub repo slug** `alviarts/perpustakaan-offline` — repo URLs in README/manual/Tentang dialog stay as-is.
- All references inside `.devin/handoff/` and `docs/archive/` (historical session notes — preserving the original branding from those time periods).

### Migration impact

Because `productName` changed, the Windows install directory + Start Menu shortcut + Add/Remove Programs entry + uninstall registry key all change. Existing v1.0.3 users will see **two entries** in *Apps & features* (the old "PerpustakaanOffline" + the new "PerpustakaanNusantara") until they manually uninstall the old one. The SQLite database and uploaded photos persist transparently across the rename because they live under the bundle-id-keyed `<APPDATA>/id.alviarts.perpustakaan/` path, which is unchanged.

We will document this in the v1.0.4 release notes.

### Tests

All 8 quality gates green: `ALL_GATES_OK rename-nusantara`. Manual-page test now matches the new H1.

## Review & Testing Checklist for Human

- [ ] Open the app. Title bar shows "Perpustakaan Nusantara" on the left.
- [ ] Login screen shows "Perpustakaan Nusantara" as the brand label (`appName`).
- [ ] Hover the system tray icon. Tooltip shows "Perpustakaan Nusantara".
- [ ] Open `Settings → Manual`. The H1 reads "Manual Pengguna — Perpustakaan Nusantara"; every install snippet now references `PerpustakaanNusantara_<version>_x64-setup.exe` etc.
- [ ] Build a Windows installer (CI artifact). Install onto a clean VM.
  - Default install path: `C:\Program Files\PerpustakaanNusantara\`.
  - Start Menu shortcut: "PerpustakaanNusantara".
  - Add/Remove Programs entry: "PerpustakaanNusantara".
- [ ] On a Windows VM with v1.0.3 already installed, install v1.0.4. Verify both entries exist in Apps & features (expected — that's the documented migration cost) and that v1.0.4 picks up the existing SQLite database (member list + book list survive).

### Notes

- The visible name uses a space (`Perpustakaan Nusantara`); the bundle/installer name uses CamelCase (`PerpustakaanNusantara`) per Tauri convention.
- I considered renaming the Cargo package name to match, but that would churn every internal `Cargo.lock` entry + workspace path with no user-visible benefit; left it as `perpustakaan-desktop`.
