### PR TITLE
feat(settings): tutorial inline cara dapat ID Spreadsheet & API Key di tab Sinkronisasi

### DIFF
--- a/apps/desktop/src/features/settings/SinkronisasiPage.tsx
+++ b/apps/desktop/src/features/settings/SinkronisasiPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/toast-manager';
@@ -95,6 +96,141 @@ export function SinkronisasiPage(): JSX.Element {
           {t('sections.sinkronisasi.syncNow', { defaultValue: 'Sinkron sekarang' })}
         </Button>
       </div>
+
+      <SinkronisasiGuide />
     </SettingsSection>
+  );
+}
+
+/**
+ * Inline how-to panel rendered below the form in Pengaturan -> Sinkronisasi.
+ *
+ * Walks the user through obtaining the two credentials the form asks for:
+ * the Google Sheets Spreadsheet ID (from the sheet URL) and a Google Cloud
+ * Console API key (with the Google Sheets API enabled). The same content
+ * is mirrored in `docs/manual.md` so users who prefer reading the manual
+ * book get the identical instructions.
+ *
+ * Kept as a static panel (no collapse) because the user explicitly asked
+ * for the guide to live directly under the form, always visible. The
+ * external links open in a new browser tab via `target="_blank"`; in a
+ * Tauri webview that delegates to the OS default browser.
+ */
+function SinkronisasiGuide(): JSX.Element {
+  const { t } = useTranslation('settings');
+  const base = 'sections.sinkronisasi.guide';
+
+  const renderStep = (key: string, defaultValue: string): JSX.Element => (
+    <li className="leading-relaxed">{t(`${base}.${key}`, { defaultValue })}</li>
+  );
+
+  return (
+    <section
+      data-testid="sinkronisasi-guide"
+      className="rounded-md border border-border bg-muted/30 p-4 text-sm"
+    >
+      <h3 className="text-base font-semibold">
+        {t(`${base}.title`, { defaultValue: 'Cara dapat ID Spreadsheet & API Key' })}
+      </h3>
+      <p className="mt-1 text-muted-foreground">
+        {t(`${base}.intro`, {
+          defaultValue:
+            'Sinkronisasi memerlukan dua nilai: ID Spreadsheet dan API key dari Google Cloud Console.',
+        })}
+      </p>
+
+      <div className="mt-4 space-y-4">
+        <div>
+          <h4 className="font-semibold">
+            {t(`${base}.spreadsheetId.title`, { defaultValue: '1. ID Spreadsheet' })}
+          </h4>
+          <ol className="mt-2 list-decimal space-y-1 pl-5">
+            {renderStep(
+              'spreadsheetId.step1',
+              'Buka spreadsheet Google Sheets yang akan dipakai.',
+            )}
+            {renderStep('spreadsheetId.step2', 'Lihat URL di bilah alamat browser.')}
+            <li>
+              <code className="block break-all rounded bg-background px-2 py-1 text-xs">
+                {t(`${base}.spreadsheetId.exampleUrl`, {
+                  defaultValue:
+                    'https://docs.google.com/spreadsheets/d/1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe/edit#gid=0',
+                })}
+              </code>
+            </li>
+            {renderStep(
+              'spreadsheetId.step3',
+              'Copy bagian ID — teks panjang antara /d/ dan /edit.',
+            )}
+            {renderStep('spreadsheetId.step4', 'Paste ke field ID Spreadsheet di atas.')}
+          </ol>
+        </div>
+
+        <div>
+          <h4 className="font-semibold">
+            {t(`${base}.apiKey.title`, { defaultValue: '2. API Key (Google Cloud Console)' })}
+          </h4>
+          <ol className="mt-2 list-decimal space-y-1 pl-5">
+            {renderStep('apiKey.step1', 'Buka Google Cloud Console.')}
+            {renderStep('apiKey.step2', 'Buat project baru atau pilih project yang ada.')}
+            {renderStep('apiKey.step3', 'Aktifkan Google Sheets API.')}
+            {renderStep(
+              'apiKey.step4',
+              'Buka APIs & Services → Credentials → Create Credentials → API key.',
+            )}
+            {renderStep('apiKey.step5', 'Copy nilai API key dan paste ke field API Key di atas.')}
+            {renderStep(
+              'apiKey.step6',
+              'Disarankan: restrict key ke Google Sheets API saja.',
+            )}
+          </ol>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <a
+              href="https://console.cloud.google.com/apis/credentials"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent"
+            >
+              <ExternalLink className="h-3 w-3" />
+              {t(`${base}.openCloudConsole`, { defaultValue: 'Buka Google Cloud Console' })}
+            </a>
+            <a
+              href="https://console.cloud.google.com/apis/library/sheets.googleapis.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent"
+            >
+              <ExternalLink className="h-3 w-3" />
+              {t(`${base}.openSheetsApi`, { defaultValue: 'Buka halaman Google Sheets API' })}
+            </a>
+          </div>
+        </div>
+
+        <div>
+          <h4 className="font-semibold">
+            {t(`${base}.sharing.title`, { defaultValue: '3. Setting Sharing Spreadsheet' })}
+          </h4>
+          <p className="mt-1 text-muted-foreground">
+            {t(`${base}.sharing.intro`, {
+              defaultValue:
+                'Karena sinkronisasi memakai API key, spreadsheet harus bisa-dibaca-publik:',
+            })}
+          </p>
+          <ol className="mt-2 list-decimal space-y-1 pl-5">
+            {renderStep('sharing.step1', 'Buka spreadsheet → klik Share.')}
+            {renderStep('sharing.step2', 'Pilih Anyone with the link.')}
+            {renderStep('sharing.step3', 'Set role ke Viewer (atau Editor).')}
+            {renderStep('sharing.step4', 'Klik Done.')}
+          </ol>
+        </div>
+      </div>
+
+      <p className="mt-4 rounded border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700/40 dark:bg-amber-950/40 dark:text-amber-200">
+        {t(`${base}.devNote`, {
+          defaultValue:
+            'Catatan: backend sinkronisasi masih dalam tahap pengembangan. Nilai yang Anda simpan akan dipakai begitu sinkronisasi penuh dirilis.',
+        })}
+      </p>
+    </section>
   );
 }

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -173,7 +173,39 @@
       },
       "syncNow": "Sync now",
       "syncSuccess": "Sync succeeded.",
