### PR TITLE
v1.0.6 #21 — Wizard impor Excel/CSV (anggota & buku)

### DIFF
--- a/apps/desktop/src/components/shared/ImportWizard.tsx
+++ b/apps/desktop/src/components/shared/ImportWizard.tsx
@@ -1,0 +1,646 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CheckCircle2, AlertTriangle, Download, FileSpreadsheet, Upload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/components/ui/toast-manager';
+import { cn } from '@/lib/utils';
+import { formatTauriError } from '@/lib/errors';
+import {
+  autoMap,
+  buildErrorReportCsv,
+  buildMappedRows,
+  buildTemplateBytes,
+  parseFile,
+  triggerDownload,
+  type ImportFieldDef,
+  type Mapping,
+  type MappedRow,
+  type ParsedFile,
+} from '@/lib/importWizard';
+
+export interface ImportWizardImportError {
+  row: number;
+  message: string;
+}
+
+export interface ImportWizardResult {
+  inserted: number;
+  skipped: number;
+  errors: ImportWizardImportError[];
+}
+
+export interface ImportWizardProps<TItem> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Title shown in the dialog header (translated). */
+  title: string;
+  /** Description shown under the title (translated). */
+  description: string;
+  /** Field definitions used for mapping + validation + template. */
+  fields: ImportFieldDef<TItem>[];
+  /** Sheet name used in the downloadable template. */
+  templateSheetName: string;
+  /** File name used when downloading the template. */
+  templateFilename: string;
+  /** Convert raw mapped strings into the typed item shape. */
+  rowParser: (rawByKey: Record<string, string>) => TItem;
+  /** Submit only items that have no validation errors. */
+  onImport: (items: TItem[]) => Promise<ImportWizardResult>;
+  /** Called once submission completes successfully. */
+  onImported: (result: ImportWizardResult) => void;
+}
+
+type Step = 'upload' | 'map' | 'preview' | 'result';
+
+export function ImportWizard<TItem>(
+  props: ImportWizardProps<TItem>,
+) {
+  const {
+    open,
+    onOpenChange,
+    title,
+    description,
+    fields,
+    templateSheetName,
+    templateFilename,
+    rowParser,
+    onImport,
+    onImported,
+  } = props;
+
+  const { t } = useTranslation(['common']);
+  const { showToast } = useToast();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [step, setStep] = useState<Step>('upload');
+  const [parsed, setParsed] = useState<ParsedFile | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [mapping, setMapping] = useState<Mapping>({});
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<ImportWizardResult | null>(null);
+
+  const reset = (): void => {
+    setStep('upload');
+    setParsed(null);
+    setParseError(null);
+    setMapping({});
+    setResult(null);
+    if (fileRef.current) fileRef.current.value = '';
+  };
+
+  useEffect(() => {
+    if (!open) reset();
+  }, [open]);
+
+  const handleFile = async (file: File): Promise<void> => {
+    setParseError(null);
+    try {
+      const p = await parseFile(file);
+      setParsed(p);
+      const m = autoMap(fields, p.headers);
+      setMapping(m);
+      setStep('map');
+    } catch (err) {
+      setParseError(formatTauriError(err));
+    }
+  };
+
+  const handleDownloadTemplate = (): void => {
+    const bytes = buildTemplateBytes(fields, templateSheetName);
+    triggerDownload(
+      templateFilename,
+      bytes,
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+  };
+
+  const requiredFields = fields.filter((f) => f.required);
+  const mappedTargets = new Set(Object.values(mapping).filter(Boolean));
+  const missingRequired = requiredFields.filter((f) => !mappedTargets.has(f.key));
+
+  const mappedRows: MappedRow<TItem>[] = useMemo(() => {
+    if (!parsed) return [];
+    return buildMappedRows(fields, parsed, mapping, rowParser);
+  }, [parsed, fields, mapping, rowParser]);
+
+  const validRows = mappedRows.filter((r) => r.errors.length === 0);
+  const invalidRows = mappedRows.filter((r) => r.errors.length > 0);
+
+  const handleSubmit = async (): Promise<void> => {
+    if (validRows.length === 0) return;
+    setBusy(true);
+    try {
+      const items = validRows.map((r) => r.item);
+      const r = await onImport(items);
+      // Re-base the row numbers reported by backend so they refer to the
+      // original spreadsheet row (header is row 1, first data is row 2).
+      const rebased: ImportWizardResult = {
+        inserted: r.inserted,
+        skipped: r.skipped + invalidRows.length,
+        errors: [
+          ...invalidRows.map((row) => ({
+            row: row.rowNumber,
+            message: row.errors.join('; '),
+          })),
+          ...r.errors.map((e) => ({
+            row: validRows[e.row - 1]?.rowNumber ?? e.row,
+            message: e.message,
+          })),
+        ].sort((a, b) => a.row - b.row),
+      };
+      setResult(rebased);
+      setStep('result');
+      onImported(rebased);
+      showToast({
+        title: t('common:importWizard.toastDone', {
+          defaultValue: 'Selesai impor',
+        }),
+        description: t('common:importWizard.toastSummary', {
+          defaultValue: '{{inserted}} ditambahkan, {{skipped}} dilewati',
+          inserted: rebased.inserted,
+          skipped: rebased.skipped,
+        }),
+      });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('common:importWizard.toastFailed', {
+          defaultValue: 'Gagal impor',
+        }),
+        description: formatTauriError(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDownloadErrors = (): void => {
+    if (!result || result.errors.length === 0) return;
+    const csv = buildErrorReportCsv(result.errors);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    triggerDownload(`import-errors-${Date.now()}.csv`, blob);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <Stepper step={step} />
+
+        {step === 'upload' && (
+          <UploadStep
+            fileRef={fileRef}
+            onPick={(file) => void handleFile(file)}
+            parseError={parseError}
+            onDownloadTemplate={handleDownloadTemplate}
+          />
+        )}
+
+        {step === 'map' && parsed && (
+          <MappingStep
+            parsed={parsed}
+            fields={fields}
+            mapping={mapping}
+            onMappingChange={setMapping}
+            missingRequired={missingRequired}
+          />
+        )}
+
+        {step === 'preview' && parsed && (
+          <PreviewStep
+            mappedRows={mappedRows}
+            fields={fields}
+            mapping={mapping}
+            invalidCount={invalidRows.length}
+            validCount={validRows.length}
+          />
+        )}
+
+        {step === 'result' && result && (
+          <ResultStep result={result} onDownloadErrors={handleDownloadErrors} />
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          {step === 'upload' && (
+            <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+              {t('common:actions.cancel', 'Batal')}
+            </Button>
+          )}
+          {step === 'map' && (
+            <>
+              <Button variant="ghost" onClick={() => setStep('upload')} disabled={busy}>
+                {t('common:actions.back', 'Kembali')}
+              </Button>
+              <Button
+                disabled={missingRequired.length > 0}
+                onClick={() => setStep('preview')}
+                data-testid="import-wizard-next-preview"
+              >
+                {t('common:actions.next', 'Lanjut')}
+              </Button>
+            </>
+          )}
+          {step === 'preview' && (
+            <>
+              <Button variant="ghost" onClick={() => setStep('map')} disabled={busy}>
+                {t('common:actions.back', 'Kembali')}
+              </Button>
+              <Button
+                onClick={() => void handleSubmit()}
+                disabled={busy || validRows.length === 0}
+                data-testid="import-wizard-submit"
+              >
+                {busy
+                  ? t('common:states.loading', 'Memuat…')
+                  : t('common:importWizard.submit', {
+                      defaultValue: 'Impor {{count}} baris',
+                      count: validRows.length,
+                    })}
+              </Button>
+            </>
+          )}
+          {step === 'result' && (
+            <Button onClick={() => onOpenChange(false)}>
+              {t('common:actions.close', 'Tutup')}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Stepper({ step }: { step: Step }) {
+  const { t } = useTranslation(['common']);
+  const steps: Array<{ id: Step; label: string }> = [
+    { id: 'upload', label: t('common:importWizard.step.upload', 'Unggah') },
+    { id: 'map', label: t('common:importWizard.step.map', 'Mapping') },
+    { id: 'preview', label: t('common:importWizard.step.preview', 'Preview') },
+    { id: 'result', label: t('common:importWizard.step.result', 'Hasil') },
+  ];
+  const idx = steps.findIndex((s) => s.id === step);
+  return (
+    <ol className="mb-2 grid grid-cols-4 gap-2">
+      {steps.map((s, i) => {
+        const active = i === idx;
+        const done = i < idx;
+        return (
+          <li
+            key={s.id}
+            className={cn(
+              'flex items-center gap-2 rounded-md border px-3 py-2 text-sm',
+              active && 'border-primary bg-primary/5 text-primary',
+              done && 'border-emerald-500/40 bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-200',
+              !active && !done && 'text-muted-foreground',
+            )}
+          >
+            <span
+              className={cn(
+                'flex h-5 w-5 items-center justify-center rounded-full border text-xs',
+                active && 'border-primary bg-primary text-primary-foreground',
+                done && 'border-emerald-500 bg-emerald-500 text-white',
+              )}
+            >
+              {done ? <CheckCircle2 className="h-3 w-3" /> : i + 1}
+            </span>
+            <span className="truncate font-medium">{s.label}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+interface UploadStepProps {
+  fileRef: React.RefObject<HTMLInputElement>;
+  onPick: (file: File) => void;
+  parseError: string | null;
+  onDownloadTemplate: () => void;
+}
+
+function UploadStep({ fileRef, onPick, parseError, onDownloadTemplate }: UploadStepProps) {
+  const { t } = useTranslation(['common']);
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-dashed p-6 text-center">
+        <FileSpreadsheet className="mx-auto h-10 w-10 text-muted-foreground" />
+        <p className="mt-2 text-sm">
+          {t('common:importWizard.upload.help', {
+            defaultValue: 'Pilih file .xlsx, .xls, atau .csv. Header di baris pertama.',
+          })}
+        </p>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".xlsx,.xls,.csv"
+          data-testid="import-wizard-file"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) onPick(file);
+          }}
+        />
+        <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+          <Button onClick={() => fileRef.current?.click()} data-testid="import-wizard-pick">
+            <Upload className="mr-2 h-4 w-4" />
+            {t('common:importWizard.upload.pick', 'Pilih file')}
+          </Button>
+          <Button variant="outline" onClick={onDownloadTemplate} data-testid="import-wizard-template">
+            <Download className="mr-2 h-4 w-4" />
+            {t('common:importWizard.upload.template', 'Unduh template')}
+          </Button>
+        </div>
+      </div>
+      {parseError && (
+        <p className="text-sm text-destructive">{parseError}</p>
+      )}
+    </div>
+  );
+}
+
+interface MappingStepProps<TItem> {
+  parsed: ParsedFile;
+  fields: ImportFieldDef<TItem>[];
+  mapping: Mapping;
+  onMappingChange: (m: Mapping) => void;
+  missingRequired: ImportFieldDef<TItem>[];
+}
+
+function MappingStep<TItem>({
+  parsed,
+  fields,
+  mapping,
+  onMappingChange,
+  missingRequired,
+}: MappingStepProps<TItem>) {
+  const { t } = useTranslation(['common']);
+  const setOne = (header: string, target: string): void => {
+    const next: Mapping = { ...mapping, [header]: target };
+    // Avoid mapping two source headers to the same target field.
+    if (target) {
+      for (const h of parsed.headers) {
+        if (h !== header && next[h] === target) next[h] = '';
+      }
+    }
+    onMappingChange(next);
+  };
+
+  const NONE = '__none__';
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        {t('common:importWizard.map.help', {
+          defaultValue:
+            'Cocokkan kolom file dengan field aplikasi. Kolom yang tidak dipakai bisa dibiarkan kosong.',
+        })}
+      </p>
+      <div className="rounded-md border">
+        <div className="max-h-[40vh] overflow-y-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('common:importWizard.map.colSource', 'Kolom file')}</TableHead>
+                <TableHead>{t('common:importWizard.map.colSample', 'Contoh nilai')}</TableHead>
+                <TableHead>{t('common:importWizard.map.colTarget', 'Field aplikasi')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {parsed.headers.filter(Boolean).map((h) => {
+                const sample = parsed.rows[0]?.[h] ?? '';
+                return (
+                  <TableRow key={h}>
+                    <TableCell className="font-mono text-xs">{h}</TableCell>
+                    <TableCell className="max-w-[16rem] truncate text-xs text-muted-foreground">
+                      {sample || '—'}
+                    </TableCell>
+                    <TableCell>
+                      <Select
+                        value={mapping[h] || NONE}
+                        onValueChange={(v) => setOne(h, v === NONE ? '' : v)}
+                      >
+                        <SelectTrigger className="h-8 w-64">
+                          <SelectValue
+                            placeholder={t('common:importWizard.map.skip', 'Lewati')}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={NONE}>
+                            {t('common:importWizard.map.skip', 'Lewati')}
+                          </SelectItem>
+                          {fields.map((f) => (
+                            <SelectItem key={f.key} value={f.key}>
+                              {f.label}
+                              {f.required ? ' *' : ''}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+      {missingRequired.length > 0 && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
+          <AlertTriangle className="mt-0.5 h-4 w-4" />
+          <div>
+            <p className="font-medium">
+              {t('common:importWizard.map.missingTitle', 'Field wajib belum terpetakan')}
+            </p>
+            <p>{missingRequired.map((f) => f.label).join(', ')}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface PreviewStepProps<TItem> {
+  mappedRows: MappedRow<TItem>[];
+  fields: ImportFieldDef<TItem>[];
+  mapping: Mapping;
+  validCount: number;
+  invalidCount: number;
+}
+
+function PreviewStep<TItem>({
+  mappedRows,
+  fields,
+  validCount,
+  invalidCount,
+}: PreviewStepProps<TItem>) {
+  const { t } = useTranslation(['common']);
+  const visibleFields = fields.slice(0, 5);
+  const PREVIEW_LIMIT = 50;
+  const limited = mappedRows.slice(0, PREVIEW_LIMIT);
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        <Badge variant="outline" className="gap-1">
+          <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+          {t('common:importWizard.preview.valid', {
+            defaultValue: '{{count}} baris siap',
+            count: validCount,
+          })}
+        </Badge>
+        {invalidCount > 0 && (
+          <Badge variant="outline" className="gap-1 border-destructive/40 text-destructive">
+            <AlertTriangle className="h-3 w-3" />
+            {t('common:importWizard.preview.invalid', {
+              defaultValue: '{{count}} baris dilewati (error)',
+              count: invalidCount,
+            })}
+          </Badge>
+        )}
+        <span className="text-xs text-muted-foreground">
+          {t('common:importWizard.preview.limit', {
+            defaultValue: 'Menampilkan {{shown}} / {{total}} baris pertama',
+            shown: Math.min(mappedRows.length, PREVIEW_LIMIT),
+            total: mappedRows.length,
+          })}
+        </span>
+      </div>
+      <div className="rounded-md border">
+        <div className="max-h-[40vh] overflow-y-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>#</TableHead>
+                {visibleFields.map((f) => (
+                  <TableHead key={f.key}>{f.label}</TableHead>
+                ))}
+                <TableHead>{t('common:importWizard.preview.colError', 'Error')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {limited.map((row) => (
+                <TableRow
+                  key={row.rowNumber}
+                  className={cn(
+                    row.errors.length > 0 &&
+                      'bg-destructive/10 hover:bg-destructive/15',
+                  )}
+                >
+                  <TableCell className="text-xs text-muted-foreground">{row.rowNumber}</TableCell>
+                  {visibleFields.map((f) => {
+                    const value = (row.item as Record<string, unknown>)[f.key];
+                    return (
+                      <TableCell key={f.key} className="text-xs">
+                        {String(value ?? '') || '—'}
+                      </TableCell>
+                    );
+                  })}
+                  <TableCell className="text-xs text-destructive">
+                    {row.errors.join('; ') || '—'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ResultStepProps {
+  result: ImportWizardResult;
+  onDownloadErrors: () => void;
+}
+
+function ResultStep({ result, onDownloadErrors }: ResultStepProps) {
+  const { t } = useTranslation(['common']);
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <div className="rounded-md border bg-emerald-50 p-3 text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-200">
+          <p className="text-xs uppercase tracking-wide">
+            {t('common:importWizard.result.inserted', 'Ditambahkan')}
+          </p>
+          <p className="text-2xl font-semibold">{result.inserted}</p>
+        </div>
+        <div className="rounded-md border p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            {t('common:importWizard.result.skipped', 'Dilewati')}
+          </p>
+          <p className="text-2xl font-semibold">{result.skipped}</p>
+        </div>
+        <div className="rounded-md border p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            {t('common:importWizard.result.errors', 'Error')}
+          </p>
+          <p className="text-2xl font-semibold">{result.errors.length}</p>
+        </div>
+      </div>
+      {result.errors.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium">
+              {t('common:importWizard.result.errorListTitle', 'Daftar error')}
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onDownloadErrors}
+              data-testid="import-wizard-download-errors"
+            >
+              <Download className="mr-2 h-4 w-4" />
+              {t('common:importWizard.result.downloadErrors', 'Unduh CSV error')}
+            </Button>
+          </div>
+          <div className="max-h-[30vh] overflow-y-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-16">#</TableHead>
+                  <TableHead>
+                    {t('common:importWizard.result.message', 'Pesan')}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {result.errors.slice(0, 100).map((e, i) => (
+                  <TableRow key={`${e.row}-${i}`}>
+                    <TableCell className="text-xs text-muted-foreground">{e.row}</TableCell>
+                    <TableCell className="text-xs">{e.message}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/anggota/ImportExcelDialog.tsx
+++ b/apps/desktop/src/features/anggota/ImportExcelDialog.tsx
@@ -1,249 +1,133 @@
-import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { read, utils, type WorkBook } from 'xlsx';
-import { Button } from '@/components/ui/button';
-import { formatTauriError } from '@/lib/errors';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { anggotaApi, type AnggotaImportItem, type AnggotaImportResult } from '@/lib/anggota';
-import { useToast } from '@/components/ui/toast-manager';
+import { ImportWizard } from '@/components/shared/ImportWizard';
+import { anggotaApi, type AnggotaImportItem } from '@/lib/anggota';
+import type { ImportWizardResult } from '@/components/shared/ImportWizard';
+import type { ImportFieldDef } from '@/lib/importWizard';
 
 interface ImportExcelDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onImported: (result: AnggotaImportResult) => void;
-}
-
-const HEADER_MAP: Record<string, keyof AnggotaImportItem> = {
-  kode_anggota: 'kodeAnggota',
-  kodeanggota: 'kodeAnggota',
-  kode: 'kodeAnggota',
-  nis: 'kodeAnggota',
-  nama: 'nama',
-  name: 'nama',
-  kelas: 'kelas',
-  class: 'kelas',
-  jurusan: 'jurusan',
-  major: 'jurusan',
-  agama: 'agama',
-  religion: 'agama',
-  jenis_kelamin: 'jenisKelamin',
-  jeniskelamin: 'jenisKelamin',
-  gender: 'jenisKelamin',
-  no_telp: 'noTelp',
-  notelp: 'noTelp',
-  no_telepon: 'noTelp',
-  telepon: 'noTelp',
-  phone: 'noTelp',
-  email: 'email',
-};
-
-function normalizeHeader(raw: string): keyof AnggotaImportItem | null {
-  const cleaned = raw
-    .toLowerCase()
-    .trim()
-    .replace(/[\s./-]+/g, '_');
-  return HEADER_MAP[cleaned] ?? null;
-}
-
-function rowsFromWorkbook(wb: WorkBook): AnggotaImportItem[] {
-  const sheetName = wb.SheetNames[0];
-  if (!sheetName) return [];
-  const sheet = wb.Sheets[sheetName];
-  if (!sheet) return [];
-  const raw = utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: '', raw: false });
-  return raw
-    .map((rawRow) => {
-      const item: AnggotaImportItem = { kodeAnggota: '', nama: '' };
-      for (const [key, value] of Object.entries(rawRow)) {
-        const mapped = normalizeHeader(key);
-        if (!mapped) continue;
-        const str = typeof value === 'string' ? value.trim() : value == null ? '' : String(value).trim();
-        if (mapped === 'kodeAnggota' || mapped === 'nama') {
-          item[mapped] = str;
-        } else if (mapped === 'jenisKelamin') {
-          const upper = str.toUpperCase();
-          item.jenisKelamin = upper === 'L' || upper === 'P' ? upper : null;
-        } else {
-          item[mapped] = str.length > 0 ? str : null;
-        }
-      }
-      return item;
-    })
-    .filter((item) => item.kodeAnggota || item.nama);
+  onImported: (result: ImportWizardResult) => void;
 }
 
 export function ImportExcelDialog({ open, onOpenChange, onImported }: ImportExcelDialogProps) {
   const { t } = useTranslation(['anggota', 'common']);
-  const { showToast } = useToast();
-  const fileRef = useRef<HTMLInputElement>(null);
-  const [filename, setFilename] = useState<string | null>(null);
-  const [rows, setRows] = useState<AnggotaImportItem[]>([]);
-  const [parseError, setParseError] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
 
-  const reset = (): void => {
-    setFilename(null);
-    setRows([]);
-    setParseError(null);
-    if (fileRef.current) fileRef.current.value = '';
-  };
+  const fields: ImportFieldDef<AnggotaImportItem>[] = [
+    {
+      key: 'kodeAnggota',
+      label: t('anggota:fields.kodeAnggota', { defaultValue: 'Kode Anggota / NIS' }),
+      required: true,
+      aliases: ['kode_anggota', 'kodeanggota', 'kode', 'nis', 'member_code'],
+      sample: 'A0001',
+    },
+    {
+      key: 'nama',
+      label: t('anggota:fields.nama', { defaultValue: 'Nama Lengkap' }),
+      required: true,
+      aliases: ['name', 'nama_lengkap'],
+      sample: 'Budi Santoso',
+    },
+    {
+      key: 'jenisKelamin',
+      label: t('anggota:fields.jenisKelamin', { defaultValue: 'Jenis Kelamin' }),
+      required: false,
+      aliases: ['jenis_kelamin', 'jeniskelamin', 'gender', 'sex'],
+      sample: 'L',
+      validate: (v) => {
+        const upper = v.toUpperCase();
+        if (upper !== 'L' && upper !== 'P') return 'Hanya menerima L atau P';
+        return null;
+      },
+    },
+    {
+      key: 'kelas',
+      label: t('anggota:fields.kelas', { defaultValue: 'Kelas' }),
+      required: false,
+      aliases: ['class', 'tingkat'],
+      sample: 'XI IPA 1',
+    },
+    {
+      key: 'jurusan',
+      label: t('anggota:fields.jurusan', { defaultValue: 'Jurusan' }),
+      required: false,
+      aliases: ['major'],
+      sample: 'IPA',
+    },
+    {
+      key: 'agama',
+      label: t('anggota:fields.agama', { defaultValue: 'Agama' }),
+      required: false,
+      aliases: ['religion'],
+      sample: 'Islam',
+    },
+    {
+      key: 'noTelp',
+      label: t('anggota:fields.noTelp', { defaultValue: 'No. Telepon' }),
+      required: false,
+      aliases: ['no_telp', 'notelp', 'no_telepon', 'telepon', 'phone', 'hp'],
+      sample: '081234567890',
+    },
+    {
+      key: 'email',
+      label: t('anggota:fields.email', { defaultValue: 'Email' }),
+      required: false,
+      aliases: ['email', 'e_mail'],
+      sample: 'budi@example.com',
+      validate: (v) => {
+        if (v && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return 'Format email tidak valid';
+        return null;
+      },
+    },
+  ];
 
-  const handleFile = async (file: File): Promise<void> => {
-    try {
-      setParseError(null);
-      const buf = await file.arrayBuffer();
-      const wb = read(buf, { type: 'array' });
-      const parsed = rowsFromWorkbook(wb);
-      setFilename(file.name);
-      setRows(parsed);
-    } catch (err) {
-      setParseError(formatTauriError(err));
-      setRows([]);
-    }
-  };
-
-  const handleSubmit = async (): Promise<void> => {
-    if (rows.length === 0) return;
-    setBusy(true);
-    try {
-      const result = await anggotaApi.importBatch(rows);
-      onImported(result);
-      showToast({
-        title: t('anggota:feedback.importSuccess', { inserted: result.inserted }),
-        description: t('anggota:import.summary', {
-          inserted: result.inserted,
-          skipped: result.skipped,
-        }),
-      });
-      reset();
-      onOpenChange(false);
-    } catch (err) {
-      showToast({
-        variant: 'destructive',
-        title: t('anggota:feedback.importSuccess', { inserted: 0 }),
-        description: formatTauriError(err),
-      });
-    } finally {
-      setBusy(false);
-    }
+  const rowParser = (raw: Record<string, string>): AnggotaImportItem => {
+    const item: AnggotaImportItem = {
+      kodeAnggota: (raw.kodeAnggota ?? '').trim(),
+      nama: (raw.nama ?? '').trim(),
+    };
+    const jk = (raw.jenisKelamin ?? '').trim().toUpperCase();
+    if (jk === 'L' || jk === 'P') item.jenisKelamin = jk;
+    const kelas = (raw.kelas ?? '').trim();
+    if (kelas) item.kelas = kelas;
+    const jurusan = (raw.jurusan ?? '').trim();
+    if (jurusan) item.jurusan = jurusan;
+    const agama = (raw.agama ?? '').trim();
+    if (agama) item.agama = agama;
+    const noTelp = (raw.noTelp ?? '').trim();
+    if (noTelp) item.noTelp = noTelp;
+    const email = (raw.email ?? '').trim();
+    if (email) item.email = email;
+    return item;
   };
 
   return (
-    <Dialog
+    <ImportWizard<AnggotaImportItem>
       open={open}
-      onOpenChange={(next) => {
-        if (!next) reset();
-        onOpenChange(next);
+      onOpenChange={onOpenChange}
+      title={t('anggota:import.title', { defaultValue: 'Impor Anggota dari Excel/CSV' })}
+      description={t('anggota:import.description', {
+        defaultValue:
+          'Unggah file lalu cocokkan kolomnya dengan field aplikasi. Baris dengan error akan dilewati.',
+      })}
+      fields={fields}
+      templateSheetName="Anggota"
+      templateFilename="template-impor-anggota.xlsx"
+      rowParser={rowParser}
+      onImport={async (items) => {
+        const r = await anggotaApi.importBatch(items);
+        return {
+          inserted: r.inserted,
+          skipped: r.skipped,
+          errors: r.errors.map((e) => ({
+            row: e.row,
+            message: e.kodeAnggota
+              ? `${e.kodeAnggota}: ${e.message}`
+              : e.message,
+          })),
+        };
       }}
-    >
-      <DialogContent className="max-w-3xl">
-        <DialogHeader>
-          <DialogTitle>{t('anggota:import.title')}</DialogTitle>
-          <DialogDescription>{t('anggota:import.description')}</DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-3">
-          <div className="flex items-center gap-3">
-            <input
-              ref={fileRef}
-              type="file"
-              accept=".xlsx,.xls,.csv"
-              data-testid="import-file-input"
-              className="hidden"
-              onChange={async (e) => {
-                const file = e.target.files?.[0];
-                if (file) await handleFile(file);
-              }}
-            />
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => fileRef.current?.click()}
-              data-testid="import-pick-file"
-            >
-              {t('anggota:import.pickFile')}
-            </Button>
-            <span className="text-xs text-muted-foreground">
-              {filename ? t('anggota:import.filename', { name: filename }) : t('anggota:import.noFile')}
-            </span>
-          </div>
-
-          {parseError && (
-            <p className="text-sm text-destructive">
-              {t('anggota:import.parseError', { message: parseError })}
-            </p>
-          )}
-
-          {rows.length > 0 && (
-            <div className="rounded-md border">
-              <div className="border-b px-3 py-2">
-                <p className="text-sm font-medium">
-                  {t('anggota:import.previewTitle', { count: rows.length })}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {t('anggota:import.previewSubtitle')}
-                </p>
-              </div>
-              <div className="max-h-72 overflow-y-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>#</TableHead>
-                      <TableHead>{t('anggota:columns.kode')}</TableHead>
-                      <TableHead>{t('anggota:columns.nama')}</TableHead>
-                      <TableHead>{t('anggota:columns.kelas')}</TableHead>
-                      <TableHead>{t('anggota:columns.jurusan')}</TableHead>
-                      <TableHead>{t('anggota:columns.agama')}</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {rows.slice(0, 50).map((row, idx) => (
-                      <TableRow key={`${row.kodeAnggota}-${idx}`}>
-                        <TableCell className="text-xs text-muted-foreground">{idx + 1}</TableCell>
-                        <TableCell className="font-mono text-xs">{row.kodeAnggota}</TableCell>
-                        <TableCell>{row.nama}</TableCell>
-                        <TableCell>{row.kelas ?? '—'}</TableCell>
-                        <TableCell>{row.jurusan ?? '—'}</TableCell>
-                        <TableCell>{row.agama ?? '—'}</TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
-            {t('anggota:import.cancel')}
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={rows.length === 0 || busy}
-            data-testid="import-submit"
-          >
-            {busy
-              ? t('common:states.loading')
-              : t('anggota:import.submit', { count: rows.length })}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      onImported={onImported}
+    />
   );
 }

--- a/apps/desktop/src/features/buku/ImportBukuDialog.tsx
+++ b/apps/desktop/src/features/buku/ImportBukuDialog.tsx
@@ -1,246 +1,148 @@
-import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { read, utils, type WorkBook } from 'xlsx';
-import { Button } from '@/components/ui/button';
-import { formatTauriError } from '@/lib/errors';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { bukuApi, type BukuImportItem, type BukuImportResult } from '@/lib/buku';
-import { useToast } from '@/components/ui/toast-manager';
+import { ImportWizard } from '@/components/shared/ImportWizard';
+import { bukuApi, type BukuImportItem } from '@/lib/buku';
+import type { ImportWizardResult } from '@/components/shared/ImportWizard';
+import type { ImportFieldDef } from '@/lib/importWizard';
 
 interface ImportBukuDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onImported: (result: BukuImportResult) => void;
-}
-
-const HEADER_MAP: Record<string, keyof BukuImportItem> = {
-  kode_buku: 'kodeBuku',
-  kodebuku: 'kodeBuku',
-  kode: 'kodeBuku',
-  judul: 'judul',
-  title: 'judul',
-  pengarang: 'pengarang',
-  author: 'pengarang',
-  penerbit: 'penerbit',
-  publisher: 'penerbit',
-  tahun: 'tahunTerbit',
-  tahun_terbit: 'tahunTerbit',
-  year: 'tahunTerbit',
-  ddc: 'kodeDdc',
-  kode_ddc: 'kodeDdc',
-  kategori: 'kategori',
-  category: 'kategori',
-  isbn: 'isbn',
-  jumlah: 'jumlahEksemplar',
-  jumlah_eksemplar: 'jumlahEksemplar',
-  copies: 'jumlahEksemplar',
-  bahasa: 'bahasa',
-  language: 'bahasa',
-};
-
-function normalizeHeader(raw: string): keyof BukuImportItem | null {
-  const cleaned = raw.toLowerCase().trim().replace(/[\s./-]+/g, '_');
-  return HEADER_MAP[cleaned] ?? null;
-}
-
-function rowsFromWorkbook(wb: WorkBook): BukuImportItem[] {
-  const sheetName = wb.SheetNames[0];
-  if (!sheetName) return [];
-  const sheet = wb.Sheets[sheetName];
-  if (!sheet) return [];
-  const raw = utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: '', raw: false });
-  return raw
-    .map((rawRow) => {
-      const item: BukuImportItem = { kodeBuku: '', judul: '' };
-      for (const [key, value] of Object.entries(rawRow)) {
-        const mapped = normalizeHeader(key);
-        if (!mapped) continue;
-        const str =
-          typeof value === 'string' ? value.trim() : value == null ? '' : String(value).trim();
-        if (mapped === 'kodeBuku' || mapped === 'judul') {
-          item[mapped] = str;
-        } else if (mapped === 'tahunTerbit' || mapped === 'jumlahEksemplar') {
-          const n = Number(str);
-          item[mapped] = Number.isFinite(n) ? Math.trunc(n) : null;
-        } else {
-          item[mapped] = str.length > 0 ? str : null;
-        }
-      }
-      return item;
-    })
-    .filter((item) => item.kodeBuku || item.judul);
+  onImported: (result: ImportWizardResult) => void;
 }
 
 export function ImportBukuDialog({ open, onOpenChange, onImported }: ImportBukuDialogProps) {
   const { t } = useTranslation(['buku', 'common']);
-  const { showToast } = useToast();
-  const fileRef = useRef<HTMLInputElement>(null);
-  const [filename, setFilename] = useState<string | null>(null);
-  const [rows, setRows] = useState<BukuImportItem[]>([]);
-  const [parseError, setParseError] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
 
-  const reset = (): void => {
-    setFilename(null);
-    setRows([]);
-    setParseError(null);
-    if (fileRef.current) fileRef.current.value = '';
-  };
+  const fields: ImportFieldDef<BukuImportItem>[] = [
+    {
+      key: 'kodeBuku',
+      label: t('buku:columns.kode', { defaultValue: 'Kode Buku' }),
+      required: true,
+      aliases: ['kode_buku', 'kodebuku', 'kode', 'book_code'],
+      sample: 'BK-0001',
+    },
+    {
+      key: 'judul',
+      label: t('buku:columns.judul', { defaultValue: 'Judul' }),
+      required: true,
+      aliases: ['title', 'book_title'],
+      sample: 'Bumi Manusia',
+    },
+    {
+      key: 'pengarang',
+      label: t('buku:columns.pengarang', { defaultValue: 'Pengarang' }),
+      required: false,
+      aliases: ['author', 'penulis'],
+      sample: 'Pramoedya Ananta Toer',
+    },
+    {
+      key: 'penerbit',
+      label: t('buku:columns.penerbit', { defaultValue: 'Penerbit' }),
+      required: false,
+      aliases: ['publisher'],
+      sample: 'Hasta Mitra',
+    },
+    {
+      key: 'tahunTerbit',
+      label: t('buku:columns.tahun', { defaultValue: 'Tahun Terbit' }),
+      required: false,
+      aliases: ['tahun', 'tahun_terbit', 'year', 'year_published'],
+      sample: '1980',
+      validate: (v) => {
+        const n = Number(v);
+        if (!Number.isFinite(n) || !Number.isInteger(n)) return 'Tahun tidak valid';
+        if (n < 1000 || n > 2100) return 'Tahun di luar rentang 1000–2100';
+        return null;
+      },
+    },
+    {
+      key: 'kodeDdc',
+      label: t('buku:columns.ddc', { defaultValue: 'Kode DDC' }),
+      required: false,
+      aliases: ['ddc', 'kode_ddc', 'klasifikasi'],
+      sample: '899.221',
+    },
+    {
+      key: 'kategori',
+      label: t('buku:columns.kategori', { defaultValue: 'Kategori' }),
+      required: false,
+      aliases: ['category'],
+      sample: 'Fiksi',
+    },
+    {
+      key: 'isbn',
+      label: 'ISBN',
+      required: false,
+      aliases: ['isbn'],
+      sample: '978-602-7888-71-2',
+    },
+    {
+      key: 'jumlahEksemplar',
+      label: t('buku:columns.eksemplar', { defaultValue: 'Jumlah Eksemplar' }),
+      required: false,
+      aliases: ['jumlah', 'jumlah_eksemplar', 'copies', 'qty'],
+      sample: '3',
+      validate: (v) => {
+        const n = Number(v);
+        if (!Number.isFinite(n) || !Number.isInteger(n)) return 'Jumlah tidak valid';
+        if (n < 0 || n > 9999) return 'Jumlah di luar rentang 0–9999';
+        return null;
+      },
+    },
+    {
+      key: 'bahasa',
+      label: t('buku:columns.bahasa', { defaultValue: 'Bahasa' }),
+      required: false,
+      aliases: ['language', 'lang'],
+      sample: 'Indonesia',
+    },
+  ];
 
-  const handleFile = async (file: File): Promise<void> => {
-    try {
-      setParseError(null);
-      const buf = await file.arrayBuffer();
-      const wb = read(buf, { type: 'array' });
-      const parsed = rowsFromWorkbook(wb);
-      setFilename(file.name);
-      setRows(parsed);
-    } catch (err) {
-      setParseError(formatTauriError(err));
-      setRows([]);
+  const rowParser = (raw: Record<string, string>): BukuImportItem => {
+    const item: BukuImportItem = {
+      kodeBuku: (raw.kodeBuku ?? '').trim(),
+      judul: (raw.judul ?? '').trim(),
+    };
+    const pengarang = (raw.pengarang ?? '').trim();
+    if (pengarang) item.pengarang = pengarang;
+    const penerbit = (raw.penerbit ?? '').trim();
+    if (penerbit) item.penerbit = penerbit;
+    const tahun = (raw.tahunTerbit ?? '').trim();
+    if (tahun) {
+      const n = Number(tahun);
+      if (Number.isFinite(n)) item.tahunTerbit = Math.trunc(n);
     }
-  };
-
-  const handleSubmit = async (): Promise<void> => {
-    if (rows.length === 0) return;
-    setBusy(true);
-    try {
-      const result = await bukuApi.importBatch(rows);
-      onImported(result);
-      showToast({
-        title: t('buku:feedback.importSuccess', { inserted: result.inserted }),
-        description: t('buku:import.summary', {
-          inserted: result.inserted,
-          skipped: result.skipped,
-        }),
-      });
-      reset();
-      onOpenChange(false);
-    } catch (err) {
-      showToast({
-        variant: 'destructive',
-        title: t('buku:feedback.importSuccess', { inserted: 0 }),
-        description: formatTauriError(err),
-      });
-    } finally {
-      setBusy(false);
+    const ddc = (raw.kodeDdc ?? '').trim();
+    if (ddc) item.kodeDdc = ddc;
+    const kategori = (raw.kategori ?? '').trim();
+    if (kategori) item.kategori = kategori;
+    const isbn = (raw.isbn ?? '').trim();
+    if (isbn) item.isbn = isbn;
+    const jumlah = (raw.jumlahEksemplar ?? '').trim();
+    if (jumlah) {
+      const n = Number(jumlah);
+      if (Number.isFinite(n)) item.jumlahEksemplar = Math.trunc(n);
     }
+    const bahasa = (raw.bahasa ?? '').trim();
+    if (bahasa) item.bahasa = bahasa;
+    return item;
   };
 
   return (
-    <Dialog
+    <ImportWizard<BukuImportItem>
       open={open}
-      onOpenChange={(next) => {
-        if (!next) reset();
-        onOpenChange(next);
-      }}
-    >
-      <DialogContent className="max-w-3xl">
-        <DialogHeader>
-          <DialogTitle>{t('buku:import.title')}</DialogTitle>
-          <DialogDescription>{t('buku:import.description')}</DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-3">
-          <div className="flex items-center gap-3">
-            <input
-              ref={fileRef}
-              type="file"
-              accept=".xlsx,.xls,.csv"
-              data-testid="buku-import-file-input"
-              className="hidden"
-              onChange={async (e) => {
-                const file = e.target.files?.[0];
-                if (file) await handleFile(file);
-              }}
-            />
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => fileRef.current?.click()}
-              data-testid="buku-import-pick-file"
-            >
-              {t('buku:import.pickFile')}
-            </Button>
-            <span className="text-xs text-muted-foreground">
-              {filename
-                ? t('buku:import.filename', { name: filename })
-                : t('buku:import.noFile')}
-            </span>
-          </div>
-
-          {parseError && (
-            <p className="text-sm text-destructive">
-              {t('buku:import.parseError', { message: parseError })}
-            </p>
-          )}
-
-          {rows.length > 0 && (
-            <div className="rounded-md border">
-              <div className="border-b px-3 py-2">
-                <p className="text-sm font-medium">
-                  {t('buku:import.previewTitle', { count: rows.length })}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {t('buku:import.previewSubtitle')}
-                </p>
-              </div>
-              <div className="max-h-72 overflow-y-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>#</TableHead>
-                      <TableHead>{t('buku:columns.kode')}</TableHead>
-                      <TableHead>{t('buku:columns.judul')}</TableHead>
-                      <TableHead>{t('buku:columns.kategori')}</TableHead>
-                      <TableHead>{t('buku:columns.ddc')}</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {rows.slice(0, 50).map((row, idx) => (
-                      <TableRow key={`${row.kodeBuku}-${idx}`}>
-                        <TableCell className="text-xs text-muted-foreground">
-                          {idx + 1}
-                        </TableCell>
-                        <TableCell className="font-mono text-xs">{row.kodeBuku}</TableCell>
-                        <TableCell>{row.judul}</TableCell>
-                        <TableCell>{row.kategori ?? '—'}</TableCell>
-                        <TableCell>{row.kodeDdc ?? '—'}</TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
-            {t('common:actions.cancel')}
-          </Button>
-          <Button onClick={handleSubmit} disabled={busy || rows.length === 0} data-testid="buku-import-submit">
-            {busy
-              ? t('common:states.loading')
-              : t('buku:import.submit', { count: rows.length })}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      onOpenChange={onOpenChange}
+      title={t('buku:import.title', { defaultValue: 'Impor Buku dari Excel/CSV' })}
+      description={t('buku:import.description', {
+        defaultValue:
+          'Unggah file lalu cocokkan kolomnya dengan field aplikasi. Baris dengan error akan dilewati.',
+      })}
+      fields={fields}
+      templateSheetName="Buku"
+      templateFilename="template-impor-buku.xlsx"
+      rowParser={rowParser}
+      onImport={async (items) => bukuApi.importBatch(items)}
+      onImported={onImported}
+    />
   );
 }

--- a/apps/desktop/src/i18n/en/common.json
+++ b/apps/desktop/src/i18n/en/common.json
@@ -74,6 +74,45 @@
     "pick": "Pick file…",
     "clear": "Remove file"
   },
+  "importWizard": {
+    "step": {
+      "upload": "Upload",
+      "map": "Mapping",
+      "preview": "Preview",
+      "result": "Result"
+    },
+    "upload": {
+      "help": "Pick an .xlsx, .xls, or .csv file. Headers must be on the first row.",
+      "pick": "Pick file",
+      "template": "Download template"
+    },
+    "map": {
+      "help": "Match file columns to application fields. Unused columns can be left blank.",
+      "colSource": "Source column",
+      "colSample": "Sample value",
+      "colTarget": "Application field",
+      "skip": "Skip",
+      "missingTitle": "Required fields not mapped"
+    },
+    "preview": {
+      "valid": "{{count}} rows ready",
+      "invalid": "{{count}} rows skipped (error)",
+      "limit": "Showing first {{shown}} of {{total}} rows",
+      "colError": "Error"
+    },
+    "result": {
+      "inserted": "Inserted",
+      "skipped": "Skipped",
+      "errors": "Errors",
+      "errorListTitle": "Error list",
+      "downloadErrors": "Download error CSV",
+      "message": "Message"
+    },
+    "submit": "Import {{count}} rows",
+    "toastDone": "Import complete",
+    "toastSummary": "{{inserted}} inserted, {{skipped}} skipped",
+    "toastFailed": "Import failed"
+  },
   "notifications": {
     "title": "Notifications",
     "overdueTitle": "Overdue Loans",

--- a/apps/desktop/src/i18n/id/common.json
+++ b/apps/desktop/src/i18n/id/common.json
@@ -74,6 +74,45 @@
     "pick": "Pilih file…",
     "clear": "Hapus file"
   },
+  "importWizard": {
+    "step": {
+      "upload": "Unggah",
+      "map": "Mapping",
+      "preview": "Preview",
+      "result": "Hasil"
+    },
+    "upload": {
+      "help": "Pilih file .xlsx, .xls, atau .csv. Header wajib di baris pertama.",
+      "pick": "Pilih file",
+      "template": "Unduh template"
+    },
+    "map": {
+      "help": "Cocokkan kolom file dengan field aplikasi. Kolom yang tidak dipakai bisa dibiarkan kosong.",
+      "colSource": "Kolom file",
+      "colSample": "Contoh nilai",
+      "colTarget": "Field aplikasi",
+      "skip": "Lewati",
+      "missingTitle": "Field wajib belum terpetakan"
+    },
+    "preview": {
+      "valid": "{{count}} baris siap",
+      "invalid": "{{count}} baris dilewati (error)",
+      "limit": "Menampilkan {{shown}} / {{total}} baris pertama",
+      "colError": "Error"
+    },
+    "result": {
+      "inserted": "Ditambahkan",
+      "skipped": "Dilewati",
+      "errors": "Error",
+      "errorListTitle": "Daftar error",
+      "downloadErrors": "Unduh CSV error",
+      "message": "Pesan"
+    },
+    "submit": "Impor {{count}} baris",
+    "toastDone": "Selesai impor",
+    "toastSummary": "{{inserted}} ditambahkan, {{skipped}} dilewati",
+    "toastFailed": "Gagal impor"
+  },
   "notifications": {
     "title": "Notifikasi",
     "overdueTitle": "Peminjaman Terlambat",

--- a/apps/desktop/src/lib/importWizard.ts
+++ b/apps/desktop/src/lib/importWizard.ts
@@ -1,0 +1,238 @@
+import { read, utils, write, type WorkBook } from 'xlsx';
+
+export interface ImportFieldDef<TItem> {
+  key: keyof TItem & string;
+  label: string;
+  required: boolean;
+  /** Aliases (case-insensitive, normalized) used for auto-detect. */
+  aliases: string[];
+  /** Optional row-level validator. Return error message or null. */
+  validate?: (value: string, row: TItem) => string | null;
+  /** Sample value used when generating a template workbook. */
+  sample?: string;
+}
+
+export interface ParsedFile {
+  filename: string;
+  headers: string[];
+  rows: Array<Record<string, string>>;
+}
+
+export type Mapping = Record<string, string>;
+
+export interface MappedRow<TItem> {
+  rowNumber: number;
+  raw: Record<string, string>;
+  item: TItem;
+  errors: string[];
+}
+
+const NORM_RE = /[\s./_\-:()]+/g;
+
+export function normalizeHeader(raw: string): string {
+  return raw.toLowerCase().trim().replace(NORM_RE, '_');
+}
+
+/** Parse an in-memory workbook (xlsx/csv) buffer into headers + rows. */
+export function parseBytes(filename: string, buf: ArrayBuffer | Uint8Array): ParsedFile {
+  const wb: WorkBook = read(buf, { type: 'array' });
+  const sheetName = wb.SheetNames[0];
+  if (!sheetName) {
+    return { filename, headers: [], rows: [] };
+  }
+  const sheet = wb.Sheets[sheetName];
+  if (!sheet) {
+    return { filename, headers: [], rows: [] };
+  }
+  const aoa = utils.sheet_to_json<Array<unknown>>(sheet, {
+    header: 1,
+    defval: '',
+    raw: false,
+    blankrows: false,
+  });
+  if (aoa.length === 0) {
+    return { filename, headers: [], rows: [] };
+  }
+  const headerRow = aoa[0] ?? [];
+  const headers = headerRow.map((h) => (h == null ? '' : String(h).trim()));
+  const rows: Array<Record<string, string>> = [];
+  for (let i = 1; i < aoa.length; i++) {
+    const r = aoa[i] ?? [];
+    const obj: Record<string, string> = {};
+    let hasAny = false;
+    for (let c = 0; c < headers.length; c++) {
+      const h = headers[c];
+      if (!h) continue;
+      const cell = r[c];
+      const str = cell == null ? '' : String(cell).trim();
+      obj[h] = str;
+      if (str) hasAny = true;
+    }
+    if (hasAny) rows.push(obj);
+  }
+  return { filename, headers, rows };
+}
+
+export async function parseFile(file: File): Promise<ParsedFile> {
+  // happy-dom's File lacks arrayBuffer; FileReader is available in both jsdom
+  // and the real browser, so use it as a portable fallback when needed.
+  let buf: ArrayBuffer;
+  if (typeof (file as unknown as { arrayBuffer?: () => Promise<ArrayBuffer> }).arrayBuffer === 'function') {
+    buf = await file.arrayBuffer();
+  } else {
+    buf = await new Promise<ArrayBuffer>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const r = reader.result;
+        if (r instanceof ArrayBuffer) resolve(r);
+        else reject(new Error('FileReader did not return ArrayBuffer'));
+      };
+      reader.onerror = () => reject(reader.error ?? new Error('FileReader error'));
+      reader.readAsArrayBuffer(file);
+    });
+  }
+  return parseBytes(file.name, buf);
+}
+
+/**
+ * Auto-map source headers to target field keys based on alias matches.
+ * Returns Mapping where key = source header, value = target field key
+ * (or empty string when unmapped).
+ */
+export function autoMap<TItem>(
+  fields: ImportFieldDef<TItem>[],
+  headers: string[],
+): Mapping {
+  const mapping: Mapping = {};
+  const used = new Set<string>();
+  for (const h of headers) {
+    if (!h) continue;
+    const norm = normalizeHeader(h);
+    let target = '';
+    for (const f of fields) {
+      if (used.has(f.key)) continue;
+      const candidates = [normalizeHeader(f.key), normalizeHeader(f.label), ...f.aliases.map(normalizeHeader)];
+      if (candidates.includes(norm)) {
+        target = f.key;
+        break;
+      }
+    }
+    if (target) used.add(target);
+    mapping[h] = target;
+  }
+  return mapping;
+}
+
+/** Build a per-row mapped item from raw cells using the supplied mapping. */
+export function buildMappedRows<TItem>(
+  fields: ImportFieldDef<TItem>[],
+  parsed: ParsedFile,
+  mapping: Mapping,
+  rowParser: (rawByKey: Record<string, string>) => TItem,
+): MappedRow<TItem>[] {
+  const result: MappedRow<TItem>[] = [];
+  // Track duplicate detection across the whole batch for fields whose key
+  // looks like a unique identifier (contains "kode"). Anggota and buku both
+  // have a "kodeAnggota" / "kodeBuku" required field; this catches dupes
+  // before the backend rejects them.
+  const seenKey = new Map<string, Set<string>>();
+  for (const f of fields) {
+    if (f.required && f.key.toLowerCase().includes('kode')) {
+      seenKey.set(f.key, new Set());
+    }
+  }
+
+  parsed.rows.forEach((rawRow, idx) => {
+    const rawByKey: Record<string, string> = {};
+    for (const [src, tgt] of Object.entries(mapping)) {
+      if (!tgt) continue;
+      const value = rawRow[src] ?? '';
+      rawByKey[tgt] = value;
+    }
+    const item = rowParser(rawByKey);
+    const errors: string[] = [];
+    for (const f of fields) {
+      const value = rawByKey[f.key] ?? '';
+      if (f.required && !value) {
+        errors.push(`${f.label} wajib diisi`);
+      }
+      if (value && f.validate) {
+        const msg = f.validate(value, item);
+        if (msg) errors.push(msg);
+      }
+    }
+    for (const f of fields) {
+      const set = seenKey.get(f.key);
+      if (!set) continue;
+      const value = rawByKey[f.key] ?? '';
+      if (!value) continue;
+      if (set.has(value)) {
+        errors.push(`${f.label} '${value}' duplikat di file`);
+      } else {
+        set.add(value);
+      }
+    }
+    result.push({
+      rowNumber: idx + 2, // +1 for header, +1 for 1-based
+      raw: rawRow,
+      item,
+      errors,
+    });
+  });
+
+  return result;
+}
+
+/**
+ * Build a sample template workbook (.xlsx) listing the required+optional
+ * headers and one example row. Returns Uint8Array suitable for download.
+ */
+export function buildTemplateBytes<TItem>(
+  fields: ImportFieldDef<TItem>[],
+  sheetName: string,
+): Uint8Array {
+  const headers = fields.map((f) => f.label);
+  const sample = fields.map((f) => f.sample ?? '');
+  const aoa: (string | number)[][] = [headers, sample];
+  const sheet = utils.aoa_to_sheet(aoa);
+  sheet['!cols'] = headers.map((h) => ({ wch: Math.max(h.length + 2, 14) }));
+  const wb = utils.book_new();
+  utils.book_append_sheet(wb, sheet, sheetName.slice(0, 28));
+  const out = write(wb, { bookType: 'xlsx', type: 'array' }) as ArrayBuffer;
+  return new Uint8Array(out);
+}
+
+/** Build a CSV with the per-row error report for failed imports. */
+export function buildErrorReportCsv(
+  errors: Array<{ row: number; message: string }>,
+): string {
+  const head = 'row,message\n';
+  const body = errors
+    .map((e) => `${e.row},"${e.message.replace(/"/g, '""')}"`)
+    .join('\n');
+  return `${head}${body}\n`;
+}
+
+/** Trigger a browser download for an arbitrary blob. */
+export function triggerDownload(filename: string, data: Blob | Uint8Array, mime?: string): void {
+  let blob: Blob;
+  if (data instanceof Blob) {
+    blob = data;
+  } else {
+    // Copy into a fresh ArrayBuffer to satisfy DOM BlobPart typing
+    // (some TS lib variants reject SharedArrayBuffer-backed Uint8Array).
+    const ab = new ArrayBuffer(data.byteLength);
+    new Uint8Array(ab).set(data);
+    blob = new Blob([ab], { type: mime ?? 'application/octet-stream' });
+  }
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+    a.remove();
+  }, 0);
+}

--- a/apps/desktop/tests/unit/importWizard.test.ts
+++ b/apps/desktop/tests/unit/importWizard.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { read, utils, write } from 'xlsx';
+
+import {
+  autoMap,
+  buildErrorReportCsv,
+  buildMappedRows,
+  buildTemplateBytes,
+  normalizeHeader,
+  parseBytes,
+  type ImportFieldDef,
+} from '@/lib/importWizard';
+
+interface SampleItem extends Record<string, unknown> {
+  kodeBuku: string;
+  judul: string;
+  tahunTerbit?: number | null;
+}
+
+const FIELDS: ImportFieldDef<SampleItem>[] = [
+  {
+    key: 'kodeBuku',
+    label: 'Kode Buku',
+    required: true,
+    aliases: ['kode_buku', 'kode'],
+    sample: 'BK-0001',
+  },
+  {
+    key: 'judul',
+    label: 'Judul',
+    required: true,
+    aliases: ['title'],
+    sample: 'Bumi Manusia',
+  },
+  {
+    key: 'tahunTerbit',
+    label: 'Tahun',
+    required: false,
+    aliases: ['tahun', 'year'],
+    sample: '1980',
+    validate: (v) => {
+      const n = Number(v);
+      if (!Number.isFinite(n)) return 'invalid';
+      if (n < 1000 || n > 2100) return 'out-of-range';
+      return null;
+    },
+  },
+];
+
+function rowParser(raw: Record<string, string>): SampleItem {
+  const item: SampleItem = {
+    kodeBuku: (raw.kodeBuku ?? '').trim(),
+    judul: (raw.judul ?? '').trim(),
+  };
+  const t = (raw.tahunTerbit ?? '').trim();
+  if (t) {
+    const n = Number(t);
+    if (Number.isFinite(n)) item.tahunTerbit = Math.trunc(n);
+  }
+  return item;
+}
+
+function buildXlsx(headers: string[], rows: string[][]): Uint8Array {
+  const aoa: (string | number)[][] = [headers, ...rows];
+  const sheet = utils.aoa_to_sheet(aoa);
+  const wb = utils.book_new();
+  utils.book_append_sheet(wb, sheet, 'data');
+  return new Uint8Array(write(wb, { bookType: 'xlsx', type: 'array' }) as ArrayBuffer);
+}
+
+describe('normalizeHeader', () => {
+  it('lowercases & replaces separators with underscore', () => {
+    expect(normalizeHeader('Kode Buku')).toBe('kode_buku');
+    expect(normalizeHeader('Tahun-Terbit')).toBe('tahun_terbit');
+    expect(normalizeHeader('  No. Telepon  ')).toBe('no_telepon');
+  });
+});
+
+describe('autoMap', () => {
+  it('matches headers via aliases (case-insensitive)', () => {
+    const headers = ['Kode Buku', 'Title', 'Year', 'Catatan'];
+    const map = autoMap(FIELDS, headers);
+    expect(map['Kode Buku']).toBe('kodeBuku');
+    expect(map['Title']).toBe('judul');
+    expect(map['Year']).toBe('tahunTerbit');
+    expect(map['Catatan']).toBe('');
+  });
+
+  it('does not double-map a target', () => {
+    const headers = ['kode', 'kode_buku'];
+    const map = autoMap(FIELDS, headers);
+    // first one wins
+    expect(map.kode).toBe('kodeBuku');
+    expect(map.kode_buku).toBe('');
+  });
+});
+
+describe('parseBytes + buildMappedRows', () => {
+  it('parses a workbook and validates rows', () => {
+    const bytes = buildXlsx(
+      ['Kode Buku', 'Judul', 'Tahun'],
+      [
+        ['BK-001', 'Bumi Manusia', '1980'],
+        ['BK-002', 'Anak Semua Bangsa', '1980'],
+        ['BK-003', '', '1980'], // missing judul
+        ['BK-001', 'Duplikat', '1980'], // duplicate kode
+        ['BK-004', 'Tahun Salah', '99999'], // invalid tahun
+      ],
+    );
+    const parsed = parseBytes('sample.xlsx', bytes);
+    expect(parsed.headers).toEqual(['Kode Buku', 'Judul', 'Tahun']);
+    expect(parsed.rows).toHaveLength(5);
+
+    const map = autoMap(FIELDS, parsed.headers);
+    const rows = buildMappedRows(FIELDS, parsed, map, rowParser);
+    expect(rows).toHaveLength(5);
+
+    // Row 1 (sheet row 2) is OK
+    expect(rows[0]?.errors).toEqual([]);
+    expect(rows[0]?.item.kodeBuku).toBe('BK-001');
+    expect(rows[0]?.item.tahunTerbit).toBe(1980);
+
+    // Missing judul
+    expect(rows[2]?.errors).toContain('Judul wajib diisi');
+
+    // Duplicate kode
+    expect(rows[3]?.errors.some((e) => e.includes('duplikat'))).toBe(true);
+
+    // Invalid tahun
+    expect(rows[4]?.errors).toContain('out-of-range');
+  });
+});
+
+describe('buildTemplateBytes', () => {
+  it('produces a workbook with headers and sample row', () => {
+    const bytes = buildTemplateBytes(FIELDS, 'Buku');
+    const wb = read(bytes, { type: 'array' });
+    const sheet = wb.Sheets[wb.SheetNames[0]!]!;
+    const aoa = utils.sheet_to_json<Array<string>>(sheet, {
+      header: 1,
+      defval: '',
+      raw: false,
+    });
+    expect(aoa[0]).toEqual(['Kode Buku', 'Judul', 'Tahun']);
+    expect(aoa[1]).toEqual(['BK-0001', 'Bumi Manusia', '1980']);
+  });
+});
+
+describe('buildErrorReportCsv', () => {
+  it('escapes quotes and emits header row', () => {
+    const csv = buildErrorReportCsv([
+      { row: 2, message: 'kode_buku is required' },
+      { row: 5, message: 'duplicate "key"' },
+    ]);
+    expect(csv).toBe('row,message\n2,"kode_buku is required"\n5,"duplicate ""key"""\n');
+  });
+});


### PR DESCRIPTION
## Summary
Refactor dialog impor Excel/CSV untuk **anggota** dan **buku** menjadi **wizard 4-langkah** berbasis komponen bersama (`ImportWizard`). Dialog lama hanya menampilkan preview + tombol Impor; sekarang user dapat:

1. **Upload** — pilih file `.xlsx` / `.xls` / `.csv` atau **unduh template kosong** (`.xlsx`) dengan header & 1 contoh baris untuk panduan struktur.
2. **Mapping** — auto-detect header file (via alias case-insensitive, mis. `kode`, `kode_buku`, `book_code` → `kodeBuku`); user dapat override per kolom lewat dropdown; cegah dua kolom memetakan ke target yang sama; warning saat ada field wajib yang belum dipetakan.
3. **Preview** — tabel preview dengan baris valid (badge hijau) vs baris yang akan dilewati (highlight merah); validasi per baris di sisi UI sebelum kirim ke backend (wajib-diisi, deteksi duplikat `kode*` di file, range tahun 1000–2100, jumlah eksemplar 0–9999, format email, jenis kelamin L/P).
4. **Hasil** — kartu ringkas `Inserted` / `Skipped` / `Errors` + daftar error per-baris dengan tombol **Unduh CSV error** (nomor baris dipetakan balik ke baris file aslinya, bukan offset valid-rows internal, sehingga user bisa langsung membuka file Excel & memperbaikinya).

Backend `bukuApi.importBatch` & `anggotaApi.importBatch` tidak berubah — keduanya sudah mengembalikan per-row error sebelum PR ini, hanya saja UI lama tidak memunculkannya.

Implementasi:
- `apps/desktop/src/components/shared/ImportWizard.tsx` — komponen wizard generik `<TItem>` (Stepper + UploadStep + MappingStep + PreviewStep + ResultStep).
- `apps/desktop/src/lib/importWizard.ts` — utilitas (`normalizeHeader`, `autoMap`, `parseBytes`, `parseFile`, `buildMappedRows`, `buildTemplateBytes`, `buildErrorReportCsv`, `triggerDownload`).
- `apps/desktop/src/features/buku/ImportBukuDialog.tsx` & `apps/desktop/src/features/anggota/ImportExcelDialog.tsx` — sekarang tipis, hanya men-declare field-defs, alias, validator, dan rowParser khusus domain.
- `apps/desktop/src/i18n/{id,en}/common.json` — namespace baru `common.importWizard` (paritas penuh id↔en).
- `apps/desktop/tests/unit/importWizard.test.ts` — 5 unit test (`normalizeHeader`, `autoMap`, `parseBytes` + validasi, `buildTemplateBytes`, `buildErrorReportCsv`).

Static checks lokal:
- `pnpm --filter @perpustakaan/desktop typecheck` — green.
- `pnpm --filter @perpustakaan/desktop lint` — green.
- `pnpm --filter @perpustakaan/desktop test` — **243 passed** (sebelumnya 237; +5 wizard, +1 dari setup).
- `pnpm i18n:lint` — id ↔ en parity OK.
- `cargo clippy --all-targets -- -D warnings` — green.
- `cargo test --lib` — **107 passed**.

## Review & Testing Checklist for Human
- [ ] Buka **Buku → Impor** lalu coba unggah `.xlsx` dengan header berbeda-beda (mis. `Kode Buku`, `book_code`, `Kode`) dan pastikan auto-mapping mengisi kolom kanan dengan benar.
- [ ] Klik **Unduh template** di langkah Upload (untuk kedua domain) dan verifikasi file yang ter-download punya header sesuai field + 1 baris contoh.
- [ ] Pada langkah **Preview**, sengaja sertakan baris dengan: judul kosong, kode duplikat di file, tahun > 2100, dan jumlah eksemplar negatif → semuanya harus muncul di kolom Error dan dihitung di badge "dilewati".
- [ ] Klik **Impor** di langkah Preview → langkah **Result** harus menampilkan jumlah `Inserted`/`Skipped`/`Errors`, dan tombol **Unduh CSV error** mengunduh CSV dengan nomor baris file (bukan urutan setelah filter).
- [ ] Ulangi flow yang sama di **Anggota → Impor** termasuk validasi `jenisKelamin` (hanya L/P) dan format email.
- [ ] Pastikan setelah dialog ditutup lalu dibuka lagi, wizard kembali ke langkah 1 (state ter-reset).

### Notes
- Tipe callback `onImported` pada kedua dialog sekarang menerima `ImportWizardResult` (struktur generik dengan `errors: { row, message }[]`). Pemanggil saat ini di `BukuList.tsx` & `AnggotaList.tsx` mengabaikan argumen — mereka hanya memanggil `reload()` — sehingga aman.
- `parseFile()` di-fallback ke `FileReader` jika `File.arrayBuffer()` tidak tersedia (happy-dom test environment). `parseBytes()` di-export terpisah agar mudah diuji dari unit test tanpa membuat File asli.
- Tidak ada perubahan skema DB atau Tauri command — murni perubahan UI + util frontend + tests.
