### PR TITLE
chore(release): v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-05-04
+
+### Added
+
+- **KTA template library: 10 preset designs + gallery picker** —
+  `Settings → Template KTA` now exposes a "Galeri Template" button that
+  opens a modal showing 10 ready-to-use card designs at CR-80
+  (85.6 × 53.98 mm) — Klasik Polos, Strip Atas Teal, Sidebar Rail Navy,
+  Minimalis Modern, Sash Diagonal Rose, Portrait Tengah Emerald,
+  Tradisional Amber, Pelajar Modern Indigo, Emas Eksklusif Gold, and
+  QR Forward Cyan. Each thumbnail renders the design at scale=0.55 via
+  the live `KtaPreview` so what you see is what prints. Picking a
+  preset loads its layout into the editor — operators can tweak
+  colours / fields / positions before saving. Schema gains a `'rect'`
+  `KtaFieldKind` for filled rectangle decorations (with optional
+  `fill` hex + `radius` mm); existing user templates are unchanged
+  because they have no `rect` fields. (#105)
+
 ## [1.0.4] - 2026-05-04
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2832,7 +2832,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.4"
+version = "1.0.5"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

Bumps the app version `1.0.4 -> 1.0.5` across `package.json`, `apps/desktop/package.json`, `apps/desktop/src-tauri/Cargo.toml`, `Cargo.lock`, and `apps/desktop/src-tauri/tauri.conf.json`. Adds the matching `CHANGELOG.md` section so the `release-v2` workflow can extract it as the GitHub Release body when the `v1.0.5` tag is pushed.

### v1.0.5 ships

**Added**
- KTA template library: 10 preset designs + gallery picker (#105)

### Tests

All 8 quality gates green: `ALL_GATES_OK release-v1.0.5`.

## Review & Testing Checklist for Human

- [ ] Confirm the rendered `## [1.0.5]` section in `CHANGELOG.md` is accurate.
- [ ] After this PR merges, push the `v1.0.5` tag from `main`. CI's `release-v2` workflow should auto-extract the `## [1.0.5]` section as the GitHub Release body and publish Windows MSI / NSIS installers + Linux deb / AppImage / RPM artifacts.
- [ ] On Windows, install the new MSI on top of v1.0.4. Confirm the existing SQLite database under `<APPDATA>/id.alviarts.perpustakaan/` and any custom templates from the v1.0.4 KTA editor still load.

### Notes

- v1.0.5 is a small, focused release shipping the previously deferred #10 from the v1.0.3 backlog. If you have additional v1.0.5 candidates not yet in the backlog, point me at them and I'll queue them up.