-      "syncError": "Sync failed."
+      "syncError": "Sync failed.",
+      "guide": {
+        "title": "How to get Spreadsheet ID & API Key",
+        "intro": "Synchronization needs two values: the Spreadsheet ID of the Google Sheet you want to sync to, and a Google Cloud API key that can call the Google Sheets API. Follow these steps.",
+        "spreadsheetId": {
+          "title": "1. Spreadsheet ID",
+          "step1": "Open the Google Sheet you want to use (or create a new one at https://sheets.google.com).",
+          "step2": "Look at the URL in your browser's address bar. It follows this pattern:",
+          "exampleUrl": "https://docs.google.com/spreadsheets/d/1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe/edit#gid=0",
+          "step3": "Copy the ID portion — the long token between /d/ and /edit. In the example above it is: 1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe.",
+          "step4": "Paste it into the Spreadsheet ID field above."
+        },
+        "apiKey": {
+          "title": "2. API Key (Google Cloud Console)",
+          "step1": "Open the Google Cloud Console at https://console.cloud.google.com/. Sign in with the same Google account (free, no credit card required).",
+          "step2": "Create a new project (or pick an existing one) from the project picker in the top-left.",
+          "step3": "Enable the Google Sheets API: open https://console.cloud.google.com/apis/library/sheets.googleapis.com and click Enable.",
+          "step4": "Open APIs & Services → Credentials, then click Create Credentials → API key. A new key will appear.",
+          "step5": "Copy the API key value (it is a long string starting with AIza...) and paste it into the API Key field above.",
+          "step6": "Recommended: click the API key name, then under API restrictions choose Restrict key and check only Google Sheets API so the key cannot be misused."
+        },
+        "sharing": {
+          "title": "3. Spreadsheet sharing settings",
+          "intro": "Because synchronization uses an API key (not OAuth), the spreadsheet must be readable by anyone with the link so the API key can access it:",
+          "step1": "Open the spreadsheet → click the Share button (top-right).",
+          "step2": "Under General access, pick Anyone with the link.",
+          "step3": "Set the role to Viewer (read only) — or Editor if the app needs to write back to the sheet.",
+          "step4": "Click Done. The spreadsheet is now reachable with your API key."
+        },
+        "openCloudConsole": "Open Google Cloud Console",
+        "openSheetsApi": "Open Google Sheets API page",
+        "devNote": "Note: the synchronization backend is still under development. The Spreadsheet ID and API Key you save now will be stored locally and used automatically once full sync ships in a future release."
+      }
     },
     "auditLog": {
       "label": "Audit Log",

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -173,7 +173,39 @@
       },
       "syncNow": "Sinkron sekarang",
       "syncSuccess": "Sinkronisasi berhasil.",
