### PR TITLE
chore(release): v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,72 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-05-04
+
+### Added
+
+- **KTA export PDF + open output folder** — "Cetak KTA" page now ships a
+  "Simpan PDF" button that writes the selected member cards to a vector
+  PDF under `<APPDATA>/exports/kta-YYYYMMDD-HHMMSS.pdf` via `jsPDF`. A
+  toast surfaces the filename, an emerald ribbon under the header pins
+  it for the session, and a "Buka Folder Hasil" button opens the
+  containing directory in the OS file manager. Vector text + JPEG
+  raster portraits keep file sizes small. (#96)
+- **Auto-compress uploaded photos** — every image uploaded via
+  `assets_save` is decoded with the `image` crate, downscaled with
+  Lanczos3 if its long edge exceeds the per-category cap, and re-encoded
+  as quality-85 JPEG (or original PNG if it has alpha). Caps: 800 px
+  for member portraits, 1200 px for book covers, 512 px for the school
+  logo. Typical phone snaps drop from 4 MiB to <200 KiB. SVG and GIF
+  bypass compression. (#97)
+- **Editable Laporan Kas + manual entries + audit log** — the cashbook
+  now supports inline edit, delete, and ad-hoc manual entries (income
+  or expense) via three new Tauri commands (`kas_create`, `kas_update`,
+  `kas_delete`) wrapped in transactions. Every mutation writes a
+  before/after JSON detail to `audit_log` so admins can see who
+  changed what. (#99)
+- **Dashboard: live OS clock + deterministic quote-of-the-day** —
+  header now shows a `LiveClock` ticking every second in `id-ID` with
+  a full-locale date below it. The dashboard card surfaces a daily
+  quote selected via `(year * 367 + dayOfYear) % QUOTES.length` so
+  every operator on the same calendar day sees the same quote, and
+  the quote rotates deterministically across years. 121 hand-curated
+  Indonesian + English entries about reading and learning. (#100)
+- **User profile dialog** — header dropdown's "Profil" item now opens
+  a dialog where the signed-in operator can edit display name, foto,
+  date / place of birth, contact info, address, gender, and religion.
+  Backed by a new `user_profiles` table (FK to `users.id` with
+  cascade delete) and `user_profile_get` / `user_profile_update`
+  Tauri commands. Header avatar + greeting update live via the
+  `users:profile-changed` event; saves emit an `audit_log` row with
+  the full before/after JSON. Username, role, and password remain
+  managed by `Settings → Akun`. (#103)
+
+### Changed
+
+- **Hak Akses permission matrix readability** — settings page now
+  shows a two-row role header (role label + count of granted
+  permissions), a sticky "Area" column, zebra rows, and vertical
+  dividers between roles so wide matrices stay scannable. (#98)
+- **Modern custom title bar** — replaced the OS-native window
+  decorations with a 36 px React title bar that hosts the app icon,
+  product name, drag region, and minimize / maximize / close buttons.
+  Drag region supports double-click-to-maximize and the maximize icon
+  syncs with `window.onResized`. Browser-mode dev still works because
+  the Tauri window API is lazy-loaded and falls back gracefully when
+  unavailable. (#101)
+- **Brand rename Perpustakaan Offline → Perpustakaan Nusantara** —
+  every operator-visible reference (window title, productName,
+  Windows installer + Start Menu entry + Add/Remove Programs name,
+  manual H1, README, system tray tooltip, login brand label) now
+  reads "Perpustakaan Nusantara". The bundle identifier
+  (`id.alviarts.perpustakaan`), Cargo package name, and GitHub repo
+  slug are intentionally unchanged so existing v1.0.x users keep
+  their SQLite database under `<APPDATA>/<bundle-id>/` with no
+  manual migration. Windows users will see two entries in
+  Apps & features after upgrading until they uninstall the old
+  one — that's the documented migration cost. (#102)
+
 ## [1.0.3] - 2026-05-04
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2832,7 +2832,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.3"
+version = "1.0.4"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

Bumps the app version `1.0.3 -> 1.0.4` across `package.json`, `apps/desktop/package.json`, `apps/desktop/src-tauri/Cargo.toml`, `Cargo.lock`, and `apps/desktop/src-tauri/tauri.conf.json`. Adds the matching `CHANGELOG.md` section so the `release-v2` GitHub Actions workflow can extract it as the GitHub Release body when the `v1.0.4` tag is pushed.

### v1.0.4 ships

**Added**
- KTA export PDF + Open output folder (#96)
- Auto-compress uploaded photos via the `image` crate (#97)
- Editable Laporan Kas + manual entries + audit log (#99)
- Dashboard: live OS clock + deterministic quote-of-the-day (#100)
- User profile dialog with biodata + foto (#103)

**Changed**
- Hak Akses permission matrix readability (#98)
- Modern custom title bar with native window controls (#101)
- Brand rename Perpustakaan Offline -> Perpustakaan Nusantara (#102)

### Tests

All 8 quality gates green: `ALL_GATES_OK release-v1.0.4`.

## Review & Testing Checklist for Human

- [ ] Confirm the rendered `## [1.0.4]` section in `CHANGELOG.md` reads cleanly and the bullet list is exhaustive (KTA export, auto-compress, kas, dashboard clock+quote, profile dialog, Hak Akses redesign, title bar, brand rename).
- [ ] After this PR merges, push the `v1.0.4` tag from `main`. CI's `release-v2` workflow should auto-extract the `## [1.0.4]` section as the GitHub Release body and publish Windows MSI / NSIS installers + Linux deb / AppImage / RPM.
- [ ] On Windows, install the new MSI on top of v1.0.3. Confirm the existing SQLite database under `<APPDATA>/id.alviarts.perpustakaan/` still loads (member list + book list survive). Two entries in Apps & features is expected because of the productName rename in #102.

### Notes

- `packages/shared` stays at `1.0.1` because it has no shipping changes in this cycle.
- The release tag itself isn't created in this PR; it will be pushed manually after merge so CI can trigger the release-v2 workflow.