### PR TITLE
fix(sirkulasi): tombol Coba lagi + Muat ulang halaman saat izin kamera ditolak

### DIFF
--- a/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
+++ b/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
@@ -20,6 +20,8 @@ import {
   CheckCircle2,
   Keyboard,
   Loader2,
+  RefreshCw,
+  RotateCcw,
   ScanLine,
   ShieldCheck,
   Trash2,
@@ -499,8 +501,77 @@ export function SirkulasiPage() {
             </div>
 
             {scanner.error && (
-              <div className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive">
-                {scanner.error}
+              <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                <p className="font-medium">
+                  {scanner.errorKind === 'permission'
+                    ? t('sirkulasi:scanner.permissionTitle', {
+                        defaultValue: 'Akses kamera diblokir',
+                      })
+                    : scanner.errorKind === 'no-device'
+                      ? t('sirkulasi:scanner.noDeviceTitle', {
+                          defaultValue: 'Kamera tidak ditemukan',
+                        })
+                      : scanner.errorKind === 'in-use'
+                        ? t('sirkulasi:scanner.inUseTitle', {
+                            defaultValue: 'Kamera sedang dipakai aplikasi lain',
+                          })
+                        : t('sirkulasi:scanner.errorTitle', {
+                            defaultValue: 'Gagal memulai kamera',
+                          })}
+                </p>
+                <p className="mt-1 text-xs leading-relaxed text-destructive/80">
+                  {scanner.errorKind === 'permission'
+                    ? t('sirkulasi:scanner.permissionHelp', {
+                        defaultValue:
+                          'Buka pengaturan aplikasi/browser, ubah izin kamera ke "Izinkan", lalu klik Coba lagi. Jika tombol Coba lagi tidak memunculkan prompt izin, klik Muat ulang halaman.',
+                      })
+                    : scanner.errorKind === 'no-device'
+                      ? t('sirkulasi:scanner.noDeviceHelp', {
+                          defaultValue:
+                            'Pastikan kamera webcam tersambung dan tidak dinonaktifkan di Device Manager.',
+                        })
+                      : scanner.errorKind === 'in-use'
+                        ? t('sirkulasi:scanner.inUseHelp', {
+                            defaultValue:
+                              'Tutup aplikasi lain yang sedang menggunakan kamera (Zoom, Meet, Camera, dll), lalu klik Coba lagi.',
+                          })
+                        : scanner.error}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      void scanner.start();
+                    }}
+                    disabled={scanner.starting}
+                  >
+                    {scanner.starting ? (
+                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+                    )}
+                    {t('sirkulasi:scanner.retry', { defaultValue: 'Coba lagi' })}
+                  </Button>
+                  {scanner.errorKind === 'permission' && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        if (typeof window !== 'undefined') {
+                          window.location.reload();
+                        }
+                      }}
+                    >
+                      <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                      {t('sirkulasi:scanner.reload', {
+                        defaultValue: 'Muat ulang halaman',
+                      })}
+                    </Button>
+                  )}
+                </div>
               </div>
             )}
 

--- a/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
+++ b/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
@@ -24,12 +24,28 @@ export interface UseBarcodeScannerOptions {
   cooldownMs?: number;
 }
 