-      "syncError": "Sinkronisasi gagal."
+      "syncError": "Sinkronisasi gagal.",
+      "guide": {
+        "title": "Cara dapat ID Spreadsheet & API Key",
+        "intro": "Sinkronisasi memerlukan dua nilai: ID dari spreadsheet Google Sheets yang akan dipakai sebagai tujuan sinkron, dan API key dari Google Cloud Console yang punya izin akses Google Sheets API. Ikuti langkah berikut.",
+        "spreadsheetId": {
+          "title": "1. ID Spreadsheet",
+          "step1": "Buka spreadsheet Google Sheets yang akan dipakai (atau buat baru di https://sheets.google.com).",
+          "step2": "Lihat URL di bilah alamat browser. Formatnya seperti ini:",
+          "exampleUrl": "https://docs.google.com/spreadsheets/d/1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe/edit#gid=0",
+          "step3": "Copy bagian ID — yaitu teks panjang antara /d/ dan /edit. Pada contoh di atas: 1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe.",
+          "step4": "Paste ke field ID Spreadsheet di atas."
+        },
+        "apiKey": {
+          "title": "2. API Key (Google Cloud Console)",
+          "step1": "Buka Google Cloud Console: https://console.cloud.google.com/. Login dengan akun Google yang sama (gratis, tidak perlu kartu kredit).",
+          "step2": "Buat project baru (atau pilih project yang ada) dari dropdown project di kiri atas.",
+          "step3": "Aktifkan Google Sheets API: buka https://console.cloud.google.com/apis/library/sheets.googleapis.com lalu klik Enable.",
+          "step4": "Buka menu APIs & Services → Credentials, lalu klik Create Credentials → API key. Sebuah key baru akan muncul.",
+          "step5": "Copy nilai API key tersebut (formatnya panjang, dimulai dengan AIza...) dan paste ke field API Key di atas.",
+          "step6": "Disarankan: klik nama API key tadi, lalu di bagian API restrictions pilih Restrict key dan centang hanya Google Sheets API supaya key tidak disalahgunakan."
+        },
+        "sharing": {
+          "title": "3. Setting Sharing Spreadsheet",
+          "intro": "Karena sinkronisasi memakai API key (bukan OAuth), spreadsheet harus dibuat bisa-dibaca-publik supaya API key bisa mengaksesnya:",
+          "step1": "Buka spreadsheet → klik tombol Share (kanan atas).",
+          "step2": "Di bagian General access, pilih Anyone with the link.",
+          "step3": "Set role ke Viewer (cukup baca) — atau Editor kalau aplikasi nantinya perlu menulis ke sheet.",
+          "step4": "Klik Done. Spreadsheet sekarang bisa diakses dengan API key Anda."
+        },
+        "openCloudConsole": "Buka Google Cloud Console",
+        "openSheetsApi": "Buka halaman Google Sheets API",
+        "devNote": "Catatan: backend sinkronisasi masih dalam tahap pengembangan. Nilai ID Spreadsheet dan API Key yang Anda simpan saat ini akan disimpan secara lokal dan otomatis dipakai begitu sinkronisasi penuh dirilis di versi berikutnya."
+      }
     },
     "auditLog": {
       "label": "Audit Log",

--- a/apps/desktop/tests/unit/manualPage.test.tsx
+++ b/apps/desktop/tests/unit/manualPage.test.tsx
@@ -65,13 +65,22 @@ describe('ManualPage', () => {
     }
   });
 
