### PR TITLE
fix(ui): ikon kalender input date terlihat lagi di mode gelap

### DIFF
--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -142,18 +142,21 @@
 }
 
 /*
- * Theme-aware native date inputs (revisi v1.0.3 #4).
+ * Theme-aware native date inputs.
  *
  * `color-scheme` opts native form widgets (calendar picker indicator,
  * autofill, scrollbars) into the matching colour scheme so the calendar
  * icon is dark on light backgrounds and light on dark backgrounds. We
  * apply it on the root via `.dark` so every `<input type="date">` —
  * whether it goes through the `DatePicker` wrapper or a raw `<Input>` —
- * picks up the right colour.
+ * picks up the right colour. Both WebView2 (Windows) and webkit2gtk-4.1
+ * (Linux Tauri build) honour this, so no explicit `filter: invert()` is
+ * applied — doing so would flip the already-light dark-mode icon back to
+ * black and make it invisible (regression observed in v1.0.5).
  *
- * Fallback: explicitly invert the `::-webkit-calendar-picker-indicator`
- * in dark mode for engines (older Linux WebKit) that don't honour
- * `color-scheme` reliably.
+ * The picker indicator is always interactive across <input type=date|time|
+ * datetime-local|month|week>, so we surface a pointer cursor and a small
+ * opacity bump on hover for affordance.
  */
 :root {
   color-scheme: light;
@@ -161,18 +164,19 @@
 .dark {
   color-scheme: dark;
 }
-.dark input[type='date']::-webkit-calendar-picker-indicator,
-.dark input[type='time']::-webkit-calendar-picker-indicator,
-.dark input[type='datetime-local']::-webkit-calendar-picker-indicator,
-.dark input[type='month']::-webkit-calendar-picker-indicator,
-.dark input[type='week']::-webkit-calendar-picker-indicator {
-  filter: invert(1);
-}
-input[type='date']::-webkit-calendar-picker-indicator {
+input[type='date']::-webkit-calendar-picker-indicator,
+input[type='time']::-webkit-calendar-picker-indicator,
+input[type='datetime-local']::-webkit-calendar-picker-indicator,
+input[type='month']::-webkit-calendar-picker-indicator,
+input[type='week']::-webkit-calendar-picker-indicator {
   cursor: pointer;
-  opacity: 0.7;
+  opacity: 0.85;
 }
-input[type='date']::-webkit-calendar-picker-indicator:hover {
+input[type='date']::-webkit-calendar-picker-indicator:hover,
+input[type='time']::-webkit-calendar-picker-indicator:hover,
+input[type='datetime-local']::-webkit-calendar-picker-indicator:hover,
+input[type='month']::-webkit-calendar-picker-indicator:hover,
+input[type='week']::-webkit-calendar-picker-indicator:hover {
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary

Field `<input type="date">` (mis. **TANGGAL LAHIR** di form Anggota) di mode gelap menampilkan ikon kalender yang nyaris tak terlihat — hanya bayangan abu-abu samar di atas background gelap. Di mode terang ikon tampil normal.

**Akar masalah:** dua aturan CSS saling bertabrakan di `apps/desktop/src/styles/globals.css`.

1. `:root.dark { color-scheme: dark }` membuat WebView2 (Windows) dan webkit2gtk-4.1 (Linux Tauri build) **otomatis** merender `::-webkit-calendar-picker-indicator` dengan warna terang (mendekati putih) supaya kontras di background gelap. Ini sudah cukup untuk menyelesaikan tema icon.
2. Aturan tambahan `.dark input[type='date']::-webkit-calendar-picker-indicator { filter: invert(1) }` (komentar lama menyebutnya "fallback untuk WebKit lama") **membalik** ikon terang itu kembali jadi hitam di atas background gelap → praktis tak terlihat lagi (lihat screenshot dari user).

**Fix:** hapus blok `filter: invert(1)` dan andalkan `color-scheme: dark` saja. Aturan `cursor: pointer` + `opacity` digabung supaya berlaku konsisten untuk semua varian indicator (`date`, `time`, `datetime-local`, `month`, `week`). Perilaku mode terang tidak berubah.

**Perubahan:**
- `apps/desktop/src/styles/globals.css` — hapus `.dark ... { filter: invert(1) }`, gabung aturan `cursor`+`opacity` untuk semua tipe input bertimestamp, dan rapikan komentar penjelas.

## Review & Testing Checklist for Human

🟢 **Risk: green** — perubahan CSS-only, tidak menyentuh JS/TS/Rust. Cakupan terbatas pada ikon picker indikator native.

- [ ] **Mode gelap:** buka **Anggota → Tambah/Edit Anggota**, perhatikan field **TANGGAL LAHIR** — ikon kalender sekarang harus terlihat jelas (kontras tinggi pada background gelap), tidak buram.
- [ ] **Mode terang:** toggle ke tema terang lewat header — ikon tetap tampil normal seperti sebelumnya (tidak ada regresi).
- [ ] **Cek tempat lain pakai `<input type="date">`:** Profile dialog, Laporan Kas form, dan filter Kunjungan/Peminjaman — ikon tetap konsisten di kedua mode.
- [ ] (Opsional) **Tipe lain:** kalau ada `time` / `datetime-local` di codebase, pastikan ikon picker-nya juga rapi.

### Notes

- Tidak ada perubahan logic / komponen React. Test suite (244 vitest) tidak terpengaruh; CI tetap dijalankan untuk memastikan lint + typecheck + build pass.
- Aturan baru bersifat **non-`.dark`-specific** untuk `cursor` & `opacity`, jadi kursor pointer juga muncul di mode terang (sebelumnya sudah, sekarang lebih jelas + di-extend ke `time`/`datetime-local`/`month`/`week`).
