### PR TITLE
feat(profile): user profile dialog with biodata + photo

### DIFF
--- a/apps/desktop/src-tauri/src/commands/assets.rs
+++ b/apps/desktop/src-tauri/src/commands/assets.rs
@@ -79,6 +79,13 @@ fn compress_opts_for(category: &str) -> Option<CompressOpts> {
             max_dim: 512,
             jpeg_quality: 92,
         }),
+        // Operator/admin biodata portraits (v1.0.4 #16). Same envelope as
+        // anggota: header avatar tops out around 28 px and the profile
+        // dialog preview at ~96 px, so 800 px is plenty even on hi-DPI.
+        "user" => Some(CompressOpts {
+            max_dim: 800,
+            jpeg_quality: 85,
+        }),
         _ => None,
     }
 }

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -16,4 +16,5 @@ pub mod laporan;
 pub mod master_data;
 pub mod peminjaman;
 pub mod settings;
+pub mod user_profile;
 pub mod window_state;

--- a/apps/desktop/src-tauri/src/commands/user_profile.rs
+++ b/apps/desktop/src-tauri/src/commands/user_profile.rs
@@ -1,0 +1,364 @@
+//! User profile / biodata commands (v1.0.4 #16).
+//!
+//! The Header dropdown ships a "Profil" item that opens a dialog where the
+//! signed-in operator can edit their display name + portrait + a small
+//! biodata block (date/place of birth, contact, address, gender, religion).
+//! Username, role, and password remain managed by Settings → Akun.
+//!
+//! Storage layout:
+//!
+//! - `users.full_name` is the display name (already exists; we just keep it
+//!   in sync with the dialog's "Nama Lengkap" field).
+//! - `user_profiles` is a sibling table with `user_id` PK + biodata columns.
+//!   It is created on first profile save (UPSERT) so v1.0.x users that never
+//!   open the dialog don't pay a row.
+//!
+//! Every save records an `audit_log` entry (`update / users / <user_id>`)
+//! with a JSON detail payload listing the changed fields, mirroring the
+//! pattern from `kas` (#11) so admins can see who changed what.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tauri::{AppHandle, Emitter, State};
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+/// Operator profile / biodata. Mirrors the row stored in `user_profiles`
+/// plus the `full_name` denormalised from `users` so the frontend gets
+/// everything it needs in a single round-trip.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserProfile {
+    pub user_id: i64,
+    pub username: String,
+    pub full_name: String,
+    pub role: String,
+    pub foto_path: Option<String>,
+    pub tanggal_lahir: Option<String>,
+    pub tempat_lahir: Option<String>,
+    pub telepon: Option<String>,
+    pub email: Option<String>,
+    pub alamat: Option<String>,
+    pub jenis_kelamin: Option<String>,
+    pub agama: Option<String>,
+}
+
+/// Subset of fields the operator can update via the profile dialog. The
+/// command applies every field as-given (set or clear); the frontend
+/// dialog presents an edit form that posts the entire snapshot.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserProfileInput {
+    pub full_name: String,
+    pub foto_path: Option<String>,
+    pub tanggal_lahir: Option<String>,
+    pub tempat_lahir: Option<String>,
+    pub telepon: Option<String>,
+    pub email: Option<String>,
+    pub alamat: Option<String>,
+    pub jenis_kelamin: Option<String>,
+    pub agama: Option<String>,
+}
+
+#[tauri::command]
+pub fn user_profile_get(
+    state: State<'_, AppState>,
+    user_id: i64,
+) -> AppResult<UserProfile> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    fetch_profile(&conn, user_id)
+}
+
+#[tauri::command]
+pub fn user_profile_update(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    user_id: i64,
+    payload: UserProfileInput,
+) -> AppResult<UserProfile> {
+    let trimmed_name = payload.full_name.trim();
+    if trimmed_name.is_empty() {
+        return Err(AppError::Validation("nama lengkap wajib diisi".into()));
+    }
+
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+
+    let before = fetch_profile(&conn, user_id)?;
+    let tx = conn.transaction()?;
+
+    tx.execute(
+        "UPDATE users SET full_name = ?1, updated_at = datetime('now') WHERE id = ?2",
+        rusqlite::params![trimmed_name, user_id],
+    )?;
+
+    tx.execute(
+        r#"INSERT INTO user_profiles
+                (user_id, foto_path, tanggal_lahir, tempat_lahir, telepon,
+                 email, alamat, jenis_kelamin, agama, updated_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, datetime('now'))
+           ON CONFLICT(user_id) DO UPDATE SET
+               foto_path     = excluded.foto_path,
+               tanggal_lahir = excluded.tanggal_lahir,
+               tempat_lahir  = excluded.tempat_lahir,
+               telepon       = excluded.telepon,
+               email         = excluded.email,
+               alamat        = excluded.alamat,
+               jenis_kelamin = excluded.jenis_kelamin,
+               agama         = excluded.agama,
+               updated_at    = datetime('now')"#,
+        rusqlite::params![
+            user_id,
+            payload.foto_path,
+            payload.tanggal_lahir,
+            payload.tempat_lahir,
+            payload.telepon,
+            payload.email,
+            payload.alamat,
+            payload.jenis_kelamin,
+            payload.agama,
+        ],
+    )?;
+
+    let after = UserProfile {
+        user_id: before.user_id,
+        username: before.username.clone(),
+        full_name: trimmed_name.to_string(),
+        role: before.role.clone(),
+        foto_path: payload.foto_path.clone(),
+        tanggal_lahir: payload.tanggal_lahir.clone(),
+        tempat_lahir: payload.tempat_lahir.clone(),
+        telepon: payload.telepon.clone(),
+        email: payload.email.clone(),
+        alamat: payload.alamat.clone(),
+        jenis_kelamin: payload.jenis_kelamin.clone(),
+        agama: payload.agama.clone(),
+    };
+
+    let detail = json!({
+        "before": {
+            "full_name":     before.full_name,
+            "foto_path":     before.foto_path,
+            "tanggal_lahir": before.tanggal_lahir,
+            "tempat_lahir":  before.tempat_lahir,
+            "telepon":       before.telepon,
+            "email":         before.email,
+            "alamat":        before.alamat,
+            "jenis_kelamin": before.jenis_kelamin,
+            "agama":         before.agama,
+        },
+        "after": {
+            "full_name":     after.full_name,
+            "foto_path":     after.foto_path,
+            "tanggal_lahir": after.tanggal_lahir,
+            "tempat_lahir":  after.tempat_lahir,
+            "telepon":       after.telepon,
+            "email":         after.email,
+            "alamat":        after.alamat,
+            "jenis_kelamin": after.jenis_kelamin,
+            "agama":         after.agama,
+        },
+    });
+
+    tx.execute(
+        "INSERT INTO audit_log (user_id, aksi, entitas, entitas_id, detail)
+         VALUES (?1, 'update', 'users', ?2, ?3)",
+        rusqlite::params![user_id, user_id, detail.to_string()],
+    )?;
+
+    tx.commit()?;
+    drop(conn);
+
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let fresh = fetch_profile(&conn, user_id)?;
+    drop(conn);
+
+    // Notify the UI so the header avatar + greeting refresh without a
+    // full reload.
+    let _ = app.emit("users:profile-changed", &fresh);
+    Ok(fresh)
+}
+
+fn fetch_profile(conn: &rusqlite::Connection, user_id: i64) -> AppResult<UserProfile> {
+    let user = conn.query_row(
+        "SELECT username, full_name, role FROM users WHERE id = ?1",
+        rusqlite::params![user_id],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        },
+    );
+    let (username, full_name, role) = match user {
+        Ok(t) => t,
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            return Err(AppError::NotFound(format!("user {user_id}")));
+        }
+        Err(e) => return Err(AppError::Db(e)),
+    };
+
+    let profile = conn.query_row(
+        r#"SELECT foto_path, tanggal_lahir, tempat_lahir, telepon, email,
+                  alamat, jenis_kelamin, agama
+             FROM user_profiles
+            WHERE user_id = ?1"#,
+        rusqlite::params![user_id],
+        |row| {
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+            ))
+        },
+    );
+    let (
+        foto_path,
+        tanggal_lahir,
+        tempat_lahir,
+        telepon,
+        email,
+        alamat,
+        jenis_kelamin,
+        agama,
+    ) = match profile {
+        Ok(t) => t,
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            (None, None, None, None, None, None, None, None)
+        }
+        Err(e) => return Err(AppError::Db(e)),
+    };
+
+    Ok(UserProfile {
+        user_id,
+        username,
+        full_name,
+        role,
+        foto_path,
+        tanggal_lahir,
+        tempat_lahir,
+        telepon,
+        email,
+        alamat,
+        jenis_kelamin,
+        agama,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::run_migrations;
+    use rusqlite::Connection;
+
+    fn fresh_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        // Seed a user we can edit.
+        conn.execute(
+            "INSERT INTO users (username, password_hash, full_name, role, aktif)
+             VALUES ('alvi', 'x', 'Alvi Awal', 'admin', 1)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn fetch_profile_returns_defaults_when_no_row_yet() {
+        let conn = fresh_db();
+        let p = fetch_profile(&conn, 1).unwrap();
+        assert_eq!(p.user_id, 1);
+        assert_eq!(p.username, "alvi");
+        assert_eq!(p.full_name, "Alvi Awal");
+        assert_eq!(p.role, "admin");
+        assert!(p.foto_path.is_none());
+        assert!(p.tanggal_lahir.is_none());
+    }
+
+    #[test]
+    fn fetch_profile_returns_not_found_for_unknown_user() {
+        let conn = fresh_db();
+        let err = fetch_profile(&conn, 99).unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn upsert_then_read_round_trips_all_fields() {
+        let mut conn = fresh_db();
+        let tx = conn.transaction().unwrap();
+        tx.execute(
+            "UPDATE users SET full_name = 'Alvi Updated' WHERE id = 1",
+            [],
+        )
+        .unwrap();
+        tx.execute(
+            r#"INSERT INTO user_profiles
+                    (user_id, foto_path, tanggal_lahir, tempat_lahir, telepon,
+                     email, alamat, jenis_kelamin, agama, updated_at)
+               VALUES (1, 'uploads/user/x.jpg', '1995-08-17', 'Jakarta',
+                       '0812', 'a@b.id', 'Jl. Merdeka', 'L', 'Islam',
+                       datetime('now'))
+               ON CONFLICT(user_id) DO NOTHING"#,
+            [],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        let p = fetch_profile(&conn, 1).unwrap();
+        assert_eq!(p.full_name, "Alvi Updated");
+        assert_eq!(p.foto_path.as_deref(), Some("uploads/user/x.jpg"));
+        assert_eq!(p.tanggal_lahir.as_deref(), Some("1995-08-17"));
+        assert_eq!(p.tempat_lahir.as_deref(), Some("Jakarta"));
+        assert_eq!(p.telepon.as_deref(), Some("0812"));
+        assert_eq!(p.email.as_deref(), Some("a@b.id"));
+        assert_eq!(p.alamat.as_deref(), Some("Jl. Merdeka"));
+        assert_eq!(p.jenis_kelamin.as_deref(), Some("L"));
+        assert_eq!(p.agama.as_deref(), Some("Islam"));
+    }
+
+    #[test]
+    fn upsert_updates_existing_row_in_place() {
+        let mut conn = fresh_db();
+        let tx = conn.transaction().unwrap();
+        tx.execute(
+            r#"INSERT INTO user_profiles (user_id, foto_path, updated_at)
+                 VALUES (1, 'uploads/user/v1.jpg', datetime('now'))"#,
+            [],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        let tx = conn.transaction().unwrap();
+        tx.execute(
+            r#"INSERT INTO user_profiles
+                    (user_id, foto_path, updated_at)
+               VALUES (1, 'uploads/user/v2.jpg', datetime('now'))
+               ON CONFLICT(user_id) DO UPDATE SET
+                   foto_path  = excluded.foto_path,
+                   updated_at = datetime('now')"#,
+            [],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        // Should be exactly one row.
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM user_profiles", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let p = fetch_profile(&conn, 1).unwrap();
+        assert_eq!(p.foto_path.as_deref(), Some("uploads/user/v2.jpg"));
+    }
+}

--- a/apps/desktop/src-tauri/src/db/schema.sql
+++ b/apps/desktop/src-tauri/src/db/schema.sql
@@ -280,6 +280,26 @@ CREATE INDEX IF NOT EXISTS idx_user_permissions_user ON user_permissions(user_id
 CREATE INDEX IF NOT EXISTS idx_user_permissions_key  ON user_permissions(permission_key);
 
 -- ----------------------------------------------------------------------------
+-- User profile / biodata (v1.0.4 #16) — admin/pustakawan can edit display name,
+-- portrait, contact info, and personal data. Username + role + password remain
+-- managed by Settings → Akun. One row per users.id; FK ON DELETE CASCADE so
+-- removing the user also wipes their biodata.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_profiles (
+    user_id        INTEGER PRIMARY KEY,
+    foto_path      TEXT,
+    tanggal_lahir  TEXT,             -- ISO date YYYY-MM-DD, nullable
+    tempat_lahir   TEXT,
+    telepon        TEXT,
+    email          TEXT,
+    alamat         TEXT,
+    jenis_kelamin  TEXT,             -- 'L' | 'P' | NULL
+    agama          TEXT,
+    updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- ----------------------------------------------------------------------------
 -- Audit log (siapa-melakukan-apa)
 -- ----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS audit_log (

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -186,6 +186,8 @@ pub fn run() {
             commands::assets::assets_resolve,
             commands::assets::assets_delete,
             commands::assets::assets_read_data_url,
+            commands::user_profile::user_profile_get,
+            commands::user_profile::user_profile_update,
         ])
         .on_window_event(|window, event| {
             // BUG-011: intercept the X-button on the main window and

--- a/apps/desktop/src/components/layout/Header.tsx
+++ b/apps/desktop/src/components/layout/Header.tsx
@@ -18,6 +18,8 @@ import { useAuthStore } from '@/stores/authStore';
 import { useIdentityStore } from '@/stores/identityStore';
 import { logoutRequest } from '@/lib/auth';
 import { cn } from '@/lib/utils';
+import { ProfilDialog } from '@/features/profile/ProfilDialog';
+import { useUserAvatar } from '@/hooks/useUserAvatar';
 
 const ROUTE_LABELS: Record<string, string> = {
   '/dashboard': 'common:menu.dashboard',
@@ -111,6 +113,8 @@ export function Header() {
   const logout = useAuthStore((s) => s.logout);
   const identity = useIdentityStore((s) => s.identity);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [profilOpen, setProfilOpen] = useState(false);
+  const avatarUrl = useUserAvatar(user?.id);
 
   const breadcrumbKeys = resolveBreadcrumbKeys(routerState.location.pathname);
   const breadcrumbLabels = breadcrumbKeys.map((key) => (key.includes(':') ? t(key) : key));
@@ -205,8 +209,20 @@ export function Header() {
               data-testid="user-menu"
               className="border-border hover:bg-accent flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
             >
-              <span className="bg-primary/15 text-primary flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold">
-                {(user?.fullName ?? '?').slice(0, 1).toUpperCase()}
+              <span
+                className="bg-primary/15 text-primary flex h-7 w-7 items-center justify-center overflow-hidden rounded-full text-xs font-semibold"
+                aria-hidden="true"
+              >
+                {avatarUrl ? (
+                  <img
+                    src={avatarUrl}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    draggable={false}
+                  />
+                ) : (
+                  <>{(user?.fullName ?? '?').slice(0, 1).toUpperCase()}</>
+                )}
               </span>
               <span className="hidden text-left md:block">
                 <span className="block text-xs font-medium leading-tight">
@@ -220,7 +236,10 @@ export function Header() {
           <DropdownMenuContent align="end" className="w-56">
             <DropdownMenuLabel>{user?.username ?? '—'}</DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuItem disabled>
+            <DropdownMenuItem
+              onClick={() => setProfilOpen(true)}
+              data-testid="open-profil"
+            >
               <UserIcon className="mr-2 h-4 w-4" />
               {t('common:menu.profile')}
             </DropdownMenuItem>
@@ -232,6 +251,7 @@ export function Header() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+      <ProfilDialog open={profilOpen} onOpenChange={setProfilOpen} />
     </header>
   );
 }

--- a/apps/desktop/src/features/profile/ProfilDialog.tsx
+++ b/apps/desktop/src/features/profile/ProfilDialog.tsx
@@ -1,0 +1,345 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FilePickerInput } from '@/components/shared/FilePickerInput';
+import { useToast } from '@/components/ui/toast-manager';
+import { useAuthStore } from '@/stores/authStore';
+import { userProfileApi, type UserProfile, type UserProfileInput } from '@/lib/userProfile';
+import { formatTauriError } from '@/lib/errors';
+
+interface ProfilDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const AGAMA_OPTIONS = [
+  'Islam',
+  'Kristen',
+  'Katolik',
+  'Hindu',
+  'Buddha',
+  'Konghucu',
+  'Lainnya',
+] as const;
+
+/**
+ * Operator profile / biodata dialog (v1.0.4 #16). Lets the signed-in user
+ * edit their display name, portrait, contact info, and personal data
+ * without going through Settings → Akun (which is admin-only and covers
+ * username + password + role).
+ *
+ * The username, role, and password are intentionally read-only here — the
+ * user explicitly asked to "tetap login admin" and only edit the *display*
+ * data.
+ */
+export function ProfilDialog({ open, onOpenChange }: ProfilDialogProps): JSX.Element {
+  const { t } = useTranslation(['common']);
+  const toast = useToast();
+  const sessionUser = useAuthStore((s) => s.user);
+  const setSessionUser = useAuthStore((s) => s.setUser);
+
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [form, setForm] = useState<UserProfileInput>(blankInput());
+
+  useEffect(() => {
+    if (!open || !sessionUser) {
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    void (async () => {
+      try {
+        const fetched = await userProfileApi.get(sessionUser.id);
+        if (cancelled) return;
+        setProfile(fetched);
+        setForm({
+          fullName: fetched.fullName,
+          fotoPath: fetched.fotoPath,
+          tanggalLahir: fetched.tanggalLahir,
+          tempatLahir: fetched.tempatLahir,
+          telepon: fetched.telepon,
+          email: fetched.email,
+          alamat: fetched.alamat,
+          jenisKelamin: fetched.jenisKelamin,
+          agama: fetched.agama,
+        });
+      } catch (err) {
+        toast.showToast({
+          variant: 'destructive',
+          title: t('common:profile.loadFailed', { defaultValue: 'Gagal memuat profil' }),
+          description: formatTauriError(err),
+        });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, sessionUser, t, toast]);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault();
+    if (!sessionUser) return;
+    if (form.fullName.trim().length === 0) {
+      toast.showToast({
+        variant: 'destructive',
+        title: t('common:profile.validationName', {
+          defaultValue: 'Nama lengkap wajib diisi',
+        }),
+      });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const next = await userProfileApi.update(sessionUser.id, {
+        ...form,
+        fullName: form.fullName.trim(),
+      });
+      setProfile(next);
+      // Sync the auth store so the header avatar + greeting update without
+      // a full page reload.
+      setSessionUser({
+        ...sessionUser,
+        fullName: next.fullName,
+      });
+      toast.showToast({
+        title: t('common:profile.saved', { defaultValue: 'Profil disimpan' }),
+        description: next.fullName,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      toast.showToast({
+        variant: 'destructive',
+        title: t('common:profile.saveFailed', { defaultValue: 'Gagal menyimpan profil' }),
+        description: formatTauriError(err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto" data-testid="profil-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('common:profile.title', { defaultValue: 'Profil Pengguna' })}</DialogTitle>
+          <DialogDescription>
+            {t('common:profile.description', {
+              defaultValue:
+                'Ubah biodata akun Anda. Username, peran, dan kata sandi diatur lewat Pengaturan → Akun.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="grid gap-4 py-2">
+          <section className="grid gap-3 sm:grid-cols-[auto_1fr] sm:items-start">
+            <div>
+              <FilePickerInput
+                value={form.fotoPath}
+                onChange={(p) => setForm((f) => ({ ...f, fotoPath: p }))}
+                category="user"
+                rounded
+                previewSize={112}
+                pickLabel={t('common:profile.changePhoto', { defaultValue: 'Ubah Foto' })}
+                clearLabel={t('common:profile.removePhoto', { defaultValue: 'Hapus' })}
+                testId="profil-foto"
+                disabled={loading || submitting}
+              />
+            </div>
+            <div className="grid gap-3">
+              <ReadOnlyField
+                label={t('common:profile.username', { defaultValue: 'Username' })}
+                value={profile?.username ?? sessionUser?.username ?? '—'}
+              />
+              <ReadOnlyField
+                label={t('common:profile.role', { defaultValue: 'Peran' })}
+                value={profile?.role ?? sessionUser?.role ?? '—'}
+              />
+              <Field label={t('common:profile.fullName', { defaultValue: 'Nama Lengkap' })}>
+                <Input
+                  value={form.fullName}
+                  onChange={(e) => setForm((f) => ({ ...f, fullName: e.target.value }))}
+                  data-testid="profil-fullname"
+                  required
+                  maxLength={120}
+                  disabled={submitting}
+                />
+              </Field>
+            </div>
+          </section>
+
+          <section className="grid gap-3 sm:grid-cols-2">
+            <Field label={t('common:profile.tempatLahir', { defaultValue: 'Tempat Lahir' })}>
+              <Input
+                value={form.tempatLahir ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, tempatLahir: e.target.value || null }))
+                }
+                disabled={submitting}
+                maxLength={80}
+              />
+            </Field>
+            <Field label={t('common:profile.tanggalLahir', { defaultValue: 'Tanggal Lahir' })}>
+              <Input
+                type="date"
+                value={form.tanggalLahir ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, tanggalLahir: e.target.value || null }))
+                }
+                disabled={submitting}
+              />
+            </Field>
+            <Field label={t('common:profile.jenisKelamin', { defaultValue: 'Jenis Kelamin' })}>
+              <Select
+                value={form.jenisKelamin ?? ''}
+                onValueChange={(v) =>
+                  setForm((f) => ({ ...f, jenisKelamin: (v as 'L' | 'P') || null }))
+                }
+                disabled={submitting}
+              >
+                <SelectTrigger data-testid="profil-jenis-kelamin">
+                  <SelectValue
+                    placeholder={t('common:profile.choose', { defaultValue: 'Pilih…' })}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="L">
+                    {t('common:profile.male', { defaultValue: 'Laki-laki' })}
+                  </SelectItem>
+                  <SelectItem value="P">
+                    {t('common:profile.female', { defaultValue: 'Perempuan' })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field label={t('common:profile.agama', { defaultValue: 'Agama' })}>
+              <Select
+                value={form.agama ?? ''}
+                onValueChange={(v) => setForm((f) => ({ ...f, agama: v || null }))}
+                disabled={submitting}
+              >
+                <SelectTrigger data-testid="profil-agama">
+                  <SelectValue
+                    placeholder={t('common:profile.choose', { defaultValue: 'Pilih…' })}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {AGAMA_OPTIONS.map((opt) => (
+                    <SelectItem key={opt} value={opt}>
+                      {opt}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field label={t('common:profile.telepon', { defaultValue: 'Telepon' })}>
+              <Input
+                value={form.telepon ?? ''}
+                onChange={(e) => setForm((f) => ({ ...f, telepon: e.target.value || null }))}
+                disabled={submitting}
+                maxLength={32}
+              />
+            </Field>
+            <Field label={t('common:profile.email', { defaultValue: 'Email' })}>
+              <Input
+                type="email"
+                value={form.email ?? ''}
+                onChange={(e) => setForm((f) => ({ ...f, email: e.target.value || null }))}
+                disabled={submitting}
+                maxLength={120}
+              />
+            </Field>
+          </section>
+
+          <Field label={t('common:profile.alamat', { defaultValue: 'Alamat' })}>
+            <textarea
+              value={form.alamat ?? ''}
+              onChange={(e) => setForm((f) => ({ ...f, alamat: e.target.value || null }))}
+              disabled={submitting}
+              rows={2}
+              maxLength={320}
+              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-16 w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </Field>
+
+          <DialogFooter className="pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              {t('common:actions.cancel', { defaultValue: 'Batal' })}
+            </Button>
+            <Button type="submit" disabled={submitting || loading} data-testid="profil-save">
+              {submitting
+                ? t('common:profile.saving', { defaultValue: 'Menyimpan…' })
+                : t('common:actions.save', { defaultValue: 'Simpan' })}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function blankInput(): UserProfileInput {
+  return {
+    fullName: '',
+    fotoPath: null,
+    tanggalLahir: null,
+    tempatLahir: null,
+    telepon: null,
+    email: null,
+    alamat: null,
+    jenisKelamin: null,
+    agama: null,
+  };
+}
+
+interface FieldProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function Field({ label, children }: FieldProps): JSX.Element {
+  return (
+    <label className="grid gap-1.5 text-sm">
+      <span className="text-muted-foreground text-xs font-medium">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+interface ReadOnlyFieldProps {
+  label: string;
+  value: string;
+}
+
+function ReadOnlyField({ label, value }: ReadOnlyFieldProps): JSX.Element {
+  return (
+    <div className="grid gap-1.5 text-sm">
+      <span className="text-muted-foreground text-xs font-medium">{label}</span>
+      <span className="bg-muted/40 rounded-md border px-3 py-2 font-mono text-xs">{value}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/hooks/useUserAvatar.ts
+++ b/apps/desktop/src/hooks/useUserAvatar.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import { isTauri } from '@/lib/auth';
+import { assetsApi } from '@/lib/assets';
+import { userProfileApi } from '@/lib/userProfile';
+
+/**
+ * Resolve the signed-in operator's avatar to a renderable data URL. Returns
+ * `null` when the user has no portrait set, or when running in browser-mode
+ * dev where we cannot read local files.
+ *
+ * Re-fetches whenever the `users:profile-changed` Tauri event fires (emitted
+ * by the profile dialog after a successful save) so the header avatar
+ * updates without a full page reload.
+ */
+export function useUserAvatar(userId: number | undefined): string | null {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (userId == null) {
+      setUrl(null);
+      return;
+    }
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+
+    async function refresh(): Promise<void> {
+      try {
+        if (userId == null) return;
+        const profile = await userProfileApi.get(userId);
+        if (cancelled) return;
+        if (!profile.fotoPath) {
+          setUrl(null);
+          return;
+        }
+        const data = await assetsApi.readDataUrl(profile.fotoPath);
+        if (cancelled) return;
+        setUrl(data || null);
+      } catch {
+        // Quietly fall back to the initial — the header should never crash
+        // because of a missing avatar.
+        if (!cancelled) setUrl(null);
+      }
+    }
+
+    void refresh();
+
+    if (isTauri()) {
+      void listen<unknown>('users:profile-changed', () => {
+        void refresh();
+      }).then((u) => {
+        if (cancelled) {
+          u();
+        } else {
+          unlisten = u;
+        }
+      });
+    }
+
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [userId]);
+
+  return url;
+}

--- a/apps/desktop/src/i18n/en/common.json
+++ b/apps/desktop/src/i18n/en/common.json
@@ -73,5 +73,29 @@
   "filePicker": {
     "pick": "Pick file…",
     "clear": "Remove file"
+  },
+  "profile": {
+    "title": "User Profile",
+    "description": "Edit your account biodata. Username, role, and password are managed in Settings → Accounts.",
+    "username": "Username",
+    "role": "Role",
+    "fullName": "Full Name",
+    "tempatLahir": "Place of Birth",
+    "tanggalLahir": "Date of Birth",
+    "jenisKelamin": "Gender",
+    "agama": "Religion",
+    "telepon": "Phone",
+    "email": "Email",
+    "alamat": "Address",
+    "choose": "Choose…",
+    "male": "Male",
+    "female": "Female",
+    "changePhoto": "Change Photo",
+    "removePhoto": "Remove",
+    "saving": "Saving…",
+    "saved": "Profile saved",
+    "saveFailed": "Failed to save profile",
+    "loadFailed": "Failed to load profile",
+    "validationName": "Full name is required"
   }
 }

--- a/apps/desktop/src/i18n/id/common.json
+++ b/apps/desktop/src/i18n/id/common.json
@@ -73,5 +73,29 @@
   "filePicker": {
     "pick": "Pilih file…",
     "clear": "Hapus file"
+  },
+  "profile": {
+    "title": "Profil Pengguna",
+    "description": "Ubah biodata akun Anda. Username, peran, dan kata sandi diatur lewat Pengaturan → Akun.",
+    "username": "Username",
+    "role": "Peran",
+    "fullName": "Nama Lengkap",
+    "tempatLahir": "Tempat Lahir",
+    "tanggalLahir": "Tanggal Lahir",
+    "jenisKelamin": "Jenis Kelamin",
+    "agama": "Agama",
+    "telepon": "Telepon",
+    "email": "Email",
+    "alamat": "Alamat",
+    "choose": "Pilih…",
+    "male": "Laki-laki",
+    "female": "Perempuan",
+    "changePhoto": "Ubah Foto",
+    "removePhoto": "Hapus",
+    "saving": "Menyimpan…",
+    "saved": "Profil disimpan",
+    "saveFailed": "Gagal menyimpan profil",
+    "loadFailed": "Gagal memuat profil",
+    "validationName": "Nama lengkap wajib diisi"
   }
 }

--- a/apps/desktop/src/lib/assets.ts
+++ b/apps/desktop/src/lib/assets.ts
@@ -8,7 +8,7 @@ import { isTauri } from '@/lib/auth';
  * validated by `validate_category` in `commands/assets.rs`, so adding a
  * new category here also requires bumping the allow-list there.
  */
-export type AssetCategory = 'anggota' | 'buku' | 'identitas';
+export type AssetCategory = 'anggota' | 'buku' | 'identitas' | 'user';
 
 /** Image extensions accepted by the Tauri file dialog and the backend. */
 export const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg', 'bmp'] as const;

--- a/apps/desktop/src/lib/userProfile.ts
+++ b/apps/desktop/src/lib/userProfile.ts
@@ -1,0 +1,113 @@
+import { invoke } from '@tauri-apps/api/core';
+import { isTauri } from '@/lib/auth';
+
+export interface UserProfile {
+  userId: number;
+  username: string;
+  fullName: string;
+  role: string;
+  fotoPath: string | null;
+  tanggalLahir: string | null;
+  tempatLahir: string | null;
+  telepon: string | null;
+  email: string | null;
+  alamat: string | null;
+  jenisKelamin: 'L' | 'P' | null;
+  agama: string | null;
+}
+
+export interface UserProfileInput {
+  fullName: string;
+  fotoPath: string | null;
+  tanggalLahir: string | null;
+  tempatLahir: string | null;
+  telepon: string | null;
+  email: string | null;
+  alamat: string | null;
+  jenisKelamin: 'L' | 'P' | null;
+  agama: string | null;
+}
+
+interface RawUserProfile {
+  user_id: number;
+  username: string;
+  full_name: string;
+  role: string;
+  foto_path: string | null;
+  tanggal_lahir: string | null;
+  tempat_lahir: string | null;
+  telepon: string | null;
+  email: string | null;
+  alamat: string | null;
+  jenis_kelamin: 'L' | 'P' | null;
+  agama: string | null;
+}
+
+function toCamel(raw: RawUserProfile): UserProfile {
+  return {
+    userId: raw.user_id,
+    username: raw.username,
+    fullName: raw.full_name,
+    role: raw.role,
+    fotoPath: raw.foto_path,
+    tanggalLahir: raw.tanggal_lahir,
+    tempatLahir: raw.tempat_lahir,
+    telepon: raw.telepon,
+    email: raw.email,
+    alamat: raw.alamat,
+    jenisKelamin: raw.jenis_kelamin,
+    agama: raw.agama,
+  };
+}
+
+export interface UserProfileApi {
+  get(userId: number): Promise<UserProfile>;
+  update(userId: number, payload: UserProfileInput): Promise<UserProfile>;
+}
+
+const tauriApi: UserProfileApi = {
+  async get(userId) {
+    const raw = await invoke<RawUserProfile>('user_profile_get', { userId });
+    return toCamel(raw);
+  },
+  async update(userId, payload) {
+    const raw = await invoke<RawUserProfile>('user_profile_update', {
+      userId,
+      payload,
+    });
+    return toCamel(raw);
+  },
+};
+
+const browserStore = new Map<number, UserProfile>();
+
+const browserApi: UserProfileApi = {
+  async get(userId) {
+    return (
+      browserStore.get(userId) ?? {
+        userId,
+        username: 'admin',
+        fullName: 'Administrator',
+        role: 'admin',
+        fotoPath: null,
+        tanggalLahir: null,
+        tempatLahir: null,
+        telepon: null,
+        email: null,
+        alamat: null,
+        jenisKelamin: null,
+        agama: null,
+      }
+    );
+  },
+  async update(userId, payload) {
+    const next: UserProfile = {
+      ...(await browserApi.get(userId)),
+      ...payload,
+    };
+    browserStore.set(userId, next);
+    return next;
+  },
+};
+
+export const userProfileApi: UserProfileApi = isTauri() ? tauriApi : browserApi;

--- a/apps/desktop/tests/unit/userProfile.test.ts
+++ b/apps/desktop/tests/unit/userProfile.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Force browser-mode by mocking isTauri before importing the module under
+// test. The browser fallback writes to an in-memory map so we can verify
+// the round-trip without any Rust host.
+vi.mock('@/lib/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth')>('@/lib/auth');
+  return {
+    ...actual,
+    isTauri: () => false,
+  };
+});
+
+import { userProfileApi } from '@/lib/userProfile';
+
+describe('userProfileApi (browser fallback)', () => {
+  beforeEach(async () => {
+    // Reset the in-memory store between tests by overwriting with defaults.
+    await userProfileApi.update(1, {
+      fullName: 'Administrator',
+      fotoPath: null,
+      tanggalLahir: null,
+      tempatLahir: null,
+      telepon: null,
+      email: null,
+      alamat: null,
+      jenisKelamin: null,
+      agama: null,
+    });
+  });
+
+  it('returns a default profile for an unknown user id', async () => {
+    const p = await userProfileApi.get(42);
+    expect(p.userId).toBe(42);
+    expect(p.fullName).toBe('Administrator');
+    expect(p.fotoPath).toBeNull();
+  });
+
+  it('persists updates and returns them on next get', async () => {
+    const updated = await userProfileApi.update(1, {
+      fullName: 'Alvi Awal',
+      fotoPath: 'uploads/user/foo.jpg',
+      tanggalLahir: '1995-08-17',
+      tempatLahir: 'Jakarta',
+      telepon: '0812',
+      email: 'a@b.id',
+      alamat: 'Jl. Merdeka',
+      jenisKelamin: 'L',
+      agama: 'Islam',
+    });
+    expect(updated.fullName).toBe('Alvi Awal');
+    expect(updated.fotoPath).toBe('uploads/user/foo.jpg');
+
+    const fetched = await userProfileApi.get(1);
+    expect(fetched.fullName).toBe('Alvi Awal');
+    expect(fetched.tanggalLahir).toBe('1995-08-17');
+    expect(fetched.tempatLahir).toBe('Jakarta');
+    expect(fetched.telepon).toBe('0812');
+    expect(fetched.email).toBe('a@b.id');
+    expect(fetched.alamat).toBe('Jl. Merdeka');
+    expect(fetched.jenisKelamin).toBe('L');
+    expect(fetched.agama).toBe('Islam');
+  });
+
+  it('clears optional fields when updates pass null', async () => {
+    await userProfileApi.update(1, {
+      fullName: 'X',
+      fotoPath: 'uploads/user/v1.jpg',
+      tanggalLahir: '2000-01-01',
+      tempatLahir: 'Bandung',
+      telepon: '0',
+      email: 'x@y.z',
+      alamat: 'Foo',
+      jenisKelamin: 'P',
+      agama: 'Hindu',
+    });
+    const cleared = await userProfileApi.update(1, {
+      fullName: 'X',
+      fotoPath: null,
+      tanggalLahir: null,
+      tempatLahir: null,
+      telepon: null,
+      email: null,
+      alamat: null,
+      jenisKelamin: null,
+      agama: null,
+    });
+    expect(cleared.fotoPath).toBeNull();
+    expect(cleared.tanggalLahir).toBeNull();
+    expect(cleared.alamat).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes v1.0.4 #16. Adds a "Profil" dialog reachable from the header user dropdown so the signed-in operator can edit their display name, portrait, date/place of birth, contact info, address, gender, and religion. Username, role, and password remain managed by `Settings -> Akun`.

User quote (from `.devin/handoff/v1.0.3/backlog.md` #16):

> "saya ingin disini ada pop up edit admin seperti mengganti foto dan mengganti nama user di dalam tetapi login tetap admin, mungkin tanggal lahir, seperti biodata admin perpustakaan lah"

### Schema

New `user_profiles` table (PK=user_id FK to users.id ON DELETE CASCADE) with foto_path + tanggal_lahir + tempat_lahir + telepon + email + alamat + jenis_kelamin + agama columns. Idempotent via the existing `run_migrations()` pipeline. `users.full_name` (which already exists) is the source of truth for the display name; the dialog keeps it in sync.

### Backend (Rust)

- `commands/user_profile.rs` with `user_profile_get(user_id)` + `user_profile_update(user_id, payload)`. Update is transactional: bumps `users.full_name`, UPSERTs `user_profiles`, writes an `audit_log` row (entitas='users', aksi='update') with JSON before/after detail.
- Emits `users:profile-changed` so the header avatar refreshes live.
- 4 unit tests covering empty profile, unknown user, round-trip every column, idempotent upsert.

### Frontend (React)

- `features/profile/ProfilDialog.tsx` - form with `FilePickerInput` (round preview, category `'user'`, auto-compress 800px JPEG q=85 from #3), Select for gender + religion, native date input for DOB, textarea for address. Read-only username + role.
- `hooks/useUserAvatar.ts` - subscribes to the Tauri event so the header avatar updates without a reload.
- `components/layout/Header.tsx` - dropdown "Profil" item now opens the dialog (was a `disabled` placeholder); avatar slot renders the foto when present, falls back to the initial.
- New `AssetCategory` literal `'user'` (compress preset matches `anggota`); `validate_category` already accepts the slug.
- i18n keys for the dialog labels (id + en).
- 3 unit tests for the browser-mode `userProfileApi` fallback.

### Tests

All 8 quality gates green: `ALL_GATES_OK user-profile-dialog`.

## Review & Testing Checklist for Human

- [ ] Login as `admin/admin123`. Click the user menu (top right). Click "Profil" - the dialog should open with the username + role displayed read-only and `full_name` pre-filled.
- [ ] Change the full name, click "Ubah Foto", pick a JPG/PNG, fill in DOB + gender + religion, save. Toast "Profil disimpan" appears, the dialog closes, and the header avatar + greeting update live.
- [ ] Re-open the dialog - every field you saved should round-trip including the foto preview.
- [ ] Pick a 4000x3000 JPG; verify the saved file under `~/.local/share/id.alviarts.perpustakaan/uploads/user/` is downscaled to <=800px (auto-compress from #3).
- [ ] Open `Settings -> Audit Log`. The save should produce a row `update / users / <id>` whose `detail` JSON shows the before/after of every field you changed.
- [ ] Save with an empty "Nama Lengkap" - the form blocks with "Nama lengkap wajib diisi", no DB write happens.

### Notes

- Bundle identifier and `users` table layout are unchanged, so there is no v1.0.3 -> v1.0.4 migration cost beyond the new `user_profiles` row that's only created on first save.
- The dialog reuses the existing `FilePickerInput` from #1, which picks up the new `'user'` category compress preset automatically.