+/**
+ * Categorisation of camera-startup errors so the UI can render different
+ * recovery hints. `'permission'` covers the case where the user (or a
+ * stricter browser policy) denied camera access — that is the only one
+ * where re-calling `start()` may not re-prompt and the user has to flip
+ * a setting first.
+ */
+export type ScannerErrorKind =
+  | 'permission'
+  | 'no-device'
+  | 'in-use'
+  | 'unsupported'
+  | 'other';
+
 export interface UseBarcodeScannerResult {
   videoRef: React.RefObject<HTMLVideoElement>;
   active: boolean;
   /** True while waiting for `getUserMedia`/permission. */
   starting: boolean;
   error: string | null;
+  /** Structured tag for the most recent error, mirrors `error` lifecycle. */
+  errorKind: ScannerErrorKind | null;
   start: () => Promise<void>;
   stop: () => void;
   /** List of cameras the browser exposed, ordered as MediaDevices returns them. */
@@ -37,6 +53,38 @@ export interface UseBarcodeScannerResult {
   /** Currently selected `deviceId`. Falls back to the first device. */
   selectedDeviceId: string | null;
   selectDevice: (deviceId: string) => void;
+}
+
+/**
+ * Map a `getUserMedia` failure to one of {@link ScannerErrorKind}.
+ *
+ * `getUserMedia` rejects with a `DOMException` whose `name` is set to the
+ * spec-defined value (NotAllowedError, NotFoundError, etc.). We special-
+ * case the ones that need different UX recovery hints and lump the rest
+ * under `'other'`.
+ */
+export function classifyScannerError(e: unknown): ScannerErrorKind {
+  if (e && typeof e === 'object' && 'name' in e) {
+    const name = (e as { name: unknown }).name;
+    if (typeof name === 'string') {
+      switch (name) {
+        case 'NotAllowedError':
+        case 'PermissionDeniedError':
+        case 'SecurityError':
+          return 'permission';
+        case 'NotFoundError':
+        case 'OverconstrainedError':
+          return 'no-device';
+        case 'NotReadableError':
+        case 'TrackStartError':
+          return 'in-use';
+      }
+    }
+  }
+  if (e instanceof Error && /getUserMedia/i.test(e.message)) {
+    return 'unsupported';
+  }
+  return 'other';
 }
 
 const HINTS = (() => {
@@ -70,6 +118,7 @@ export function useBarcodeScanner(
   const [active, setActive] = useState(false);
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<ScannerErrorKind | null>(null);
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
 
@@ -83,10 +132,12 @@ export function useBarcodeScanner(
   const start = useCallback(async (): Promise<void> => {
     if (typeof window === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
       setError('Browser tidak mendukung akses kamera (getUserMedia tidak tersedia).');
+      setErrorKind('unsupported');
       return;
     }
     setStarting(true);
     setError(null);
+    setErrorKind(null);
     try {
       // List devices first so the UI can show a picker. Some browsers
       // populate the device labels only after the user grants permission,
@@ -144,6 +195,7 @@ export function useBarcodeScanner(
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       setError(msg);
+      setErrorKind(classifyScannerError(e));
       setActive(false);
     } finally {
       setStarting(false);
@@ -179,6 +231,7 @@ export function useBarcodeScanner(
     active,
     starting,
     error,
+    errorKind,
     start,
     stop,
     devices,

--- a/apps/desktop/src/i18n/en/sirkulasi.json
+++ b/apps/desktop/src/i18n/en/sirkulasi.json
@@ -11,7 +11,16 @@
     "stop": "Disable camera",
     "starting": "Opening camera…",
     "off": "Camera not active",
-    "devicePlaceholder": "Select camera"
+    "devicePlaceholder": "Select camera",
+    "retry": "Try again",
+    "reload": "Reload page",
+    "errorTitle": "Could not start camera",
+    "permissionTitle": "Camera access blocked",
+    "permissionHelp": "Open the app/browser settings, change camera permission to \"Allow\", then click Try again. If Try again does not re-prompt, click Reload page.",
+    "noDeviceTitle": "Camera not found",
+    "noDeviceHelp": "Make sure a webcam is connected and not disabled in Device Manager.",
+    "inUseTitle": "Camera in use by another app",
+    "inUseHelp": "Close any other app using the camera (Zoom, Meet, Camera, etc.), then click Try again."
   },
   "manual": {
     "placeholder": "Or type / scan via USB scanner (Enter to submit)",

--- a/apps/desktop/src/i18n/id/sirkulasi.json
+++ b/apps/desktop/src/i18n/id/sirkulasi.json
@@ -11,7 +11,16 @@
     "stop": "Matikan kamera",
     "starting": "Membuka kamera…",
     "off": "Kamera belum aktif",
-    "devicePlaceholder": "Pilih kamera"
+    "devicePlaceholder": "Pilih kamera",
+    "retry": "Coba lagi",
+    "reload": "Muat ulang halaman",
+    "errorTitle": "Gagal memulai kamera",
+    "permissionTitle": "Akses kamera diblokir",
+    "permissionHelp": "Buka pengaturan aplikasi/browser, ubah izin kamera ke \"Izinkan\", lalu klik Coba lagi. Jika tombol Coba lagi tidak memunculkan prompt izin, klik Muat ulang halaman.",
+    "noDeviceTitle": "Kamera tidak ditemukan",
+    "noDeviceHelp": "Pastikan kamera webcam tersambung dan tidak dinonaktifkan di Device Manager.",
+    "inUseTitle": "Kamera sedang dipakai aplikasi lain",
+    "inUseHelp": "Tutup aplikasi lain yang sedang menggunakan kamera (Zoom, Meet, Camera, dll), lalu klik Coba lagi."
   },
   "manual": {
     "placeholder": "Atau ketik / scan pakai USB scanner (Enter untuk submit)",

--- a/apps/desktop/tests/unit/scannerError.test.ts
+++ b/apps/desktop/tests/unit/scannerError.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { classifyScannerError } from '@/features/sirkulasi/useBarcodeScanner';
+
+/**
+ * Match the categorisation that drives the structured error panel in
+ * `SirkulasiPage`. The webcam scanner page renders different recovery
+ * hints (retry button, reload button, instructions) based on these
+ * tags, so misclassifying one would silently regress the UX.
+ */
+describe('classifyScannerError', () => {
+  it('maps NotAllowedError to permission', () => {
+    const e = Object.assign(new Error('denied'), { name: 'NotAllowedError' });
+    expect(classifyScannerError(e)).toBe('permission');
+  });
+
+  it('maps the legacy PermissionDeniedError name to permission', () => {
+    const e = Object.assign(new Error('denied'), { name: 'PermissionDeniedError' });
+    expect(classifyScannerError(e)).toBe('permission');
+  });
+
+  it('maps SecurityError (insecure context) to permission', () => {
+    const e = Object.assign(new Error('insecure'), { name: 'SecurityError' });
+    expect(classifyScannerError(e)).toBe('permission');
+  });
+
+  it('maps NotFoundError to no-device', () => {
+    const e = Object.assign(new Error('no cam'), { name: 'NotFoundError' });
+    expect(classifyScannerError(e)).toBe('no-device');
+  });
+
+  it('maps OverconstrainedError to no-device', () => {
+    const e = Object.assign(new Error('constraint'), { name: 'OverconstrainedError' });
+    expect(classifyScannerError(e)).toBe('no-device');
+  });
+
+  it('maps NotReadableError (camera busy) to in-use', () => {
+    const e = Object.assign(new Error('busy'), { name: 'NotReadableError' });
+    expect(classifyScannerError(e)).toBe('in-use');
+  });
+
+  it('maps TrackStartError to in-use', () => {
+    const e = Object.assign(new Error('busy'), { name: 'TrackStartError' });
+    expect(classifyScannerError(e)).toBe('in-use');
+  });
+
+  it('falls back to other for unknown DOMException names', () => {
+    const e = Object.assign(new Error('mystery'), { name: 'WeirdError' });
+    expect(classifyScannerError(e)).toBe('other');
+  });
+
+  it('treats unmarked errors mentioning getUserMedia as unsupported', () => {
+    expect(classifyScannerError(new Error('navigator.getUserMedia missing'))).toBe(
+      'unsupported',
+    );
+  });
+
+  it('handles non-error inputs without crashing', () => {
+    expect(classifyScannerError(undefined)).toBe('other');
+    expect(classifyScannerError(null)).toBe('other');
+    expect(classifyScannerError('string error')).toBe('other');
+  });
+});


### PR DESCRIPTION
## Summary

Bug UX (laporan dari user setelah v1.0.6 release): di halaman **Sirkulasi (Webcam)**, kalau user salah pilih "Block" saat browser/OS minta izin kamera, panel error sebelumnya cuma menampilkan teks "Permission denied" tanpa instruksi recovery yang jelas. Tombol "Aktifkan kamera" memang masih ada, tapi banyak browser meng-cache keputusan deny tersebut sehingga klik ulang tidak akan munculkan prompt izin lagi — user kepentok tanpa tahu langkah selanjutnya.

PR ini memperbaiki UX dengan:

1. **`useBarcodeScanner.ts`** — mengkategorikan error `getUserMedia` ke 5 jenis lewat `classifyScannerError`:
   - `permission` (NotAllowedError / PermissionDeniedError / SecurityError)
   - `no-device` (NotFoundError / OverconstrainedError)
   - `in-use` (NotReadableError / TrackStartError)
   - `unsupported` (browser tidak punya getUserMedia)
   - `other` (fallback)
   
   `errorKind` di-expose lewat hook result.

2. **`SirkulasiPage.tsx`** — panel error sekarang terstruktur:
   - Judul spesifik per kategori (mis. "Akses kamera diblokir" untuk permission)
   - Helper text dengan instruksi recovery (mis. "Buka pengaturan browser, ubah izin kamera ke Izinkan, lalu klik Coba lagi")
   - Tombol **"Coba lagi"** — panggil `scanner.start()` ulang (semua kategori)
   - Tombol **"Muat ulang halaman"** — `window.location.reload()` (khusus permission, untuk kasus browser yang nggak re-prompt setelah retry)

3. **i18n** — keys baru di `id/sirkulasi.json` + `en/sirkulasi.json`, `pnpm i18n:lint` parity OK.

4. **Test** — `apps/desktop/tests/unit/scannerError.test.ts` (10 cases) memastikan klasifikasi `DOMException.name` konsisten.

## Review & Testing Checklist for Human

- [ ] Reproduce di dev: `pnpm dev`, buka `/sirkulasi`, klik "Aktifkan kamera", pilih "Block" di prompt izin → verifikasi panel merah baru muncul dengan judul "Akses kamera diblokir" + tombol "Coba lagi" + tombol "Muat ulang halaman"
- [ ] Verifikasi tombol "Coba lagi" memanggil `scanner.start()` ulang (di-disable saat `scanner.starting=true`); kalau browser masih cache deny, klik "Muat ulang halaman" untuk reset state
- [ ] Test happy-path: setelah unblock di chrome://settings/content/camera (atau equivalent di Tauri webview/Edge), klik "Coba lagi" — kamera harusnya menyala
- [ ] Bahasa: gunakan switcher id/en, panel error tetap terstruktur dan terjemahan tampil benar di kedua locale

### Notes

- Scope kecil — masuk ke v1.0.7 patch / fitur berikutnya bersama bug fixes lain
- Tidak menyentuh logika decode barcode atau alur peminjaman/pengembalian
- 264 vitest pass (sebelumnya 254, +10 test baru), lint+typecheck+build hijau, i18n parity OK