### PR TITLE
fix(sirkulasi): scan KTA + barcode return + scanner accuracy + button labels (PR A of v1.0.7 batch)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/peminjaman.rs
+++ b/apps/desktop/src-tauri/src/commands/peminjaman.rs
@@ -86,6 +86,17 @@ pub struct PeminjamanListResult {
 pub struct PeminjamanCreateInput {
     pub anggota_id: i64,
     pub buku_ids: Vec<i64>,
+    /// Optional override telling the backend which physical copy
+    /// (`eksemplar.id`) to mark as borrowed for each entry in
+    /// `buku_ids`. When provided, the i-th entry MUST belong to the
+    /// i-th `buku_ids` and be currently `tersedia`. Used by the webcam
+    /// circulation flow so the exact scanned barcode is the one
+    /// recorded as on-loan — without this, the backend silently picks
+    /// the lowest-id available copy via FIFO and the operator's later
+    /// return scan fails to find an active loan
+    /// (BUG-17 in v1.0.7 batch).
+    #[serde(default)]
+    pub eksemplar_ids: Option<Vec<i64>>,
     pub tanggal_pinjam: Option<String>,
     pub tanggal_jatuh_tempo: Option<String>,
     pub catatan: Option<String>,
@@ -623,18 +634,17 @@ pub fn peminjaman_get(state: State<'_, AppState>, id: i64) -> AppResult<Peminjam
     Ok(PeminjamanDetail { header, items })
 }
 
-#[tauri::command]
-pub fn peminjaman_create(
-    state: State<'_, AppState>,
+/// Inner implementation that takes a borrowed `Connection` so unit tests
+/// can drive it without spinning up a Tauri `AppState`. The public
+/// `peminjaman_create` command is a thin wrapper that locks the shared
+/// state and forwards to this function.
+pub fn peminjaman_create_inner(
+    conn: &mut rusqlite::Connection,
     input: PeminjamanCreateInput,
 ) -> AppResult<PeminjamanDetail> {
     if input.buku_ids.is_empty() {
         return Err(AppError::Validation("buku_ids tidak boleh kosong".into()));
     }
-    let mut conn = state
-        .db
-        .lock()
-        .map_err(|e| AppError::Internal(e.to_string()))?;
 
     let anggota: Option<(i64, bool)> = conn
         .query_row(
@@ -649,7 +659,7 @@ pub fn peminjaman_create(
         return Err(AppError::Validation("anggota tidak aktif".into()));
     }
 
-    let maks = setting_int(&conn, "transaksi.maks_buku_pinjam", DEFAULT_MAKS_PINJAM);
+    let maks = setting_int(conn, "transaksi.maks_buku_pinjam", DEFAULT_MAKS_PINJAM);
     let aktif_count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM peminjaman_item pi \
          JOIN peminjaman p ON p.id = pi.peminjaman_id \
@@ -664,7 +674,7 @@ pub fn peminjaman_create(
     }
 
     let lama = setting_int(
-        &conn,
+        conn,
         "transaksi.lama_pinjam_hari",
         DEFAULT_LAMA_PINJAM_HARI,
     );
@@ -688,6 +698,21 @@ pub fn peminjaman_create(
         ));
     }
 
+    // When the caller supplies a per-row eksemplar override, validate the
+    // shape upfront so we don't open a transaction we have to roll back.
+    let eksemplar_overrides = match input.eksemplar_ids.as_ref() {
+        Some(list) if list.is_empty() => None,
+        Some(list) => {
+            if list.len() != input.buku_ids.len() {
+                return Err(AppError::Validation(
+                    "eksemplar_ids harus sama panjang dengan buku_ids".into(),
+                ));
+            }
+            Some(list.clone())
+        }
+        None => None,
+    };
+
     let tx = conn.transaction()?;
     let nomor = next_nomor_pinjam(&tx)?;
     tx.execute(
@@ -704,21 +729,53 @@ pub fn peminjaman_create(
     )?;
     let peminjaman_id = tx.last_insert_rowid();
 
-    for buku_id in &input.buku_ids {
-        let eks: Option<(i64, String)> = tx
-            .query_row(
-                "SELECT id, kode_eksemplar FROM eksemplar \
-                 WHERE buku_id = ?1 AND status = 'tersedia' \
-                 ORDER BY id ASC LIMIT 1",
-                params![buku_id],
-                |r| Ok((r.get(0)?, r.get::<_, String>(1)?)),
-            )
-            .optional()?;
-        let (eksemplar_id, _kode) = eks.ok_or_else(|| {
-            AppError::Validation(format!(
-                "tidak ada eksemplar tersedia untuk buku id={buku_id}"
-            ))
-        })?;
+    for (idx, buku_id) in input.buku_ids.iter().enumerate() {
+        let eksemplar_id = if let Some(overrides) = eksemplar_overrides.as_ref() {
+            // Caller (typically the Sirkulasi webcam page) scanned a
+            // specific physical copy — make sure that copy is tersedia
+            // and actually belongs to the requested buku before booking
+            // it. Anything else means the operator scanned the wrong
+            // barcode or the basket got out of sync, both of which
+            // deserve a clear validation error.
+            let ek = overrides[idx];
+            let row: Option<(i64, i64, String)> = tx
+                .query_row(
+                    "SELECT id, buku_id, status FROM eksemplar WHERE id = ?1",
+                    params![ek],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get::<_, String>(2)?)),
+                )
+                .optional()?;
+            let (_, owner_buku_id, status) = row.ok_or_else(|| {
+                AppError::Validation(format!("eksemplar id={ek} tidak ditemukan"))
+            })?;
+            if owner_buku_id != *buku_id {
+                return Err(AppError::Validation(format!(
+                    "eksemplar id={ek} bukan milik buku id={buku_id}"
+                )));
+            }
+            if status != "tersedia" {
+                return Err(AppError::Validation(format!(
+                    "eksemplar id={ek} tidak tersedia (status={status})"
+                )));
+            }
+            ek
+        } else {
+            let eks: Option<(i64, String)> = tx
+                .query_row(
+                    "SELECT id, kode_eksemplar FROM eksemplar \
+                     WHERE buku_id = ?1 AND status = 'tersedia' \
+                     ORDER BY id ASC LIMIT 1",
+                    params![buku_id],
+                    |r| Ok((r.get(0)?, r.get::<_, String>(1)?)),
+                )
+                .optional()?;
+            let (eksemplar_id, _kode) = eks.ok_or_else(|| {
+                AppError::Validation(format!(
+                    "tidak ada eksemplar tersedia untuk buku id={buku_id}"
+                ))
+            })?;
+            eksemplar_id
+        };
         tx.execute(
             "INSERT INTO peminjaman_item (peminjaman_id, buku_id, eksemplar_id, status) \
              VALUES (?1, ?2, ?3, 'dipinjam')",
@@ -743,9 +800,21 @@ pub fn peminjaman_create(
 
     tx.commit()?;
 
-    let header = select_peminjaman_row(&conn, peminjaman_id)?;
-    let items = list_items_for(&conn, peminjaman_id)?;
+    let header = select_peminjaman_row(conn, peminjaman_id)?;
+    let items = list_items_for(conn, peminjaman_id)?;
     Ok(PeminjamanDetail { header, items })
+}
+
+#[tauri::command]
+pub fn peminjaman_create(
+    state: State<'_, AppState>,
+    input: PeminjamanCreateInput,
+) -> AppResult<PeminjamanDetail> {
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    peminjaman_create_inner(&mut conn, input)
 }
 
 #[tauri::command]
@@ -1555,6 +1624,142 @@ mod tests {
         assert_eq!(active.anggota_nama, "Sari");
         assert_eq!(active.kode_eksemplar, "B-001-01");
         assert_eq!(active.judul, "Bumi Manusia");
+    }
+
+    #[test]
+    fn peminjaman_create_with_eksemplar_ids_books_the_specific_copies() {
+        // Two eksemplar of the same buku — without an override the
+        // backend would FIFO-pick e1, but the operator scanned e2 in
+        // the webcam basket and we expect e2 to be the one recorded
+        // on-loan (BUG-17 regression guard).
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Sari", None);
+        let (bid, e1) =
+            seed_buku_with_eksemplar(&conn, "B-001", "Bumi Manusia", "B-001-01", "tersedia");
+        conn.execute(
+            "INSERT INTO eksemplar (buku_id, kode_eksemplar, status) VALUES (?1, 'B-001-02', 'tersedia')",
+            params![bid],
+        )
+        .expect("seed second eksemplar");
+        let e2 = conn.last_insert_rowid();
+
+        let detail = peminjaman_create_inner(
+            &mut conn,
+            PeminjamanCreateInput {
+                anggota_id: aid,
+                buku_ids: vec![bid],
+                eksemplar_ids: Some(vec![e2]),
+                tanggal_pinjam: Some("2024-01-01".into()),
+                tanggal_jatuh_tempo: Some("2024-01-08".into()),
+                catatan: None,
+            },
+        )
+        .expect("create");
+
+        assert_eq!(detail.items.len(), 1);
+        assert_eq!(detail.items[0].eksemplar_id, Some(e2));
+        // The other eksemplar must remain tersedia.
+        let s1: String = conn
+            .query_row(
+                "SELECT status FROM eksemplar WHERE id = ?1",
+                params![e1],
+                |r| r.get(0),
+            )
+            .expect("status e1");
+        assert_eq!(s1, "tersedia");
+        let s2: String = conn
+            .query_row(
+                "SELECT status FROM eksemplar WHERE id = ?1",
+                params![e2],
+                |r| r.get(0),
+            )
+            .expect("status e2");
+        assert_eq!(s2, "dipinjam");
+    }
+
+    #[test]
+    fn peminjaman_create_without_eksemplar_ids_falls_back_to_fifo() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Sari", None);
+        let (bid, e1) =
+            seed_buku_with_eksemplar(&conn, "B-001", "Bumi Manusia", "B-001-01", "tersedia");
+        conn.execute(
+            "INSERT INTO eksemplar (buku_id, kode_eksemplar, status) VALUES (?1, 'B-001-02', 'tersedia')",
+            params![bid],
+        )
+        .expect("seed second eksemplar");
+
+        let detail = peminjaman_create_inner(
+            &mut conn,
+            PeminjamanCreateInput {
+                anggota_id: aid,
+                buku_ids: vec![bid],
+                eksemplar_ids: None,
+                tanggal_pinjam: Some("2024-01-01".into()),
+                tanggal_jatuh_tempo: Some("2024-01-08".into()),
+                catatan: None,
+            },
+        )
+        .expect("create");
+
+        assert_eq!(detail.items.len(), 1);
+        assert_eq!(
+            detail.items[0].eksemplar_id,
+            Some(e1),
+            "FIFO must pick the lowest-id available copy when no override is supplied"
+        );
+    }
+
+    #[test]
+    fn peminjaman_create_rejects_eksemplar_belonging_to_other_buku() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Sari", None);
+        let (b1, _e1) =
+            seed_buku_with_eksemplar(&conn, "B-001", "Buku Satu", "B-001-01", "tersedia");
+        let (_b2, e_other) =
+            seed_buku_with_eksemplar(&conn, "B-002", "Buku Dua", "B-002-01", "tersedia");
+
+        let err = peminjaman_create_inner(
+            &mut conn,
+            PeminjamanCreateInput {
+                anggota_id: aid,
+                buku_ids: vec![b1],
+                eksemplar_ids: Some(vec![e_other]),
+                tanggal_pinjam: Some("2024-01-01".into()),
+                tanggal_jatuh_tempo: Some("2024-01-08".into()),
+                catatan: None,
+            },
+        )
+        .expect_err("must reject eksemplar from another buku");
+        match err {
+            AppError::Validation(msg) => assert!(msg.contains("bukan milik buku")),
+            other => panic!("expected validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peminjaman_create_rejects_eksemplar_ids_length_mismatch() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Sari", None);
+        let (b1, _) =
+            seed_buku_with_eksemplar(&conn, "B-001", "Buku Satu", "B-001-01", "tersedia");
+
+        let err = peminjaman_create_inner(
+            &mut conn,
+            PeminjamanCreateInput {
+                anggota_id: aid,
+                buku_ids: vec![b1],
+                eksemplar_ids: Some(vec![1, 2]),
+                tanggal_pinjam: Some("2024-01-01".into()),
+                tanggal_jatuh_tempo: Some("2024-01-08".into()),
+                catatan: None,
+            },
+        )
+        .expect_err("must reject mismatched lengths");
+        match err {
+            AppError::Validation(msg) => assert!(msg.contains("sama panjang")),
+            other => panic!("expected validation error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
+++ b/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/components/ui/toast-manager';
 import { anggotaApi, type Anggota } from '@/lib/anggota';
+import { parseQrPayload } from '@/lib/kta';
 import {
   peminjamanApi,
   type ActiveLoanForEksemplar,
@@ -117,7 +118,13 @@ export function SirkulasiPage() {
 
   /**
    * Try to interpret the scanned text. Order:
-   * 1. Pinjam mode without anggota → look up `anggota_get_by_kode`.
+   * 1. Pinjam mode without anggota → first try the KTA QR payload
+   *    (`member:<id>`) printed by the KTA card flow, then fall back to
+   *    looking up the raw text via `anggota_get_by_kode`. The QR path is
+   *    what actually makes the webcam-printed KTA scannable —
+   *    `getByKode` only matches the `kode_anggota` column, so without
+   *    parsing the QR payload first the scan would fail with "unknown
+   *    code" even though the QR decoded fine (BUG-01).
    * 2. Resolve as eksemplar (always attempted second).
    * 3. Kembalikan mode → use `peminjaman_aktif_by_eksemplar`.
    */
@@ -126,6 +133,24 @@ export function SirkulasiPage() {
     if (!code) return;
 
     if (mode === 'pinjam' && !anggota) {
+      const memberId = parseQrPayload(code);
+      if (memberId !== null) {
+        try {
+          const a = await anggotaApi.get(memberId);
+          setAnggota(a);
+          showToast({
+            title: t('sirkulasi:toast.anggotaSet', { defaultValue: 'Anggota terpilih' }),
+            description: `${a.kodeAnggota} · ${a.nama}`,
+          });
+          beep('ok');
+          return;
+        } catch {
+          // Fall through — the QR was a member:<id> shape but the id
+          // didn't resolve (e.g. member was deleted). Try the kode
+          // path next; if that also fails the eksemplar branch will
+          // surface a clean "unknown code" toast.
+        }
+      }
       try {
         const a = await anggotaApi.getByKode(code);
         if (a) {
@@ -285,13 +310,16 @@ export function SirkulasiPage() {
     }
     setSubmitting(true);
     try {
-      // Backend `peminjaman_create` saat ini menerima `bukuIds`. Untuk
-      // kompatibilitas, kirim daftar bukuId — eksemplar otomatis akan
-      // dipilih oleh backend (FIFO bedasarkan id). Itu sudah cukup karena
-      // operator hanya butuh tahu eksemplar yg dipinjam = jumlah scan.
+      // Pass both bukuIds and the matching eksemplarIds so the backend
+      // records the exact physical copies that were scanned. Without
+      // the eksemplarIds override the backend silently picks the
+      // lowest-id available copy via FIFO, which can disagree with the
+      // barcode the operator actually scanned and break the later
+      // return flow (BUG-17).
       const detail = await peminjamanApi.create({
         anggotaId: anggota.id,
         bukuIds: usable.map((b) => b.eksemplar.bukuId),
+        eksemplarIds: usable.map((b) => b.eksemplar.eksemplarId),
         tanggalPinjam: todayIso(),
         tanggalJatuhTempo: plusDays(7),
       });
@@ -407,7 +435,7 @@ export function SirkulasiPage() {
             }}
           >
             <ShieldCheck className="mr-1.5 h-4 w-4" />
-            {t('sirkulasi:mode.pinjam', { defaultValue: 'Pinjam' })}
+            {t('sirkulasi:mode.pinjam', { defaultValue: 'Scan Anggota Pinjam' })}
           </Button>
           <Button
             variant={mode === 'kembalikan' ? 'default' : 'outline'}
@@ -418,7 +446,7 @@ export function SirkulasiPage() {
             }}
           >
             <Undo2 className="mr-1.5 h-4 w-4" />
-            {t('sirkulasi:mode.kembalikan', { defaultValue: 'Kembalikan' })}
+            {t('sirkulasi:mode.kembalikan', { defaultValue: 'Scan Kembalikan Pinjaman' })}
           </Button>
         </div>
       </div>

--- a/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
+++ b/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
@@ -160,8 +160,30 @@ export function useBarcodeScanner(
         throw new Error('Video element belum siap');
       }
 
-      controlsRef.current = await reader.decodeFromVideoDevice(
-        preferred ?? undefined,
+      // Ask the browser for a higher-resolution stream than the zxing
+      // default (which falls back to roughly 640×480 on most webcams).
+      // Code-128 barcodes printed at A4-label scale are too small for
+      // 480p to decode reliably — the user reports having to hold the
+      // book very close to the lens before the scan registers (BUG-18).
+      // 1280×720 doubles the linear pixel budget, restores reliable
+      // decoding at a normal arm's-length distance, and is supported by
+      // virtually every laptop/USB webcam on the market. The browser
+      // is free to fall back to the next-best size if 720p is not
+      // available — `ideal` is a soft constraint, not `exact`.
+      const videoConstraints: MediaTrackConstraints = preferred
+        ? {
+            deviceId: { exact: preferred },
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
+          }
+        : {
+            facingMode: { ideal: 'environment' },
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
+          };
+
+      controlsRef.current = await reader.decodeFromConstraints(
+        { audio: false, video: videoConstraints },
         video,
         (result: Result | undefined, err) => {
           if (result) {

--- a/apps/desktop/src/i18n/en/sirkulasi.json
+++ b/apps/desktop/src/i18n/en/sirkulasi.json
@@ -2,8 +2,8 @@
   "title": "Circulation (Webcam)",
   "subtitle": "Scan member and copy barcodes for fast loan/return processing. Shortcut: Ctrl+L.",
   "mode": {
-    "pinjam": "Loan",
-    "kembalikan": "Return"
+    "pinjam": "Scan Member Borrow",
+    "kembalikan": "Scan Return Loan"
   },
   "scanner": {
     "title": "Scanner",

--- a/apps/desktop/src/i18n/id/sirkulasi.json
+++ b/apps/desktop/src/i18n/id/sirkulasi.json
@@ -2,8 +2,8 @@
   "title": "Sirkulasi (Webcam)",
   "subtitle": "Pindai barcode anggota dan eksemplar untuk peminjaman/pengembalian cepat. Pintasan: Ctrl+L.",
   "mode": {
-    "pinjam": "Pinjam",
-    "kembalikan": "Kembalikan"
+    "pinjam": "Scan Anggota Pinjam",
+    "kembalikan": "Scan Kembalikan Pinjaman"
   },
   "scanner": {
     "title": "Pemindai",

--- a/apps/desktop/src/lib/peminjaman.ts
+++ b/apps/desktop/src/lib/peminjaman.ts
@@ -57,6 +57,16 @@ export interface PeminjamanListResult {
 export interface PeminjamanCreateInput {
   anggotaId: number;
   bukuIds: number[];
+  /**
+   * Optional per-row physical-copy override paired with `bukuIds`. When
+   * provided, the i-th `eksemplarId` is the exact `eksemplar.id` to mark
+   * as borrowed for the i-th `bukuId`. The Sirkulasi (webcam) flow uses
+   * this so the scanned barcode is the one actually recorded on-loan —
+   * without it, the backend silently picks the lowest-id available copy
+   * via FIFO and the operator's later return scan can fail to find an
+   * active loan.
+   */
+  eksemplarIds?: number[];
   tanggalPinjam?: string;
   tanggalJatuhTempo?: string;
   catatan?: string;


### PR DESCRIPTION
## Summary

PR A of the v1.0.7 bugs batch (handoff doc PR #119). Fixes the three top-priority webcam circulation issues + the requested button rename:

- **BUG-01** (Sirkulasi scan KTA → "Kode tidak dikenali"): `handleScan` now parses the QR payload via `parseQrPayload` first and looks the member up by id when the payload matches the `member:<id>` shape printed on the KTA card. The previous code only ran `getByKode` against the raw QR text, which never matched the `kode_anggota` column and failed even when the QR decoded perfectly. Falls back to the kode-anggota lookup for legacy/manual codes.

- **BUG-17** (return scan "Tidak ada peminjaman aktif" even though the loan is open): root cause was `peminjaman_create` silently picking the lowest-id available eksemplar via FIFO instead of the copy the operator actually scanned, so the later return scan looked for a `kode_eksemplar` that was never recorded as on-loan. Backend now accepts an optional `eksemplar_ids` override (paired with `buku_ids`) and validates ownership + status before booking. The Sirkulasi page passes the scanned `eksemplarIds` directly. `peminjaman_create` is split into a thin tauri wrapper + `peminjaman_create_inner` so the new behaviour is covered by 4 new Rust unit tests (specific copy booked, FIFO fallback, wrong-buku rejection, length-mismatch rejection).

- **BUG-18** (scanner accuracy / barcode hard to read): switched zxing from `decodeFromVideoDevice` to `decodeFromConstraints` with a `1280×720` ideal resolution (and `facingMode=environment` when no camera is pinned). The previous default fell back to roughly 640×480, which is too low to decode Code-128 barcodes printed at typical book-label scale at arm's-length distance.

- **FEAT-07** (rename buttons): "Pinjam" → "Scan Anggota Pinjam" and "Kembalikan" → "Scan Kembalikan Pinjaman" in `id` / `en` (with matching default-value strings on the in-component i18n calls).

Gates run locally before push: `pnpm typecheck`, `pnpm lint`, `pnpm i18n:lint`, `pnpm test` (264 vitest passing), `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (116 tests passing — was 112; added 4 new for the override path).

Refs: `.devin/handoff/v1.0.7-bugs-batch/BUGS.md` BUG-01, BUG-17, BUG-18, FEAT-07.

## Review & Testing Checklist for Human

Risk: **yellow** — backend signature for `peminjaman_create` is extended (additive, optional field) and the webcam flow is reworked end-to-end. Recommend the following before merging:

- [ ] **BUG-01 manual smoke**: print a fresh KTA from the Anggota page, open Sirkulasi (Webcam) in Pinjam mode, scan the QR. Expect the "Anggota terpilih" toast with the right name + kode (no longer "Kode tidak dikenali"). Bonus: also try the legacy path by typing the kode (e.g. `A0001`) into the manual input — should still resolve.
- [ ] **BUG-17 manual smoke**: with a buku that has ≥ 2 eksemplar (e.g. `B-001-01` and `B-001-02`), scan the *second* copy in Pinjam mode and save. Then in Kembalikan mode scan that same `B-001-02` barcode — expect the loan card to appear (previously this returned "Tidak ada peminjaman aktif"). Confirm that the eksemplar listed in the loan card is the one you scanned.
- [ ] **BUG-18 manual smoke**: in Sirkulasi (Webcam), check the live preview — it should be visibly higher resolution than before (laptop webcams usually expose 720p). Try scanning a Code-128 book-label barcode at typical arm's-length distance; it should pick up faster than v1.0.6. If your camera does not support 720p the browser will silently fall back, so this should not regress anyone.
- [ ] **FEAT-07 visual check**: button labels in the Sirkulasi header read "Scan Anggota Pinjam" / "Scan Kembalikan Pinjaman" in Indonesian and "Scan Member Borrow" / "Scan Return Loan" in English.

Recommended test plan: run the Sirkulasi page end-to-end in both modes against a freshly seeded DB. There is a `smoke-test-v2` skill in `.agents/skills/` that walks through the standard fresh-install flow and now also covers these scenarios.

### Notes

- The `peminjaman_create` Tauri command keeps the old `bukuIds`-only signature working — `eksemplarIds` is optional. Existing callers (PeminjamanForm, tests) are unchanged.
- The Pinjam flow's previous comment ("Backend `peminjaman_create` saat ini menerima `bukuIds`. Untuk kompatibilitas, kirim daftar bukuId — eksemplar otomatis akan dipilih oleh backend (FIFO bedasarkan id). Itu sudah cukup karena operator hanya butuh tahu eksemplar yg dipinjam = jumlah scan.") was wrong: it WAS NOT enough, because the operator's later return scan needs to match the exact copy. That comment is replaced inline.
- BUG-09/10 (Aturan Peminjaman maks-buku not synced + raw-JSON toast) and FEAT-08 (denda quick-input) are intentionally out of scope here — they are PR B in the handoff plan.
- Handoff PROGRESS.md will be updated to mark these four items as `IN_PR` once this PR number is confirmed.
