### PR TITLE
chore(release): v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,102 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-05-05
+
+### Added
+
+- **Notifikasi peminjaman telat (bell + dashboard)** — header sekarang
+  punya bell icon dengan badge angka jumlah peminjaman yang sudah lewat
+  jatuh tempo, plus panel "Peminjaman Telat" di Dashboard yang
+  menampilkan list anggota + buku + tanggal jatuh tempo + jumlah hari
+  telat. Backend baru: `peminjaman_overdue_list` Tauri command. Refresh
+  otomatis tiap kali tab Dashboard / Peminjaman dibuka. (#107)
+- **Riwayat peminjaman per anggota** — di halaman detail anggota,
+  tab baru "Riwayat Peminjaman" menampilkan timeline lengkap (statistik
+  total + aktif + selesai + telat, top 5 buku yang dipinjam, dan tabel
+  semua transaksi diurutkan dari terbaru). Backend: `anggota_loan_history`
+  Tauri command dengan agregasi SQL. (#108)
+- **Label barcode buku + 10 template preset** — fitur baru "Cetak Label"
+  di halaman Buku untuk batch-print barcode label dengan format Code-128.
+  10 preset tersedia (mis. Avery 5160, custom 70×30mm, dll). Editor
+  template support custom dimensi, font, posisi field, dan filled-rect
+  decoration. CRUD template via `label_buku.rs` Tauri commands + tabel
+  baru `label_buku_templates`. (#109)
+- **Import wizard Excel/CSV (anggota & buku)** — dialog wizard 4-step
+  (upload file → preview parse → mapping field → confirm import) untuk
+  bulk-create data anggota atau buku dari spreadsheet. Validasi field
+  inline (range tahun, format jenis kelamin, dll), error report CSV
+  download, dan template Excel pre-formatted. Library bersama:
+  `apps/desktop/src/lib/importWizard.ts`. (#110)
+- **Mode sirkulasi webcam (Ctrl+L)** — halaman baru `/sirkulasi`
+  dengan dua mode (Pinjam / Kembalikan) yang membaca barcode buku
+  via webcam laptop pakai `@zxing/browser`. Format barcode supported:
+  Code-128, Code-39, EAN-13, EAN-8, QR. Backend: `eksemplar_resolve` +
+  `peminjaman_aktif_by_eksemplar`. Shortcut global Ctrl/Cmd+L untuk
+  jump ke halaman dari mana saja. (#111)
+- **Tutorial inline cara dapat ID Spreadsheet & API Key** — di
+  `Pengaturan → Sinkronisasi`, di bawah form, panel selalu-tampil yang
+  berisi 3 sub-section bernumber: (1) ID Spreadsheet — copy dari URL
+  Google Sheets, (2) API Key — Google Cloud Console → enable Sheets
+  API → Credentials → Create API key, (3) Sharing settings — set
+  spreadsheet ke "Anyone with the link". 2 tombol shortcut langsung ke
+  Cloud Console & halaman Sheets API. Dev-note transparan: backend
+  sinkronisasi masih placeholder di v1.0.6 — field tersimpan lokal
+  tapi belum ada call ke Sheets API. Backend full sinkron dijadwalkan
+  untuk v1.0.7+. Manual book di-update dengan instruksi identik.
+  (#116)
+
+### Fixed
+
+- **Cetak KTA: preview tidak kepotong di kolom kanan 320px** —
+  panel preview di `Cetak KTA` sebelumnya mencoba render kartu pada
+  scale yang membuat header "KARTU TANDA ANGGOTA" terpotong jadi
+  "KARTU ANG..." dan body kartu meluap keluar viewport. Layout flex
+  + `fitToWidth` pada `KtaPreview` sekarang menjamin kartu pas di
+  kolom dengan aspect-ratio mm akurat. (#112)
+- **Ikon kalender input date tidak terlihat di mode gelap** — native
+  `<input type="date">` calendar picker indicator dan picker popup
+  default warnanya gelap, jadi invisible di dark mode. Fix: `.dark
+  { color-scheme: dark }` di `globals.css` opt-in ke dark scheme
+  untuk semua native form widgets — calendar icon, autofill dropdown,
+  scrollbars semua ikut tema gelap. (#113)
+- **Daftar Isi Manual diklik tidak scroll ke section tujuan** —
+  link TOC sebelumnya hanya memperbarui hash URL tanpa benar-benar
+  scroll ke heading karena heading-heading di markdown tidak punya
+  ID anchor. Sekarang ManualPage menambahkan `id` slugified ke setiap
+  heading rendered ReactMarkdown, dan klik TOC pakai
+  `scrollIntoView({ behavior: 'smooth', block: 'start' })`. (#114)
+- **Hasil cetak KTA: foto broken + proporsi teks tidak konsisten** —
+  dua bug dalam satu PR. (1) Popup window cetak menerima relative
+  path foto anggota seperti `uploads/foto.png` yang tidak bisa
+  resolve di luar konteks Tauri webview, jadi tampil sebagai
+  broken-image icon. Fix: load foto via `assetsApi.readDataUrl()` jadi
+  base64 inline sebelum render HTML. (2) `fontSize` template KTA
+  disimpan dalam piksel mati, padahal kartu di-render di 3 ukuran
+  berbeda (template editor scale=2.4, preview fitToWidth ~280px,
+  cetak scale=1 ~756px) — text terlihat proporsi berbeda di tiap
+  view. Fix: konversi semua `font-size` ke unit `cqi` (1cqi = 1%
+  lebar card) + tambah `container-type: inline-size` di card
+  wrapper. Editor + preview + cetak sekarang tampil identik
+  proporsinya. (#115)
+
+### Notes
+
+- **Tab Sinkronisasi**: ditandai sebagai *placeholder + tutorial
+  setup* di v1.0.6. Form menyimpan ID Spreadsheet & API Key secara
+  lokal, tapi backend belum mengirim data ke Google Sheets — itu
+  dijadwalkan ke v1.0.7+. Dev-note transparan dipasang di panel
+  tutorial supaya user tahu nilai yang mereka simpan akan otomatis
+  dipakai begitu sinkronisasi penuh dirilis. Setup tidak sia-sia.
+- **Windows SmartScreen**: installer v1.0.6 tetap unsigned (tidak ada
+  Authenticode certificate), jadi user akan melihat warning "Windows
+  protected your PC" saat install pertama. Workaround user-side: klik
+  "More info" → "Run anyway". Setelah upload release, installer
+  v1.0.6 akan di-submit ke Microsoft SmartScreen (https://www.microsoft.com/en-us/wdsi/filesubmission)
+  untuk reputation building. Solusi permanen: code-signing
+  certificate (EV ~USD 300–600/tahun, OV ~USD 100–250/tahun, Azure
+  Trusted Signing ~USD 10/bulan) — dijadwalkan ke versi berikutnya.
+
 ## [1.0.5] - 2026-05-04
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2832,7 +2832,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.5"
+version = "1.0.6"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Bump version 1.0.5 → 1.0.6 dan lengkapi CHANGELOG section `[1.0.6]`.

Versi:
- `apps/desktop/package.json` 1.0.5 → 1.0.6
- `apps/desktop/src-tauri/tauri.conf.json` 1.0.5 → 1.0.6
- `apps/desktop/src-tauri/Cargo.toml` 1.0.5 → 1.0.6 (+ Cargo.lock auto-updated via `cargo check`)

CHANGELOG `[1.0.6]` (2026-05-05) mencakup 11 PR yang sudah di-merge ke `main` sejak v1.0.5:

**Added** (6):
- #107 Notifikasi peminjaman telat (bell + dashboard)
- #108 Riwayat peminjaman per anggota
- #109 Label barcode buku + 10 template preset
- #110 Import wizard Excel/CSV (anggota & buku)
- #111 Mode sirkulasi webcam (Ctrl+L)
- #116 Tutorial inline cara dapat ID Spreadsheet & API Key

**Fixed** (4):
- #112 Cetak KTA preview tidak kepotong di kolom kanan 320px
- #113 Ikon kalender input date terlihat lagi di mode gelap
- #114 Daftar Isi Manual sekarang scroll ke section tujuan
- #115 Hasil cetak KTA: foto tidak broken + proporsi teks konsisten editor↔preview↔cetak

**Notes**:
- Tab Sinkronisasi v1.0.6 = placeholder + tutorial setup; backend full sinkron dijadwalkan v1.0.7+ (per konfirmasi user)
- Installer v1.0.6 tetap unsigned. User akan submit ke Microsoft SmartScreen pasca-upload untuk reputation building. Opsi code-signing (EV cert / Azure Trusted Signing) dijadwalkan ke versi berikutnya

## Review & Testing Checklist for Human

- [ ] Verifikasi tiga file versi konsisten: `cd /repo && grep -r '1\.0\.6' apps/desktop/package.json apps/desktop/src-tauri/tauri.conf.json apps/desktop/src-tauri/Cargo.toml apps/desktop/src-tauri/Cargo.lock`
- [ ] Test extraction: `node scripts/extract-changelog.mjs v1.0.6` mengembalikan section `[1.0.6]` lengkap (ini yang dipakai workflow `release-v2` saat tag-push untuk isi GitHub Release body)
- [ ] Smoke-test sudah dilakukan di session ini terhadap kelima bug fix (#112–#115) + tutorial (#116) — recording + report di session message sebelumnya. Tidak ada regresi terdeteksi

### Notes

- Setelah PR ini merge: push annotated tag `v1.0.6` ke `main` untuk trigger workflow `Publish v2 GitHub Release` yang akan build Windows MSI + NSIS dan attach ke GitHub Release page
- Jangan force-push main; jangan amend commit; jangan skip CI
- 5 PR sebelumnya (#112, #113, #114, #115, #116) sudah merged ke main dan dipakai tested di smoke test sebelum cut release ini