### PR TITLE
feat(anggota): loan history tab with summary stats, top books, timeline

### DIFF
--- a/apps/desktop/src-tauri/src/commands/peminjaman.rs
+++ b/apps/desktop/src-tauri/src/commands/peminjaman.rs
@@ -119,6 +119,49 @@ pub struct PeminjamanQuickStats {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AnggotaLoanSummary {
+    pub total_peminjaman: i64,
+    pub total_item: i64,
+    pub aktif_count: i64,
+    pub overdue_count: i64,
+    pub total_denda: i64,
+    pub total_bayar: i64,
+    pub last_pinjam: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnggotaTopBuku {
+    pub buku_id: i64,
+    pub kode_buku: String,
+    pub judul: String,
+    pub jumlah: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnggotaLoanHistoryRow {
+    pub peminjaman_id: i64,
+    pub nomor_pinjam: String,
+    pub tanggal_pinjam: String,
+    pub tanggal_jatuh_tempo: String,
+    pub tanggal_kembali: Option<String>,
+    pub status: String,
+    pub total_item: i64,
+    pub total_denda: i64,
+    pub buku_judul_pertama: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnggotaLoanHistory {
+    pub summary: AnggotaLoanSummary,
+    pub top_buku: Vec<AnggotaTopBuku>,
+    pub history: Vec<AnggotaLoanHistoryRow>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OverdueRow {
     pub peminjaman_id: i64,
     pub item_id: i64,
@@ -774,6 +817,138 @@ pub fn peminjaman_overdue_list(
     peminjaman_overdue_list_inner(&conn, limit)
 }
 
+pub fn anggota_loan_history_inner(
+    conn: &rusqlite::Connection,
+    id: i64,
+    limit: Option<i64>,
+) -> AppResult<AnggotaLoanHistory> {
+    let cap = limit.unwrap_or(100).clamp(1, 1000);
+
+    // Reject unknown anggota with NotFound so the UI can redirect.
+    let exists: bool = conn
+        .query_row(
+            "SELECT 1 FROM anggota WHERE id = ?1",
+            params![id],
+            |_| Ok(true),
+        )
+        .optional()?
+        .unwrap_or(false);
+    if !exists {
+        return Err(AppError::NotFound(format!("anggota id={id}")));
+    }
+
+    // Header-level aggregates (one row per peminjaman). Counted separately
+    // from item-level aggregates so the LEFT JOIN below does not multiply
+    // total_denda / total_bayar by item count.
+    let (total_peminjaman, total_denda, total_bayar, last_pinjam): (
+        i64,
+        i64,
+        i64,
+        Option<String>,
+    ) = conn.query_row(
+        "SELECT COUNT(*), \
+                COALESCE(SUM(total_denda), 0), \
+                COALESCE(SUM(total_bayar), 0), \
+                MAX(tanggal_pinjam) \
+         FROM peminjaman WHERE anggota_id = ?1",
+        params![id],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+    )?;
+
+    // Item-level aggregates. Joined back to peminjaman to filter overdue
+    // items via the header's tanggal_jatuh_tempo.
+    let (total_item, aktif_count, overdue_count): (i64, i64, i64) = conn.query_row(
+        "SELECT \
+            COALESCE(COUNT(*), 0), \
+            COALESCE(SUM(CASE WHEN pi.status = 'dipinjam' THEN 1 ELSE 0 END), 0), \
+            COALESCE(SUM(CASE WHEN pi.status = 'dipinjam' \
+                              AND p.tanggal_jatuh_tempo < date('now') THEN 1 ELSE 0 END), 0) \
+         FROM peminjaman_item pi \
+         JOIN peminjaman p ON p.id = pi.peminjaman_id \
+         WHERE p.anggota_id = ?1",
+        params![id],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+    )?;
+
+    let summary = AnggotaLoanSummary {
+        total_peminjaman,
+        total_item,
+        aktif_count,
+        overdue_count,
+        total_denda,
+        total_bayar,
+        last_pinjam,
+    };
+
+    let mut top_stmt = conn.prepare(
+        "SELECT b.id, b.kode_buku, b.judul, COUNT(*) AS jumlah \
+         FROM peminjaman_item pi \
+         JOIN peminjaman p ON p.id = pi.peminjaman_id \
+         JOIN buku b ON b.id = pi.buku_id \
+         WHERE p.anggota_id = ?1 \
+         GROUP BY b.id, b.kode_buku, b.judul \
+         ORDER BY jumlah DESC, b.judul ASC \
+         LIMIT 5",
+    )?;
+    let top_buku: Vec<AnggotaTopBuku> = top_stmt
+        .query_map(params![id], |r| {
+            Ok(AnggotaTopBuku {
+                buku_id: r.get(0)?,
+                kode_buku: r.get(1)?,
+                judul: r.get(2)?,
+                jumlah: r.get(3)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut hist_stmt = conn.prepare(
+        "SELECT p.id, p.nomor_pinjam, p.tanggal_pinjam, p.tanggal_jatuh_tempo, \
+                p.tanggal_kembali, p.status, p.total_denda, \
+                COALESCE((SELECT COUNT(*) FROM peminjaman_item pi WHERE pi.peminjaman_id = p.id), 0), \
+                (SELECT b.judul FROM peminjaman_item pi \
+                 JOIN buku b ON b.id = pi.buku_id \
+                 WHERE pi.peminjaman_id = p.id ORDER BY pi.id ASC LIMIT 1) \
+         FROM peminjaman p \
+         WHERE p.anggota_id = ?1 \
+         ORDER BY p.tanggal_pinjam DESC, p.id DESC \
+         LIMIT ?2",
+    )?;
+    let history: Vec<AnggotaLoanHistoryRow> = hist_stmt
+        .query_map(params![id, cap], |r| {
+            Ok(AnggotaLoanHistoryRow {
+                peminjaman_id: r.get(0)?,
+                nomor_pinjam: r.get(1)?,
+                tanggal_pinjam: r.get(2)?,
+                tanggal_jatuh_tempo: r.get(3)?,
+                tanggal_kembali: r.get(4)?,
+                status: r.get(5)?,
+                total_denda: r.get(6)?,
+                total_item: r.get(7)?,
+                buku_judul_pertama: r.get(8)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    Ok(AnggotaLoanHistory {
+        summary,
+        top_buku,
+        history,
+    })
+}
+
+#[tauri::command]
+pub fn anggota_loan_history(
+    state: State<'_, AppState>,
+    id: i64,
+    limit: Option<i64>,
+) -> AppResult<AnggotaLoanHistory> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    anggota_loan_history_inner(&conn, id, limit)
+}
+
 #[tauri::command]
 pub fn anggota_summary(state: State<'_, AppState>, id: i64) -> AppResult<AnggotaSummary> {
     let conn = state
@@ -1048,5 +1223,126 @@ mod tests {
         // None → default 50, returns all 5
         let rows = peminjaman_overdue_list_inner(&conn, None).expect("query");
         assert_eq!(rows.len(), 5);
+    }
+
+    #[test]
+    fn loan_history_returns_not_found_for_unknown_anggota() {
+        let conn = setup_db();
+        let err = anggota_loan_history_inner(&conn, 999, None).expect_err("unknown");
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn loan_history_returns_zeroed_summary_when_no_loans() {
+        let conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Budi", None);
+        let h = anggota_loan_history_inner(&conn, aid, None).expect("query");
+        assert_eq!(h.summary.total_peminjaman, 0);
+        assert_eq!(h.summary.total_item, 0);
+        assert_eq!(h.summary.aktif_count, 0);
+        assert_eq!(h.summary.overdue_count, 0);
+        assert_eq!(h.summary.total_denda, 0);
+        assert_eq!(h.summary.total_bayar, 0);
+        assert!(h.summary.last_pinjam.is_none());
+        assert!(h.history.is_empty());
+        assert!(h.top_buku.is_empty());
+    }
+
+    #[test]
+    fn loan_history_aggregates_summary_top_buku_and_history() {
+        let conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Budi", Some("X-A"));
+        let other = seed_anggota(&conn, "A0002", "Ani", None);
+        let b1 = seed_buku(&conn, "B0001", "Matematika 1");
+        let b2 = seed_buku(&conn, "B0002", "Sejarah");
+
+        // Three peminjaman for Budi:
+        //   PJ-1: 2024-01-05, 2 books (b1+b1) - dipinjam (still active, on time)
+        //   PJ-2: 2024-02-10, 1 book (b1)     - dikembalikan
+        //   PJ-3: 2020-03-01, 1 book (b2)     - overdue (still dipinjam)
+        // One peminjaman for Ani — must be excluded.
+        seed_pinjaman(&conn, "PJ-1", aid, b1, "2024-01-05", "2099-01-12", "dipinjam");
+        // Add second item to PJ-1 so total_item > 1.
+        conn.execute(
+            "INSERT INTO peminjaman_item (peminjaman_id, buku_id, status) \
+             SELECT id, ?1, 'dikembalikan' FROM peminjaman WHERE nomor_pinjam = 'PJ-1'",
+            params![b1],
+        )
+        .expect("seed extra item PJ-1");
+        // Bump total_denda for PJ-1.
+        conn.execute(
+            "UPDATE peminjaman SET total_denda = 1500, total_bayar = 1500 \
+             WHERE nomor_pinjam = 'PJ-1'",
+            [],
+        )
+        .expect("update denda PJ-1");
+
+        seed_pinjaman(
+            &conn, "PJ-2", aid, b1, "2024-02-10", "2024-02-17", "dikembalikan",
+        );
+        conn.execute(
+            "UPDATE peminjaman SET status = 'dikembalikan', total_denda = 500, total_bayar = 500 \
+             WHERE nomor_pinjam = 'PJ-2'",
+            [],
+        )
+        .expect("update PJ-2");
+
+        seed_pinjaman(&conn, "PJ-3", aid, b2, "2020-03-01", "2020-03-08", "dipinjam");
+
+        seed_pinjaman(
+            &conn, "PJ-X", other, b1, "2024-01-01", "2024-01-08", "dipinjam",
+        );
+
+        let h = anggota_loan_history_inner(&conn, aid, None).expect("query");
+        assert_eq!(h.summary.total_peminjaman, 3);
+        assert_eq!(h.summary.total_item, 4); // 2+1+1
+        assert_eq!(h.summary.aktif_count, 2); // PJ-1 first item still dipinjam + PJ-3
+        assert_eq!(h.summary.overdue_count, 1); // PJ-3 only
+        assert_eq!(h.summary.total_denda, 2000);
+        assert_eq!(h.summary.total_bayar, 2000);
+        assert_eq!(h.summary.last_pinjam.as_deref(), Some("2024-02-10"));
+
+        // top_buku ordered by count desc; b1 has 3 borrows, b2 has 1.
+        assert_eq!(h.top_buku.len(), 2);
+        assert_eq!(h.top_buku[0].kode_buku, "B0001");
+        assert_eq!(h.top_buku[0].jumlah, 3);
+        assert_eq!(h.top_buku[1].kode_buku, "B0002");
+        assert_eq!(h.top_buku[1].jumlah, 1);
+
+        // history ordered by tanggal_pinjam DESC.
+        assert_eq!(h.history.len(), 3);
+        assert_eq!(h.history[0].nomor_pinjam, "PJ-2");
+        assert_eq!(h.history[0].total_item, 1);
+        assert_eq!(h.history[1].nomor_pinjam, "PJ-1");
+        assert_eq!(h.history[1].total_item, 2);
+        assert_eq!(h.history[2].nomor_pinjam, "PJ-3");
+        assert_eq!(h.history[2].buku_judul_pertama.as_deref(), Some("Sejarah"));
+    }
+
+    #[test]
+    fn loan_history_clamps_limit() {
+        let conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Budi", None);
+        let bid = seed_buku(&conn, "B0001", "X");
+        for i in 0..5 {
+            seed_pinjaman(
+                &conn,
+                &format!("PJ-{i}"),
+                aid,
+                bid,
+                &format!("2024-01-0{}", i + 1),
+                &format!("2024-01-1{}", i + 1),
+                "dikembalikan",
+            );
+        }
+        // limit=2 returns most recent 2
+        let h = anggota_loan_history_inner(&conn, aid, Some(2)).expect("query");
+        assert_eq!(h.history.len(), 2);
+        // limit=0 → clamped to 1
+        let h = anggota_loan_history_inner(&conn, aid, Some(0)).expect("query");
+        assert_eq!(h.history.len(), 1);
+        // None → default 100, returns all 5
+        let h = anggota_loan_history_inner(&conn, aid, None).expect("query");
+        assert_eq!(h.history.len(), 5);
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ pub fn run() {
             commands::peminjaman::peminjaman_kembalikan,
             commands::peminjaman::peminjaman_quick_stats,
             commands::peminjaman::peminjaman_overdue_list,
+            commands::peminjaman::anggota_loan_history,
             commands::peminjaman::pengembalian_search,
             commands::peminjaman::anggota_summary,
             commands::peminjaman::buku_summary,

--- a/apps/desktop/src/features/anggota/AnggotaRiwayatPanel.tsx
+++ b/apps/desktop/src/features/anggota/AnggotaRiwayatPanel.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import {
+  AlertTriangle,
+  ArrowRight,
+  BookMarked,
+  CalendarClock,
+  CircleDollarSign,
+  History,
+} from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatTauriError } from '@/lib/errors';
+import { peminjamanApi, type AnggotaLoanHistory } from '@/lib/peminjaman';
+import { cn } from '@/lib/utils';
+
+const RUPIAH = new Intl.NumberFormat('id-ID', {
+  style: 'currency',
+  currency: 'IDR',
+  maximumFractionDigits: 0,
+});
+
+const STATUS_TONE: Record<string, string> = {
+  dipinjam: 'bg-primary/10 text-primary',
+  sebagian: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  dikembalikan: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  terlambat: 'bg-rose-500/10 text-rose-600 dark:text-rose-400',
+  hilang: 'bg-rose-700/10 text-rose-700 dark:text-rose-400',
+};
+
+interface Props {
+  anggotaId: number;
+}
+
+/**
+ * Loan-history tab body for the anggota detail page. Hits
+ * `anggota_loan_history` once on mount and renders a stat grid, top-5
+ * borrowed books, and a chronological list of peminjaman with status
+ * pills and per-row links to the peminjaman detail page.
+ */
+export function AnggotaRiwayatPanel({ anggotaId }: Props) {
+  const { t, i18n } = useTranslation(['anggota', 'peminjaman', 'common']);
+  const [data, setData] = useState<AnggotaLoanHistory | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    setError(null);
+    peminjamanApi
+      .anggotaLoanHistory(anggotaId)
+      .then((d) => {
+        if (!cancel) setData(d);
+      })
+      .catch((err) => {
+        if (!cancel) setError(formatTauriError(err));
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [anggotaId]);
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="border-rose-200/70 bg-rose-50/40 dark:border-rose-500/30 dark:bg-rose-500/5">
+        <CardContent className="flex items-center gap-3 p-4 text-sm text-rose-600 dark:text-rose-300">
+          <AlertTriangle className="h-4 w-4" />
+          <span>{t('anggota:history.loadError', { msg: error, defaultValue: error })}</span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) return null;
+
+  const { summary, topBuku, history } = data;
+  const dateFormatter = new Intl.DateTimeFormat(i18n.language === 'en' ? 'en-GB' : 'id-ID', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+  const fmtDate = (iso: string | null | undefined): string => {
+    if (!iso) return '—';
+    try {
+      return dateFormatter.format(new Date(`${iso}T00:00:00`));
+    } catch {
+      return iso;
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={<History className="h-5 w-5" />}
+          label={t('anggota:history.stats.total', { defaultValue: 'Total Peminjaman' })}
+          value={summary.totalPeminjaman.toString()}
+          hint={t('anggota:history.stats.totalHint', {
+            count: summary.totalItem,
+            defaultValue: '{{count}} buku diakses',
+          })}
+        />
+        <StatCard
+          icon={<BookMarked className="h-5 w-5" />}
+          label={t('anggota:history.stats.aktif', { defaultValue: 'Sedang Dipinjam' })}
+          value={summary.aktifCount.toString()}
+          hint={
+            summary.overdueCount > 0
+              ? t('anggota:history.stats.overdueHint', {
+                  count: summary.overdueCount,
+                  defaultValue: '{{count}} terlambat',
+                })
+              : t('anggota:history.stats.onTime', { defaultValue: 'Tepat waktu' })
+          }
+          tone={summary.overdueCount > 0 ? 'rose' : summary.aktifCount > 0 ? 'primary' : 'muted'}
+        />
+        <StatCard
+          icon={<CircleDollarSign className="h-5 w-5" />}
+          label={t('anggota:history.stats.denda', { defaultValue: 'Total Denda' })}
+          value={RUPIAH.format(summary.totalDenda)}
+          hint={t('anggota:history.stats.dibayar', {
+            value: RUPIAH.format(summary.totalBayar),
+            defaultValue: 'Sudah dibayar {{value}}',
+          })}
+        />
+        <StatCard
+          icon={<CalendarClock className="h-5 w-5" />}
+          label={t('anggota:history.stats.lastPinjam', { defaultValue: 'Pinjam Terakhir' })}
+          value={summary.lastPinjam ? fmtDate(summary.lastPinjam) : '—'}
+        />
+      </section>
+
+      {topBuku.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">
+              {t('anggota:history.topBuku.title', { defaultValue: 'Buku Sering Dipinjam' })}
+            </CardTitle>
+            <CardDescription>
+              {t('anggota:history.topBuku.subtitle', {
+                defaultValue: '5 judul teratas berdasarkan jumlah peminjaman',
+              })}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-2 p-4 pt-0 sm:grid-cols-2 lg:grid-cols-5">
+            {topBuku.map((b) => (
+              <div
+                key={b.bukuId}
+                className="flex flex-col rounded-md border bg-muted/30 p-3"
+              >
+                <div className="text-muted-foreground text-xs font-mono">{b.kodeBuku}</div>
+                <div className="line-clamp-2 text-sm font-medium">{b.judul}</div>
+                <div className="text-primary mt-1 text-xs font-semibold">
+                  {t('anggota:history.topBuku.count', {
+                    count: b.jumlah,
+                    defaultValue: '{{count}}× pinjam',
+                  })}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">
+            {t('anggota:history.timeline.title', { defaultValue: 'Riwayat Peminjaman' })}
+          </CardTitle>
+          <CardDescription>
+            {t('anggota:history.timeline.subtitle', {
+              count: history.length,
+              defaultValue: '{{count}} entri terbaru',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          {history.length === 0 ? (
+            <p className="text-muted-foreground p-4 text-sm">
+              {t('anggota:history.timeline.empty', {
+                defaultValue: 'Belum ada peminjaman tercatat.',
+              })}
+            </p>
+          ) : (
+            <ul className="divide-y">
+              {history.map((row) => (
+                <li key={row.peminjamanId}>
+                  <Link
+                    to="/peminjaman/$id"
+                    params={{ id: String(row.peminjamanId) }}
+                    className="hover:bg-muted/60 group flex items-center gap-3 px-4 py-3 text-sm"
+                  >
+                    <div className="flex flex-1 flex-col gap-0.5 overflow-hidden">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-xs font-medium">{row.nomorPinjam}</span>
+                        <span
+                          className={cn(
+                            'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+                            STATUS_TONE[row.status] ?? 'bg-muted text-muted-foreground',
+                          )}
+                        >
+                          {t(`peminjaman:status.${row.status}` as never, {
+                            defaultValue: row.status,
+                          })}
+                        </span>
+                      </div>
+                      <div className="text-muted-foreground truncate text-xs">
+                        {row.bukuJudulPertama ?? '—'}
+                        {row.totalItem > 1 ? ` (+${row.totalItem - 1})` : ''}
+                      </div>
+                      <div className="text-muted-foreground text-[11px]">
+                        {fmtDate(row.tanggalPinjam)} → {fmtDate(row.tanggalJatuhTempo)}
+                        {row.tanggalKembali
+                          ? ` · ${t('anggota:history.timeline.returned', {
+                              date: fmtDate(row.tanggalKembali),
+                              defaultValue: 'kembali {{date}}',
+                            })}`
+                          : ''}
+                      </div>
+                    </div>
+                    {row.totalDenda > 0 && (
+                      <span className="text-rose-600 dark:text-rose-400 shrink-0 text-xs font-semibold tabular-nums">
+                        {RUPIAH.format(row.totalDenda)}
+                      </span>
+                    )}
+                    <ArrowRight className="text-muted-foreground group-hover:text-foreground h-4 w-4 shrink-0" />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+interface StatProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: 'primary' | 'rose' | 'muted';
+}
+
+function StatCard({ icon, label, value, hint, tone = 'muted' }: StatProps) {
+  const toneClass =
+    tone === 'rose'
+      ? 'text-rose-600 dark:text-rose-400'
+      : tone === 'primary'
+        ? 'text-primary'
+        : 'text-foreground';
+  return (
+    <Card>
+      <CardContent className="flex items-start gap-3 p-4">
+        <div className="bg-muted text-muted-foreground rounded-md p-2">{icon}</div>
+        <div className="min-w-0 flex-1">
+          <div className="text-muted-foreground text-xs">{label}</div>
+          <div className={cn('truncate text-lg font-semibold tabular-nums', toneClass)}>
+            {value}
+          </div>
+          {hint && <div className="text-muted-foreground truncate text-xs">{hint}</div>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/desktop/src/i18n/en/anggota.json
+++ b/apps/desktop/src/i18n/en/anggota.json
@@ -103,5 +103,36 @@
     "new": "Add",
     "edit": "Edit",
     "cetakKta": "Print ID Card"
+  },
+  "detail": {
+    "tabsLabel": "Member details",
+    "tab": {
+      "edit": "Edit Profile",
+      "history": "Loan History"
+    }
+  },
+  "history": {
+    "loadError": "Failed to load history: {{msg}}",
+    "stats": {
+      "total": "Total Loans",
+      "totalHint": "{{count}} books touched",
+      "aktif": "Currently Borrowed",
+      "overdueHint": "{{count}} overdue",
+      "onTime": "On time",
+      "denda": "Total Fines",
+      "dibayar": "Paid {{value}}",
+      "lastPinjam": "Last Loan"
+    },
+    "topBuku": {
+      "title": "Most-borrowed books",
+      "subtitle": "Top 5 titles by loan count",
+      "count": "{{count}}× borrowed"
+    },
+    "timeline": {
+      "title": "Loan History",
+      "subtitle": "{{count}} most recent entries",
+      "empty": "No loans recorded yet.",
+      "returned": "returned {{date}}"
+    }
   }
 }

--- a/apps/desktop/src/i18n/id/anggota.json
+++ b/apps/desktop/src/i18n/id/anggota.json
@@ -103,5 +103,36 @@
     "new": "Tambah",
     "edit": "Edit",
     "cetakKta": "Cetak KTA"
+  },
+  "detail": {
+    "tabsLabel": "Detail anggota",
+    "tab": {
+      "edit": "Edit Profil",
+      "history": "Riwayat Peminjaman"
+    }
+  },
+  "history": {
+    "loadError": "Gagal memuat riwayat: {{msg}}",
+    "stats": {
+      "total": "Total Peminjaman",
+      "totalHint": "{{count}} buku diakses",
+      "aktif": "Sedang Dipinjam",
+      "overdueHint": "{{count}} terlambat",
+      "onTime": "Tepat waktu",
+      "denda": "Total Denda",
+      "dibayar": "Sudah dibayar {{value}}",
+      "lastPinjam": "Pinjam Terakhir"
+    },
+    "topBuku": {
+      "title": "Buku Sering Dipinjam",
+      "subtitle": "5 judul teratas berdasarkan jumlah peminjaman",
+      "count": "{{count}}× pinjam"
+    },
+    "timeline": {
+      "title": "Riwayat Peminjaman",
+      "subtitle": "{{count}} entri terbaru",
+      "empty": "Belum ada peminjaman tercatat.",
+      "returned": "kembali {{date}}"
+    }
   }
 }

--- a/apps/desktop/src/lib/peminjaman.ts
+++ b/apps/desktop/src/lib/peminjaman.ts
@@ -82,6 +82,41 @@ export interface PeminjamanQuickStats {
   totalAktif: number;
 }
 
+export interface AnggotaLoanSummary {
+  totalPeminjaman: number;
+  totalItem: number;
+  aktifCount: number;
+  overdueCount: number;
+  totalDenda: number;
+  totalBayar: number;
+  lastPinjam?: string | null;
+}
+
+export interface AnggotaTopBuku {
+  bukuId: number;
+  kodeBuku: string;
+  judul: string;
+  jumlah: number;
+}
+
+export interface AnggotaLoanHistoryRow {
+  peminjamanId: number;
+  nomorPinjam: string;
+  tanggalPinjam: string;
+  tanggalJatuhTempo: string;
+  tanggalKembali?: string | null;
+  status: 'dipinjam' | 'sebagian' | 'dikembalikan' | 'terlambat' | 'hilang';
+  totalItem: number;
+  totalDenda: number;
+  bukuJudulPertama?: string | null;
+}
+
+export interface AnggotaLoanHistory {
+  summary: AnggotaLoanSummary;
+  topBuku: AnggotaTopBuku[];
+  history: AnggotaLoanHistoryRow[];
+}
+
 export interface OverdueRow {
   peminjamanId: number;
   itemId: number;
@@ -127,6 +162,7 @@ interface PeminjamanRpc {
   kembalikan(input: PeminjamanReturnInput): Promise<PeminjamanReturnResult>;
   quickStats(): Promise<PeminjamanQuickStats>;
   overdueList(limit?: number): Promise<OverdueRow[]>;
+  anggotaLoanHistory(id: number, limit?: number): Promise<AnggotaLoanHistory>;
   search(query: string): Promise<PeminjamanRow[]>;
   anggotaSummary(id: number): Promise<AnggotaSummary>;
   bukuSummary(id: number): Promise<BukuSummary>;
@@ -203,6 +239,10 @@ const tauriRpc: PeminjamanRpc = {
   async overdueList(limit) {
     const { invoke } = await import('@tauri-apps/api/core');
     return invoke<OverdueRow[]>('peminjaman_overdue_list', { limit });
+  },
+  async anggotaLoanHistory(id, limit) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<AnggotaLoanHistory>('anggota_loan_history', { id, limit });
   },
   async search(query) {
     const { invoke } = await import('@tauri-apps/api/core');
@@ -372,6 +412,61 @@ const mockRpc: PeminjamanRpc = {
     }
     rows.sort((a, b) => b.hariTerlambat - a.hariTerlambat);
     return rows.slice(0, cap);
+  },
+  async anggotaLoanHistory(id, limit) {
+    const state = readMock();
+    const today = todayIso();
+    const cap = Math.max(1, Math.min(limit ?? 100, 1000));
+    const headers = state.rows.filter((r) => r.anggotaId === id);
+    const summary: AnggotaLoanSummary = {
+      totalPeminjaman: headers.length,
+      totalItem: 0,
+      aktifCount: 0,
+      overdueCount: 0,
+      totalDenda: 0,
+      totalBayar: 0,
+      lastPinjam: headers.length > 0 ? headers[0]!.tanggalPinjam : null,
+    };
+    const counts = new Map<number, AnggotaTopBuku>();
+    const history: AnggotaLoanHistoryRow[] = [];
+    for (const h of headers) {
+      const items = state.items.filter((i) => i.peminjamanId === h.id);
+      summary.totalItem += items.length;
+      summary.totalDenda += h.totalDenda;
+      summary.totalBayar += h.totalBayar;
+      const judulPertama = items[0]?.bukuJudul ?? null;
+      for (const i of items) {
+        const c = counts.get(i.bukuId);
+        if (c) c.jumlah += 1;
+        else
+          counts.set(i.bukuId, {
+            bukuId: i.bukuId,
+            kodeBuku: i.bukuKode,
+            judul: i.bukuJudul,
+            jumlah: 1,
+          });
+        if (i.status === 'dipinjam') {
+          summary.aktifCount += 1;
+          if (dayDiff(today, h.tanggalJatuhTempo) > 0) summary.overdueCount += 1;
+        }
+      }
+      history.push({
+        peminjamanId: h.id,
+        nomorPinjam: h.nomorPinjam,
+        tanggalPinjam: h.tanggalPinjam,
+        tanggalJatuhTempo: h.tanggalJatuhTempo,
+        tanggalKembali: h.tanggalKembali,
+        status: h.status as AnggotaLoanHistoryRow['status'],
+        totalItem: items.length,
+        totalDenda: h.totalDenda,
+        bukuJudulPertama: judulPertama,
+      });
+    }
+    history.sort((a, b) => b.tanggalPinjam.localeCompare(a.tanggalPinjam));
+    const topBuku = [...counts.values()]
+      .sort((a, b) => b.jumlah - a.jumlah || a.judul.localeCompare(b.judul))
+      .slice(0, 5);
+    return { summary, topBuku, history: history.slice(0, cap) };
   },
   async search(query) {
     const state = readMock();

--- a/apps/desktop/src/routes/_authed/anggota/$id.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/$id.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
 import { createFileRoute, Link, useNavigate, useParams } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, History, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { AnggotaForm } from '@/features/anggota/AnggotaForm';
+import { AnggotaRiwayatPanel } from '@/features/anggota/AnggotaRiwayatPanel';
 import { anggotaApi, type Anggota } from '@/lib/anggota';
 import { toAnggotaInput } from '@/features/anggota/schema';
 import { useToast } from '@/components/ui/toast-manager';
 import { formatTauriError } from '@/lib/errors';
+import { cn } from '@/lib/utils';
+
+type AnggotaDetailTab = 'edit' | 'history';
 
 export const Route = createFileRoute('/_authed/anggota/$id')({
   component: EditAnggotaRoute,
@@ -27,6 +31,7 @@ function EditAnggotaRoute() {
   const [jurusan, setJurusan] = useState<string[]>([]);
   const [agama, setAgama] = useState<string[]>([]);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [tab, setTab] = useState<AnggotaDetailTab>('edit');
 
   useEffect(() => {
     let cancelled = false;
@@ -67,14 +72,37 @@ function EditAnggotaRoute() {
         </Button>
       </div>
 
-      <div className="mb-6">
+      <div className="mb-4">
         <h1 className="text-2xl font-bold tracking-tight">{t('anggota:form.editTitle')}</h1>
         <p className="text-sm text-muted-foreground">{t('anggota:form.editSubtitle')}</p>
       </div>
 
+      <div
+        role="tablist"
+        aria-label={t('anggota:detail.tabsLabel', { defaultValue: 'Detail anggota' })}
+        className="mb-6 inline-flex items-center gap-1 rounded-md border bg-muted/40 p-1 text-sm"
+      >
+        <TabButton
+          active={tab === 'edit'}
+          onClick={() => setTab('edit')}
+          icon={<Pencil className="h-3.5 w-3.5" />}
+          testid="anggota-tab-edit"
+        >
+          {t('anggota:detail.tab.edit', { defaultValue: 'Edit Profil' })}
+        </TabButton>
+        <TabButton
+          active={tab === 'history'}
+          onClick={() => setTab('history')}
+          icon={<History className="h-3.5 w-3.5" />}
+          testid="anggota-tab-history"
+        >
+          {t('anggota:detail.tab.history', { defaultValue: 'Riwayat Peminjaman' })}
+        </TabButton>
+      </div>
+
       {loading ? (
         <p className="text-sm text-muted-foreground">{t('common:states.loading')}</p>
-      ) : item ? (
+      ) : item && tab === 'edit' ? (
         <AnggotaForm
           initial={item}
           kelasOptions={kelas}
@@ -98,6 +126,8 @@ function EditAnggotaRoute() {
             }
           }}
         />
+      ) : item ? (
+        <AnggotaRiwayatPanel anggotaId={item.id} />
       ) : null}
 
       <ConfirmDialog
@@ -123,5 +153,34 @@ function EditAnggotaRoute() {
         }}
       />
     </div>
+  );
+}
+
+interface TabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  testid?: string;
+  children: React.ReactNode;
+}
+
+function TabButton({ active, onClick, icon, testid, children }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      data-testid={testid}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-colors',
+        active
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground',
+      )}
+    >
+      {icon}
+      {children}
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

Implements **v1.0.6 #20** — surface a member's peminjaman history on the anggota detail page so pustakawan can answer "sudah berapa kali pinjam? masih ada yang belum kembali? berapa total denda?" in one screen.

### Backend
- New `anggota_loan_history(id, limit?)` Tauri command returning a single payload with three sections:
  - **summary**: total peminjaman, total item, aktif count, overdue count, total denda, total bayar, last_pinjam.
  - **top_buku**: top 5 most-borrowed titles for this anggota (by peminjaman_item count).
  - **history**: chronological list of peminjaman (DESC by tanggal_pinjam) with first item title, total item count, denda, status, and date fields.
- Limit clamped to 1..=1000 (default 100). Unknown anggota id returns `AppError::NotFound`.
- Header-level totals (denda/bayar) are computed without joining peminjaman_item so multi-item peminjaman do not double-count.
- 4 new unit tests: not-found, zeroed summary, full aggregation, limit clamp.

### Frontend
- New tab UI on `/anggota/$id` with two tabs: **Edit Profil** (existing form, unchanged) and **Riwayat Peminjaman** (new).
- `AnggotaRiwayatPanel` component:
  - 4 stat cards (total, sedang dipinjam + overdue badge, total denda + dibayar, pinjam terakhir).
  - Top-5 buku grid with kode + title + count.
  - Timeline list: nomor pinjam + status pill + first book title (+N more) + tanggal range + denda highlight.
- `peminjamanApi.anggotaLoanHistory(id, limit?)` extended in both Tauri and mock RPCs.
- New i18n keys: `anggota:detail.tab.*` + `anggota:history.*`, parity-verified across id/en.

## Review & Testing Checklist for Human

- [ ] Verify totals on a member with multi-item peminjaman match the kas/denda numbers shown elsewhere in the app.
- [ ] Confirm the tab toggle preserves form scroll position when switching back to Edit.
- [ ] Test on a fresh anggota (no loans) — stats show zeros, top-5 hidden, timeline shows empty state.
- [ ] Confirm overdue badge in stats matches the dashboard panel + header bell counts.

### Notes
- The query splits header aggregates from item aggregates intentionally to avoid the LEFT JOIN denda multiplication bug discovered during testing.
- `total_item` counts every peminjaman_item row (including dikembalikan) — it's a lifetime number, not active.
- The tab UI is a minimal in-line implementation (button group + state) since the codebase has no existing Tabs primitive.