### PR TITLE
fix(kta): cegah preview cetak KTA kepotong di kolom kanan 320px

### DIFF
--- a/apps/desktop/src/features/kta/CetakKtaPage.tsx
+++ b/apps/desktop/src/features/kta/CetakKtaPage.tsx
@@ -338,7 +338,7 @@ export function CetakKtaPage() {
         <div className="rounded-lg border border-border bg-card p-4 space-y-3">
           <h3 className="text-sm font-semibold">Preview</h3>
           {previewAnggota ? (
-            <KtaPreview layout={layout} anggota={previewAnggota} identity={identity} scale={2.4} />
+            <KtaPreview layout={layout} anggota={previewAnggota} identity={identity} fitToWidth />
           ) : (
             <p className="text-sm text-muted-foreground">Pilih anggota untuk lihat preview.</p>
           )}

--- a/apps/desktop/src/features/kta/KtaPreview.tsx
+++ b/apps/desktop/src/features/kta/KtaPreview.tsx
@@ -18,6 +18,13 @@ interface Props {
   selectedFieldId?: string | null;
   onSelectField?: (id: string | null) => void;
   scale?: number;
+  /**
+   * When true, the card stretches to fill the parent container's width and
+   * keeps its aspect ratio via `aspect-ratio`. `scale` is ignored. Use for
+   * narrow side panels (e.g. Cetak KTA preview column) where the natural
+   * pixel size of an ID-1 card would overflow.
+   */
+  fitToWidth?: boolean;
   className?: string;
 }
 
@@ -28,10 +35,20 @@ export function KtaPreview({
   selectedFieldId,
   onSelectField,
   scale = 2,
+  fitToWidth = false,
   className,
 }: Props) {
   const widthPx = Math.round(layout.widthMm * MM_TO_PX * scale);
   const heightPx = Math.round(layout.heightMm * MM_TO_PX * scale);
+  const sizeStyle: React.CSSProperties = fitToWidth
+    ? {
+        width: '100%',
+        aspectRatio: `${layout.widthMm} / ${layout.heightMm}`,
+      }
+    : {
+        width: widthPx,
+        height: heightPx,
+      };
 
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
 
@@ -57,8 +74,7 @@ export function KtaPreview({
       data-testid="kta-preview"
       className={className}
       style={{
-        width: widthPx,
-        height: heightPx,
+        ...sizeStyle,
         position: 'relative',
         background: layout.background ?? '#ffffff',
         border: '1px solid #cbd5e1',

--- a/apps/desktop/tests/unit/ktaPreview.test.tsx
+++ b/apps/desktop/tests/unit/ktaPreview.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { KtaPreview } from '@/features/kta/KtaPreview';
+import { defaultLayout } from '@/lib/kta';
+import type { LibraryIdentity } from '@/stores/identityStore';
+
+const identity: LibraryIdentity = {
+  nama: 'SMA Test',
+  alamat: '-',
+  kepala: '-',
+  npsn: '-',
+  tahunAjaran: '2024/2025',
+  logoPath: '',
+  kontak: '-',
+};
+
+describe('KtaPreview', () => {
+  it('uses fixed pixel size when scale is given (default)', () => {
+    const { getByTestId } = render(
+      <KtaPreview layout={defaultLayout()} anggota={null} identity={identity} scale={2} />,
+    );
+    const el = getByTestId('kta-preview');
+    // 85.6 mm * 3.78 px/mm * 2 = 647.136 → rounded 647
+    expect(el.style.width).toBe('647px');
+    // 53.98 * 3.78 * 2 = 408.0888 → rounded 408
+    expect(el.style.height).toBe('408px');
+    expect(el.style.aspectRatio).toBe('');
+  });
+
+  it('stretches to container width with aspect-ratio when fitToWidth is true', () => {
+    const { getByTestId } = render(
+      <KtaPreview layout={defaultLayout()} anggota={null} identity={identity} fitToWidth />,
+    );
+    const el = getByTestId('kta-preview');
+    expect(el.style.width).toBe('100%');
+    // jsdom normalises mixed-precision values; assert both numerator and denominator are present.
+    expect(el.style.aspectRatio).toContain('85.6');
+    expect(el.style.aspectRatio).toContain('53.98');
+    expect(el.style.height).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Halaman **Cetak KTA** (`/anggota/cetak-kta`) merender preview di kolom kanan selebar `320px` (Tailwind `lg:grid-cols-[minmax(0,1fr)_320px]`), tapi `KtaPreview` di-instantiate dengan `scale={2.4}` — kartu ID-1 (85.6 mm) hasilnya ~777 px. Akibatnya preview keluar dari kolom dan terpotong oleh viewport (lihat issue: header "KARTU ANG…" + body kartu kepotong di kanan layar).

**Fix:** tambah prop `fitToWidth?: boolean` ke `KtaPreview`. Saat `true`, kartu di-render `width: 100%` + `aspect-ratio: <widthMm> / <heightMm>` agar mengisi parent dan tetap menjaga proporsi. Default tetap `false` (backward compatible) — `TemplateEditor` & `PresetGallery` tetap pakai `scale` numerik seperti semula.

**Perubahan:**
- `apps/desktop/src/features/kta/KtaPreview.tsx` — tambah prop `fitToWidth`, hitung `sizeStyle` (fixed px atau width:100% + aspectRatio).
- `apps/desktop/src/features/kta/CetakKtaPage.tsx` — preview di kolom kanan pakai `fitToWidth` alih-alih `scale={2.4}`.
- `apps/desktop/tests/unit/ktaPreview.test.tsx` — 2 unit test baru: scale tetap (default) vs fitToWidth.

**Tidak diubah:**
- `KtaPresetGallery` (`scale={0.55}`) dan `TemplateEditor` (`scale={2.4}` di kolom kiri `minmax(0,1fr)`) — keduanya tidak overflow di skenario aslinya.
- `print.ts` / `pdf.ts` (export ke print/PDF) — tetap memakai dimensi mm asli.
- `LabelBukuPreview` mirror — tidak ada laporan masalah, scope-nya dibatasi di KTA.

## Review & Testing Checklist for Human

🟡 **Risk: yellow** — perubahan cukup kecil + fully covered oleh unit test, tapi melibatkan React rendering + CSS yang bisa berperilaku beda di webkit2gtk vs WebView2.

- [ ] Buka **Anggota → Cetak KTA**, pastikan kolom preview kanan menampilkan kartu utuh (header, foto, QR) tanpa kepotong di window normal & maximized.
- [ ] Resize window jadi sempit (mis. setengah layar) — preview tetap rapi (tidak overflow horizontal, tetap proporsional).
- [ ] Pilih anggota → klik **Simpan PDF** dan **Cetak**: dimensi & layout PDF/print harus identik dengan sebelumnya (tidak terpengaruh — `pdf.ts` dan `print.ts` pakai mm asli, bukan komponen ini).
- [ ] Buka **Settings → KTA**: editor template tetap menampilkan preview besar di kolom kiri (tidak berubah, scale=2.4).
- [ ] Buka **Galeri Preset KTA**: thumbnail 10 desain tetap rapi di grid (scale=0.55, tidak berubah).

### Notes

- `aspect-ratio` CSS didukung penuh di webkit2gtk-4.1 (Tauri Linux build) & WebView2 (Tauri Windows build), jadi tidak butuh polyfill.
- Karena `FieldNode` sudah menempatkan field via `%` (left/top/width/height), kartu otomatis menyesuaikan saat container mengecil — tidak ada perubahan logic position/size field.
- `fontSize` field tetap dalam pixel (tidak dinamis), sama dengan perilaku sebelumnya pada mode `scale` numerik.
