### PR TITLE
fix(manual): klik Daftar Isi sekarang scroll ke section tujuan

### DIFF
--- a/apps/desktop/src/features/settings/ManualPage.tsx
+++ b/apps/desktop/src/features/settings/ManualPage.tsx
@@ -49,12 +49,22 @@ interface TocEntry {
   id: string;
 }
 
+/**
+ * Convert a heading text to its anchor id. We mirror GitHub's heading-anchor
+ * algorithm: strip non-alphanumeric characters but preserve every whitespace
+ * character as a single dash. This matters for headings containing `&` or
+ * em-dash (e.g. "Login & Akun", "Master Data — Anggota") — the surrounding
+ * spaces collapse into double-dash slugs (`login--akun`, `master-data--anggota`)
+ * which is the convention `docs/manual.md` was authored against. Collapsing
+ * runs of whitespace with `\s+` would produce single-dash slugs and break
+ * every "Daftar Isi" link in the rendered manual.
+ */
 const slugify = (s: string): string =>
   s
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, '')
     .trim()
-    .replace(/\s+/g, '-');
+    .replace(/\s/g, '-');
 
 function extractToc(markdown: string): TocEntry[] {
   const lines = markdown.split('\n');
@@ -183,11 +193,28 @@ export function ManualPage(): JSX.Element {
               hr: () => <hr className="border-border my-6" />,
               a: ({ children, href }) => {
                 const isExternal = href != null && /^https?:\/\//.test(href);
+                const isHash = href != null && href.startsWith('#');
+                // Hash-only links from the manual's "Daftar Isi" should scroll
+                // to the matching heading inside the article. We handle this
+                // explicitly to bypass the SPA router and to use smooth scroll.
+                const handleHashClick = isHash
+                  ? (e: React.MouseEvent<HTMLAnchorElement>) => {
+                      e.preventDefault();
+                      const id = href.slice(1);
+                      if (!id) return;
+                      const node = document.getElementById(id);
+                      if (node) {
+                        node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        window.history.replaceState(null, '', `#${id}`);
+                      }
+                    }
+                  : undefined;
                 return (
                   <a
                     href={href}
                     target={isExternal ? '_blank' : undefined}
                     rel={isExternal ? 'noopener noreferrer' : undefined}
+                    onClick={handleHashClick}
                     className="text-primary underline-offset-2 hover:underline"
                   >
                     {children}

--- a/apps/desktop/tests/unit/manualPage.test.tsx
+++ b/apps/desktop/tests/unit/manualPage.test.tsx
@@ -76,6 +76,27 @@ describe('ManualPage', () => {
   it('emits anchor IDs on h2 headings so the TOC scroll-jump works', () => {
     renderManual();
     const heading = screen.getByRole('heading', { name: /Login & Akun/i, level: 2 });
-    expect(heading.id).toBe('login-akun');
+    // Slugifier preserves the whitespace around `&` (and em-dash etc.) as
+    // double-dashes, mirroring `docs/manual.md`'s GitHub-style anchors.
+    expect(heading.id).toBe('login--akun');
+  });
+
+  it('renders Daftar-Isi anchor IDs that match docs/manual.md links', () => {
+    renderManual();
+    // Spot-check a handful of well-known sections that use `&` / em-dash —
+    // they must produce the exact ids referenced from `[…](#…)` in the
+    // markdown source so the in-app jump actually works.
+    expect(
+      screen.getByRole('heading', { name: /Instalasi & Jalankan Pertama Kali/i, level: 2 }).id,
+    ).toBe('instalasi--jalankan-pertama-kali');
+    expect(
+      screen.getByRole('heading', { name: /Master Data — Anggota/i, level: 2 }).id,
+    ).toBe('master-data--anggota');
+    expect(
+      screen.getByRole('heading', {
+        name: /Backup, Reset, & Lokasi Data/i,
+        level: 2,
+      }).id,
+    ).toBe('backup-reset--lokasi-data');
   });
 });


### PR DESCRIPTION
## Summary

Daftar Isi Manual Book (Settings → Manual) memiliki 15 link gaya GitHub seperti `[Login & Akun](#login--akun)` dan `[Master Data — Anggota](#master-data--anggota)`. Klik salah satu **tidak scroll ke section tujuan** (lihat screenshot dari user) — hanya tetap di tempat.

**Akar masalah:**

1. **Slugifier tidak konsisten dengan anchor GitHub-style.** `apps/desktop/src/features/settings/ManualPage.tsx` menyusun id heading dengan `s.replace(/[^a-z0-9\s-]/g, '').trim().replace(/\s+/g, '-')`. Karakter `&` / em-dash (`—`) di-strip, tapi `\s+` mengkolaps semua run whitespace jadi **satu** dash. Akibatnya:

   | Heading                              | Slug yang dihasilkan        | Anchor di manual.md              |
   |--------------------------------------|------------------------------|----------------------------------|
   | `## Login & Akun`                    | `login-akun`                 | `#login--akun`                   |
   | `## Master Data — Anggota`           | `master-data-anggota`        | `#master-data--anggota`          |
   | `## Instalasi & Jalankan Pertama Kali` | `instalasi-jalankan-pertama-kali` | `#instalasi--jalankan-pertama-kali` |
   | `## Backup, Reset, & Lokasi Data`    | `backup-reset-lokasi-data`   | `#backup-reset--lokasi-data`     |

   GitHub-style anchor mempertahankan **dua** spasi yang muncul setelah `&`/em-dash dihapus, sehingga slug-nya double-dash. Slugifier kita mengkolapskannya jadi single-dash → tidak ketemu target → klik diam.

2. **Hash-link rentan terhadap interferensi router SPA.** Komponen `a` override di-render plain `<a href="#…">`. TanStack Router biasanya tidak mencegah hash navigation, tapi tergantung browser/router state, default scroll bisa tidak terjadi (terutama saat container `<article>` punya scroll sendiri).

**Fix:**

- Selaraskan slugifier ke algoritma anchor GitHub: tiap whitespace jadi satu dash (`replace(/\s/g, '-')`). Heading dengan `&`/em-dash sekarang menghasilkan slug double-dash, persis sama dengan link di `docs/manual.md`.
- Override komponen `a` untuk hash-only link: `preventDefault`, panggil `scrollIntoView({behavior:'smooth'})` pada heading target, lalu `history.replaceState` untuk update URL hash tanpa memicu router SPA.
- Update unit test: assert id `Login & Akun` jadi `login--akun` (double dash), plus 3 spot-check tambahan (Instalasi, Master Data, Backup).

**Perubahan:**
- `apps/desktop/src/features/settings/ManualPage.tsx` — slugifier baru + komentar penjelas; `a` override untuk hash-only link.
- `apps/desktop/tests/unit/manualPage.test.tsx` — update existing assertion (`login-akun` → `login--akun`) + 1 test baru spot-check 3 anchor lain.

## Review & Testing Checklist for Human

🟡 **Risk: yellow** — perubahan kecil tapi melibatkan markdown rendering + DOM scroll; perlu manual verify di Tauri webview real (jsdom tidak menjalankan smooth scroll).

- [ ] **Buka Settings → Manual.** Klik tiap entri di numbered list "Daftar Isi" pada body manual (1–15). Setiap klik harus scroll smooth ke heading section tersebut.
- [ ] **Sidebar TOC kiri** masih berfungsi: klik tombol di kolom Daftar Isi sticky → scroll ke section yang sama.
- [ ] **Hash di URL** ter-update saat klik link Daftar Isi (lihat URL bar / devtools — `#login--akun` dst.), tapi route page tidak berubah.
- [ ] **Search TOC sidebar** tidak terdampak (filter heading tetap jalan).
- [ ] (Opsional) Coba di **dark mode** — perilaku sama.

### Notes

- Spot-check semua 15 anchor numbered di manual.md sudah saya verify mapping-nya match dengan slugifier baru — tidak ada yang broken.
- `data-testid` di sidebar TOC pakai template literal `manual-toc-${entry.id}` — otomatis ikut format slug baru, tidak ada test yang nge-assert testid spesifik dengan slug lama.
- Tidak menyentuh kode lain (router, TanStack, layout).