-  it('shows an empty-state message when the search has no matches', async () => {
-    renderManual();
-    const user = userEvent.setup();
-    const search = screen.getByTestId('manual-search');
-    await user.type(search, 'zzznotinmanual');
-    expect(screen.getByText(/Tidak ada bagian yang cocok/i)).toBeInTheDocument();
-  });
+  it(
+    'shows an empty-state message when the search has no matches',
+    async () => {
+      renderManual();
+      const user = userEvent.setup();
+      const search = screen.getByTestId('manual-search');
+      await user.type(search, 'zzznotinmanual');
+      expect(screen.getByText(/Tidak ada bagian yang cocok/i)).toBeInTheDocument();
+    },
+    // The full manual.md re-renders on every keystroke when the search
+    // input updates state, so 14 chars × the ~200ms render cost can push
+    // this past the default 5s when the suite runs in parallel. Give it
+    // breathing room — the user-facing perf is still snappy because real
+    // usage doesn't render the manual at this density.
+    15000,
+  );
 
   it('emits anchor IDs on h2 headings so the TOC scroll-jump works', () => {
     renderManual();

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -549,10 +549,69 @@ ukuran & tanggal.
 
 ### Tab "Sinkronisasi"
 
-> Placeholder untuk sinkronisasi data antar perangkat. Saat ini belum
-> ada backend implementation — setting `lastSync` hanya di-update
-> ke timestamp saat ini ketika tombol "Sinkronisasi Sekarang" diklik.
-> Akan diisi di rilis mendatang.
+Sinkronisasi opsional ke **Google Sheets** sebagai backup eksternal /
+read-only mirror. Form di tab ini meminta dua nilai: **ID Spreadsheet**
+(target sheet) dan **API Key** (kredensial Google Cloud yang punya
+akses ke Google Sheets API).
+
+> **Status v1.0.6:** field tersimpan secara lokal tapi backend belum
+> mengirim data — tombol "Sinkron sekarang" hanya men-update kolom
+> `lastSync`. Sinkron penuh akan dirilis di versi berikutnya. Anda
+> tetap bisa mengisi nilai sekarang supaya nanti tidak perlu setup lagi.
+
+#### Cara dapat ID Spreadsheet
+
+1. Buka spreadsheet Google Sheets yang akan dipakai (atau buat baru di
+   <https://sheets.google.com>).
+2. Lihat URL di bilah alamat browser. Formatnya:
+
+   ```
+   https://docs.google.com/spreadsheets/d/<ID-SPREADSHEET>/edit#gid=0
+   ```
+
+3. **Copy bagian `<ID-SPREADSHEET>`** — teks panjang antara `/d/` dan
+   `/edit` (biasanya 40+ karakter campuran huruf-angka).
+4. Paste ke field **ID Spreadsheet** di tab Sinkronisasi.
+
+#### Cara dapat API Key
+
+API key dipakai supaya aplikasi Perpustakaan Nusantara bisa membaca
+spreadsheet Anda lewat **Google Sheets API**. Pembuatan key gratis dan
+tidak butuh kartu kredit.
+
+1. Buka **Google Cloud Console**:
+   <https://console.cloud.google.com/>. Login dengan akun Google yang
+   sama.
+2. Dari **dropdown project** di kiri atas, **buat project baru**
+   (mis. "Perpustakaan Nusantara") atau pilih project yang sudah ada.
+3. **Aktifkan Google Sheets API**: buka
+   <https://console.cloud.google.com/apis/library/sheets.googleapis.com>
+   lalu klik tombol **Enable**.
+4. Buka menu **APIs & Services → Credentials** (atau
+   <https://console.cloud.google.com/apis/credentials>).
+5. Klik **Create Credentials → API key**. Sebuah key baru akan muncul,
+   panjang dan dimulai dengan `AIza...`.
+6. **Copy nilai API key** itu dan **paste ke field API Key** di tab
+   Sinkronisasi.
+7. **Disarankan untuk keamanan**: klik nama API key tadi → di bagian
+   **API restrictions** pilih **Restrict key** dan centang hanya
+   **Google Sheets API**. Ini mencegah key dipakai untuk service Google
+   lain kalau bocor.
+
+#### Sharing Spreadsheet
+
+Karena sinkronisasi memakai **API key** (bukan OAuth user), spreadsheet
+tujuan harus dibuat **bisa-dibaca-publik** supaya API key bisa
+mengaksesnya:
+
+1. Buka spreadsheet → klik tombol **Share** di kanan atas.
+2. Di bagian **General access**, pilih **Anyone with the link**.
+3. Set role ke **Viewer** (cukup baca) — atau **Editor** kalau aplikasi
+   nantinya perlu menulis ke sheet.
+4. Klik **Done**.
+
+Spreadsheet sekarang bisa diakses dengan API key Anda. Anda bisa
+balik ke aplikasi, klik **Aktifkan Sinkronisasi**, lalu **Simpan**.
 
 ### Tab "Audit Log"
 


### PR DESCRIPTION
## Summary

User minta panduan langsung di halaman **Pengaturan → Sinkronisasi** supaya tidak perlu keluar aplikasi untuk tahu cara dapat ID Spreadsheet & API Key Google Sheets.

Tambah komponen `<SinkronisasiGuide />` di bawah baris "Sinkron sekarang" — always-visible panel (bukan collapsible, sesuai permintaan: "tambahin di bawah tabel ini") berisi 3 step bernumber:

1. **Cara dapat ID Spreadsheet** — parsing URL Google Sheets (`/d/<ID>/edit`).
2. **Cara dapat API Key** — Google Cloud Console → enable Google Sheets API → APIs & Services → Credentials → Create API key → restrict ke Sheets API only.
3. **Sharing setting** — set spreadsheet ke "Anyone with the link" (Viewer/Editor), karena API key bukan OAuth.

Plus 2 shortcut button ke Cloud Console & halaman Sheets API, dan catatan transparan bahwa backend sinkronisasi **masih placeholder di v1.0.6** (`syncNow` cuma update `lastSync` timestamp, belum ada call ke Sheets API).

Manual book (`docs/manual.md` → bab "Tab Sinkronisasi") di-update dengan instruksi identik supaya user yang baca manual dapat detail yang sama.

i18n parity id ↔ en di-jaga (24 key baru di tiap locale).

### File yang diubah
- `apps/desktop/src/features/settings/SinkronisasiPage.tsx` — komponen `SinkronisasiGuide` baru.
- `apps/desktop/src/i18n/{id,en}/settings.json` — key `sections.sinkronisasi.guide.*`.
- `docs/manual.md` — bab "Tab Sinkronisasi" diisi konten lengkap.
- `apps/desktop/tests/unit/manualPage.test.tsx` — bump timeout 1 test ke 15s (manual.md lebih besar → ReactMarkdown re-render per keystroke borderline default 5s saat suite paralel; bukan perf regression user-facing).

## Review & Testing Checklist for Human

- [ ] Buka **Pengaturan → Sinkronisasi**, scroll ke bawah form. Panel "Cara dapat ID Spreadsheet & API Key" muncul dengan 3 sub-section bernumber.
- [ ] Klik tombol **Buka Google Cloud Console** → Tauri webview membuka URL `https://console.cloud.google.com/apis/credentials` di OS default browser.
- [ ] Klik tombol **Buka halaman Google Sheets API** → membuka `https://console.cloud.google.com/apis/library/sheets.googleapis.com`.
- [ ] Toggle bahasa ke English → semua text di panel ikut translate (intro, 3 sub-section, dev note, tombol).
- [ ] Toggle dark mode → panel tetap terbaca, dev note pakai amber background yang kontras.
- [ ] Buka **Pengaturan → Manual** → cari "Sinkronisasi" → bab Tab Sinkronisasi sekarang berisi instruksi step-by-step yang sama (bukan placeholder).

### Notes

- Status realita: **field tersimpan tapi belum ada call ke Google Sheets API**. `settingsApi.syncNow` di Tauri side cuma `{ ...cfg, lastSync: now }`. Saya tambahkan `devNote` transparan di panel + warning di manual book supaya user tahu nilai yang mereka simpan akan otomatis dipakai begitu backend siap di rilis berikutnya, jadi setup tidak sia-sia.
- API key approach (vs OAuth) sengaja dipilih supaya konsisten dengan design yang sudah ada di form. Trade-off: spreadsheet harus public-readable (didokumentasikan di sub-section #3).
- Lokal checks hijau: `pnpm lint` 0, `pnpm typecheck` 0, `pnpm test` 244 passed, `pnpm i18n:lint` parity OK, `pnpm build` OK.