### PR TITLE
fix(peminjaman): align Aturan Peminjaman defaults + clean toasts + denda quick-input (PR B of v1.0.7 batch)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/peminjaman.rs
+++ b/apps/desktop/src-tauri/src/commands/peminjaman.rs
@@ -13,9 +13,18 @@ use tauri::State;
 use crate::error::{AppError, AppResult};
 use crate::AppState;
 
+// Defaults must match `apps/desktop/src/lib/settings.ts::DEFAULT_LOAN_RULES`.
+// When they drift, the frontend Aturan Peminjaman page shows one number
+// while the backend enforces another, which is exactly how
+// "maksimum 3" became "block at 2" in v1.0.6 (BUG-09 in the v1.0.7
+// batch). The Settings page seeds these into the `settings` table on
+// first save, but until then the backend falls back to these constants —
+// so they MUST agree with the frontend.
 const DEFAULT_LAMA_PINJAM_HARI: i64 = 7;
 const DEFAULT_DENDA_PER_HARI: i64 = 500;
-const DEFAULT_MAKS_PINJAM: i64 = 2;
+const DEFAULT_MAKS_PINJAM: i64 = 3;
+/// Minggu (`0`) is the default hari libur, matching frontend.
+const DEFAULT_HARI_LIBUR: &[u32] = &[0];
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -252,6 +261,62 @@ fn setting_int(conn: &rusqlite::Connection, key: &str, default: i64) -> i64 {
         .unwrap_or(None);
     row.and_then(|v| v.trim().parse::<i64>().ok())
         .unwrap_or(default)
+}
+
+/// Read `transaksi.hari_libur` from settings as a comma-separated list of
+/// 0..=6 weekday indices (`0=Minggu .. 6=Sabtu`, matching JS
+/// `Date.getDay()`). Falls back to `DEFAULT_HARI_LIBUR` when the setting
+/// is missing or unparseable.
+fn setting_hari_libur(conn: &rusqlite::Connection) -> Vec<u32> {
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'transaksi.hari_libur'",
+            [],
+            |r| r.get(0),
+        )
+        .optional()
+        .unwrap_or(None);
+    let Some(raw) = raw else {
+        return DEFAULT_HARI_LIBUR.to_vec();
+    };
+    let parsed: Vec<u32> = raw
+        .split(',')
+        .filter_map(|s| s.trim().parse::<u32>().ok())
+        .filter(|d| *d <= 6)
+        .collect();
+    if parsed.is_empty() {
+        DEFAULT_HARI_LIBUR.to_vec()
+    } else {
+        parsed
+    }
+}
+
+/// Count days strictly *after* `jatuh_tempo` up to and including `today`,
+/// skipping any weekday whose `Datelike::weekday().num_days_from_sunday()`
+/// matches a value in `hari_libur` (0=Minggu..6=Sabtu).
+///
+/// Returns 0 when `today <= jatuh_tempo`. The Aturan Peminjaman tab
+/// (`apps/desktop/src/lib/settings.ts`) describes this skip behaviour;
+/// the previous backend code multiplied raw calendar days by
+/// `denda_per_hari` and ignored hari_libur entirely (BUG-09 audit
+/// finding in the v1.0.7 batch).
+fn billable_late_days(jatuh_tempo: NaiveDate, today: NaiveDate, hari_libur: &[u32]) -> i64 {
+    use chrono::Datelike;
+    if today <= jatuh_tempo {
+        return 0;
+    }
+    let mut day = jatuh_tempo;
+    let mut count = 0_i64;
+    while day < today {
+        // Each iteration advances to the *next* day, then counts it if
+        // not a holiday weekday.
+        day = day.succ_opt().expect("date overflow");
+        let dow = day.weekday().num_days_from_sunday();
+        if !hari_libur.contains(&dow) {
+            count += 1;
+        }
+    }
+    count
 }
 
 fn next_nomor_pinjam(conn: &rusqlite::Connection) -> AppResult<String> {
@@ -772,6 +837,7 @@ pub fn peminjaman_kembalikan(
         .ok_or_else(|| AppError::NotFound(format!("peminjaman id={}", input.peminjaman_id)))?;
 
     let denda_per_hari = setting_int(&conn, "transaksi.denda_per_hari", DEFAULT_DENDA_PER_HARI);
+    let hari_libur = setting_hari_libur(&conn);
     let today = chrono::Local::now().date_naive();
     let bayar = input.bayar.unwrap_or(0).max(0);
 
@@ -801,7 +867,7 @@ pub fn peminjaman_kembalikan(
             )));
         }
         let jt = parse_date(&tgl_jt)?;
-        let hari_telat = (today - jt).num_days().max(0);
+        let hari_telat = billable_late_days(jt, today, &hari_libur);
         let denda = hari_telat * denda_per_hari;
         total_denda += denda;
 
@@ -1580,5 +1646,71 @@ mod tests {
         .expect("seed item");
         let active = peminjaman_aktif_by_eksemplar_inner(&conn, "B-001-01").expect("query");
         assert!(active.is_none(), "returned items must not be reported as active");
+    }
+
+    // -----------------------------------------------------------------
+    // Aturan Peminjaman audit (BUG-09 in v1.0.7 batch).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn default_maks_pinjam_matches_frontend_default() {
+        // The frontend `DEFAULT_LOAN_RULES.maksBukuPinjam` is 3 (see
+        // apps/desktop/src/lib/settings.ts). When this constant drifts,
+        // a fresh install where the user never opens Aturan Peminjaman
+        // shows "max 3 buku" in the UI but blocks the 3rd loan in the
+        // backend — exactly the BUG-09 report.
+        assert_eq!(DEFAULT_MAKS_PINJAM, 3);
+    }
+
+    #[test]
+    fn setting_hari_libur_falls_back_to_default_when_missing() {
+        let conn = setup_db();
+        assert_eq!(setting_hari_libur(&conn), DEFAULT_HARI_LIBUR.to_vec());
+    }
+
+    #[test]
+    fn setting_hari_libur_parses_csv_and_clamps_invalid_entries() {
+        let conn = setup_db();
+        conn.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('transaksi.hari_libur', '0,6,99,abc')",
+            [],
+        ).expect("seed setting");
+        // 99 and "abc" must be ignored; 0 (Sun) and 6 (Sat) kept.
+        assert_eq!(setting_hari_libur(&conn), vec![0, 6]);
+    }
+
+    #[test]
+    fn billable_late_days_returns_zero_when_returned_on_or_before_due() {
+        let due = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+        assert_eq!(billable_late_days(due, due, &[0]), 0);
+        let early = NaiveDate::from_ymd_opt(2025, 1, 9).unwrap();
+        assert_eq!(billable_late_days(due, early, &[0]), 0);
+    }
+
+    #[test]
+    fn billable_late_days_skips_sunday_when_configured() {
+        // Due 2025-01-10 (Friday). Today 2025-01-13 (Monday).
+        // Calendar diff = 3 days (Sat, Sun, Mon). With hari_libur=[0]
+        // (Sunday), billable late days = 2.
+        let due = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+        let today = NaiveDate::from_ymd_opt(2025, 1, 13).unwrap();
+        assert_eq!(billable_late_days(due, today, &[0]), 2);
+    }
+
+    #[test]
+    fn billable_late_days_counts_every_day_when_no_holidays_configured() {
+        let due = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+        let today = NaiveDate::from_ymd_opt(2025, 1, 20).unwrap();
+        assert_eq!(billable_late_days(due, today, &[]), 10);
+    }
+
+    #[test]
+    fn billable_late_days_skips_full_weekends_when_both_days_configured() {
+        // Span Mon 2025-01-13 (due) → Mon 2025-01-20 (today). Calendar
+        // diff = 7. Hari libur = [0, 6] (Sun + Sat). The span includes
+        // exactly one Sat (1-18) and one Sun (1-19), so billable = 5.
+        let due = NaiveDate::from_ymd_opt(2025, 1, 13).unwrap();
+        let today = NaiveDate::from_ymd_opt(2025, 1, 20).unwrap();
+        assert_eq!(billable_late_days(due, today, &[0, 6]), 5);
     }
 }

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -32,15 +32,24 @@ impl From<tauri::Error> for AppError {
 
 impl Serialize for AppError {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let code = match self {
-            AppError::InvalidCredentials => "invalid_credentials",
-            AppError::InactiveAccount => "inactive",
-            AppError::NotAuthenticated => "not_authenticated",
-            AppError::NotFound(_) => "not_found",
-            AppError::Validation(_) => "validation",
-            _ => "internal",
+        // Pair each variant with the user-facing message *without* the
+        // `validation: ` / `not found: ` prefix that the `Display` impl
+        // injects. The frontend's `formatTauriError` shows `message`
+        // verbatim, so leaking that prefix duplicates information already
+        // expressed by `code` and produced toasts like
+        // "validation: melebihi maksimal 2 buku per anggota" (BUG-10 in
+        // the v1.0.7 batch).
+        let (code, msg): (&str, String) = match self {
+            AppError::InvalidCredentials => ("invalid_credentials", "Kredensial tidak valid".into()),
+            AppError::InactiveAccount => ("inactive", "Akun tidak aktif".into()),
+            AppError::NotAuthenticated => ("not_authenticated", "Belum login".into()),
+            AppError::NotFound(m) => ("not_found", m.clone()),
+            AppError::Validation(m) => ("validation", m.clone()),
+            AppError::Internal(m) => ("internal", m.clone()),
+            AppError::Db(e) => ("internal", e.to_string()),
+            AppError::Io(e) => ("internal", e.to_string()),
+            AppError::Bcrypt(e) => ("internal", e.to_string()),
         };
-        let msg = self.to_string();
         let mut state = serializer.serialize_struct("AppError", 2)?;
         use serde::ser::SerializeStruct;
         state.serialize_field("code", code)?;

--- a/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
+++ b/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
@@ -9,8 +9,19 @@ import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 import { useToast } from '@/components/ui/toast-manager';
 import { calculateDenda, peminjamanApi, type PeminjamanDetail, type PeminjamanRow } from '@/lib/peminjaman';
 import { formatTauriError } from '@/lib/errors';
+import { DEFAULT_LOAN_RULES, settingsApi, type LoanRules } from '@/lib/settings';
 
-const DENDA_PER_HARI = 500;
+/**
+ * Multipliers for the denda quick-input buttons (FEAT-08 in the v1.0.7
+ * batch). The label and value derive from the live `dendaPerHari`
+ * setting, so changing Aturan Peminjaman to e.g. 1500 turns the buttons
+ * into "Rp 1.500 / Rp 3.000 / Rp 4.500" automatically.
+ */
+const DENDA_QUICK_MULTIPLIERS: readonly number[] = [1, 2, 3];
+
+function formatRupiah(value: number): string {
+  return value.toLocaleString('id-ID');
+}
 
 function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
@@ -28,6 +39,23 @@ export function PengembalianPage() {
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [bayar, setBayar] = useState<string>('0');
   const [submitting, setSubmitting] = useState(false);
+  const [loanRules, setLoanRules] = useState<LoanRules>(DEFAULT_LOAN_RULES);
+
+  useEffect(() => {
+    let cancel = false;
+    settingsApi
+      .getLoanRules()
+      .then((rules) => {
+        if (!cancel) setLoanRules(rules);
+      })
+      .catch(() => {
+        // Settings unavailable (mock/offline) — fall through with the
+        // baked-in defaults so the page is still usable.
+      });
+    return () => {
+      cancel = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancel = false;
@@ -77,8 +105,12 @@ export function PengembalianPage() {
 
   const dendaPreview = useMemo(() => {
     if (!detail) return { hariTerlambat: 0, denda: 0 };
-    return calculateDenda(detail.header.tanggalJatuhTempo, todayIso(), DENDA_PER_HARI);
-  }, [detail]);
+    return calculateDenda(
+      detail.header.tanggalJatuhTempo,
+      todayIso(),
+      loanRules.dendaPerHari,
+    );
+  }, [detail, loanRules.dendaPerHari]);
 
   function toggle(itemId: number): void {
     const next = new Set(selected);
@@ -273,6 +305,30 @@ export function PengembalianPage() {
                           min="0"
                           data-testid="pengembalian-bayar"
                         />
+                        <div
+                          className="mt-2 flex flex-wrap gap-1.5"
+                          data-testid="pengembalian-bayar-quick"
+                        >
+                          {DENDA_QUICK_MULTIPLIERS.map((mult) => {
+                            const value = loanRules.dendaPerHari * mult;
+                            return (
+                              <Button
+                                key={mult}
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                onClick={() => setBayar(String(value))}
+                                data-testid={`pengembalian-bayar-quick-${mult}x`}
+                              >
+                                {t('peminjaman:pengembalian.bayarQuick', {
+                                  defaultValue: 'Rp {{value}}',
+                                  value: formatRupiah(value),
+                                })}
+                              </Button>
+                            );
+                          })}
+                        </div>
                       </div>
                       <div className="flex items-end">
                         <Button

--- a/apps/desktop/src/i18n/en/peminjaman.json
+++ b/apps/desktop/src/i18n/en/peminjaman.json
@@ -110,7 +110,8 @@
     "detail": "Return Detail",
     "selectFirst": "Select a loan from search results",
     "allReturned": "All items already returned",
-    "dendaPreview": "{{count}} days late · Rp {{denda}}"
+    "dendaPreview": "{{count}} days late · Rp {{denda}}",
+    "bayarQuick": "Rp {{value}}"
   },
   "breadcrumb": {
     "new": "New Loan",

--- a/apps/desktop/src/i18n/id/peminjaman.json
+++ b/apps/desktop/src/i18n/id/peminjaman.json
@@ -110,7 +110,8 @@
     "detail": "Detail Pengembalian",
     "selectFirst": "Pilih peminjaman dari hasil pencarian",
     "allReturned": "Semua item sudah dikembalikan",
-    "dendaPreview": "Terlambat {{count}} hari · Rp {{denda}}"
+    "dendaPreview": "Terlambat {{count}} hari · Rp {{denda}}",
+    "bayarQuick": "Rp {{value}}"
   },
   "breadcrumb": {
     "new": "Pinjam Baru",

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -2,15 +2,15 @@
  * Tauri command error formatter.
  *
  * Tauri's `invoke()` rejects with whatever the Rust side returned via
- * `serde_json`, NOT with an `Error` instance. Our backend returns
- * `AppError` which serializes as an externally-tagged enum object such as
- * `{ "Validation": "tidak ada eksemplar tersedia ..." }`. The naive fallback
- * `String(err)` on that object yields the literal string `"[object Object]"`,
- * which is what users were seeing in toasts (BUG-002).
+ * `serde_json`, NOT with an `Error` instance. Our backend serialises
+ * `AppError` as a `{ code, message }` struct (see `error.rs`), so the
+ * happy path is to surface `message` verbatim. Earlier revisions used
+ * the externally-tagged enum shape `{ "Validation": "..." }` and a few
+ * legacy callers may still pass that — both are handled.
  *
- * `formatTauriError` extracts the human-readable message from the known
- * variants while still gracefully handling plain `Error` instances and
- * strings (used by frontend-only paths like the import dialogs).
+ * Without this normalisation users saw the raw JSON in toasts (BUG-002
+ * and BUG-10 in the v1.0.7 batch), e.g.
+ * `{"code":"validation","message":"melebihi maksimal 2 buku ..."}`.
  */
 
 const APP_ERROR_KEYS = ['Validation', 'NotFound', 'Conflict', 'Internal'] as const;
@@ -19,17 +19,32 @@ export type AppErrorKey = (typeof APP_ERROR_KEYS)[number];
 
 export type TauriAppError = { [K in AppErrorKey]?: string };
 
+/** Strip `validation: ` / `not found: ` etc. that older Display-based
+ *  serialisations leaked into the message. Keep stripping idempotent so
+ *  the new `{code,message}` shape (which already has a clean message) is
+ *  unaffected. */
+function stripLegacyPrefix(msg: string): string {
+  return msg.replace(/^(validation|not found|internal|conflict):\s*/i, '');
+}
+
 export function formatTauriError(err: unknown): string {
   if (err instanceof Error) return err.message;
-  if (typeof err === 'string') return err;
+  if (typeof err === 'string') return stripLegacyPrefix(err);
   if (err && typeof err === 'object') {
     const record = err as Record<string, unknown>;
+
+    // New shape: `{ code, message }` from `AppError::serialize`.
+    if (typeof record.message === 'string' && typeof record.code === 'string') {
+      return stripLegacyPrefix(record.message);
+    }
+
+    // Legacy externally-tagged shape: `{ Validation: "..." }`.
     for (const key of APP_ERROR_KEYS) {
       const v = record[key];
-      if (typeof v === 'string') return v;
+      if (typeof v === 'string') return stripLegacyPrefix(v);
     }
-    // Fall back to JSON serialization so at least the user sees the shape
-    // instead of `[object Object]`.
+
+    // Last resort: show the JSON instead of `[object Object]`.
     try {
       return JSON.stringify(err);
     } catch {

--- a/apps/desktop/tests/unit/errors.test.ts
+++ b/apps/desktop/tests/unit/errors.test.ts
@@ -56,4 +56,38 @@ describe('formatTauriError', () => {
     const v = formatTauriError({ Validation: 'expected', Internal: 'leak' });
     expect(v).toBe('expected');
   });
+
+  // BUG-10 in the v1.0.7 batch: the Rust backend serialises `AppError` via
+  // `error.rs` as `{ code, message }` (NOT the externally-tagged enum shape),
+  // so the formatter must accept the modern shape too — otherwise toasts
+  // surfaced the raw JSON to the user.
+
+  it('extracts message from the {code,message} struct shape', () => {
+    expect(
+      formatTauriError({
+        code: 'validation',
+        message: 'melebihi maksimal 3 buku per anggota (saat ini 2)',
+      }),
+    ).toBe('melebihi maksimal 3 buku per anggota (saat ini 2)');
+  });
+
+  it('strips a legacy "validation: " Display prefix from the message', () => {
+    // Older builds serialised via Display, leaking the `validation: ` prefix
+    // into the message. Be tolerant of that mid-flight upgrade.
+    expect(
+      formatTauriError({
+        code: 'validation',
+        message: 'validation: kode_buku required',
+      }),
+    ).toBe('kode_buku required');
+  });
+
+  it('strips the legacy prefix from externally-tagged variants too', () => {
+    expect(formatTauriError({ Validation: 'validation: x' })).toBe('x');
+  });
+
+  it('does not mistake an arbitrary {message} object for an AppError', () => {
+    // Without `code`, the new branch must not fire.
+    expect(formatTauriError({ message: 'boom' })).toBe('{"message":"boom"}');
+  });
 });


### PR DESCRIPTION
## Summary

PR B of the v1.0.7 bugs batch — Peminjaman & Pengembalian. Three items:

### BUG-09 — Aturan Peminjaman tidak benar-benar dipakai backend
- **Root cause #1 (maks_buku):** backend `DEFAULT_MAKS_PINJAM` adalah `2`, tapi frontend `DEFAULT_LOAN_RULES.maksBukuPinjam` adalah `3`. Pada fresh install (user belum pernah klik Simpan di Aturan Peminjaman), UI menampilkan "3" sementara backend menolak peminjaman ketiga dengan toast *"melebihi maksimal 2 buku per anggota"*. Konstanta sekarang `3` dan ada regression test yang assert konstanta itu sama dengan default frontend.
- **Audit finding (hari_libur):** sebelumnya backend menghitung `hari_telat = (today - jatuh_tempo).num_days()` — murni kalender, tidak pernah membaca `transaksi.hari_libur` walau setting tersedia di Aturan Peminjaman. Sekarang ada `setting_hari_libur()` + `billable_late_days()` yang skip weekday yang dikonfigurasi user (default `[0]` Minggu, sama dengan frontend). Enam unit test baru meng-cover edge cases (early return, Sunday-only, no holidays, full weekend skip, CSV parsing).
- **Audit finding (lama_pinjam, denda_per_hari):** sudah benar — dibaca via `setting_int("transaksi.lama_pinjam_hari", …)` dan `setting_int("transaksi.denda_per_hari", …)`, dan default-nya match frontend (7 hari, 500 rupiah). Tidak butuh perubahan.

### BUG-10 — Toast error tampil raw JSON
- `AppError::Serialize` dulu pakai `self.to_string()` (Display impl), yang meng-inject prefix `validation: ` / `not found: ` ke field `message`. Hasilnya: user melihat `{"code":"validation","message":"validation: melebihi maksimal …"}`. Sekarang serialize meng-output `String` mentah dari masing-masing varian.
- `formatTauriError` di-update untuk mengenali shape `{ code, message }` (yang aktual dipakai backend) dan tetap backward-compatible dengan shape lama `{ Validation: "…" }` (dipakai mock paths). Prefix lama yang tersisa di-strip secara idempoten. 4 vitest case baru.

### FEAT-08 — Quick-input denda 1×/2×/3×
- `PengembalianPage` dulu hardcode `DENDA_PER_HARI = 500` baik untuk preview denda maupun field "Bayar Denda" (jadi UI ngga reflect kalau admin ubah Aturan Peminjaman). Sekarang load `LoanRules` dari `settingsApi` saat mount, dan denda preview pakai nilai `dendaPerHari` aktual.
- Di bawah field "Bayar Denda" sekarang ada 3 tombol cepat 1×/2×/3× yang otomatis kalkulasi dari setting:
  - Denda 1.000 → `[Rp 1.000] [Rp 2.000] [Rp 3.000]`
  - Denda 1.500 → `[Rp 1.500] [Rp 3.000] [Rp 4.500]`
  - User masih bisa override manual.
- I18n key baru `peminjaman:pengembalian.bayarQuick` (id + en parity).

## Review & Testing Checklist for Human

Yellow risk — backend `Serialize` impl untuk `AppError` di-rewrite (semua toast lewat sini), `peminjaman_kembalikan` denda calculation diganti, dan `PengembalianPage` ada state baru.

- [ ] Buka Aturan Peminjaman → set Maksimum Buku = `3` → coba pinjam **3 buku** ke satu anggota → harusnya berhasil (bukan toast "maksimal 2"). Ulangi dengan setting = `5` untuk konfirmasi tidak ter-cap di 3.
- [ ] Trigger validation error apapun (mis. pinjam 4 buku padahal max 3) dan verifikasi toast hanya menampilkan kalimat user-friendly tanpa `{"code":...}` JSON.
- [ ] Set Denda per Hari = `1500`, buka halaman Pengembalian, pilih peminjaman aktif → cek 3 tombol cepat menampilkan `Rp 1.500 / Rp 3.000 / Rp 4.500`. Klik salah satu → field Bayar Denda terisi otomatis.
- [ ] (Optional) Kembalikan peminjaman terlambat dengan `hari_libur=[0]` (Minggu): denda harus skip hari Minggu di rentang keterlambatan (mis. terlambat 7 hari kalender yang masuk 1 Minggu → denda dihitung 6 hari).
- [ ] Verify CI: lint, typecheck, i18n parity, vitest (268), cargo clippy `-D warnings`, cargo test (119).

## Test Plan
1. Build aplikasi (`pnpm tauri:dev` atau `pnpm dev`).
2. Settings → Aturan Peminjaman → ubah Maksimum buku ke 5, Denda per hari 1500, Hari Libur centang Minggu + Sabtu, klik Simpan.
3. Buat anggota baru, pinjam 5 buku → verifikasi sukses.
4. Coba pinjam buku ke-6 → verifikasi toast "melebihi maksimal 5 buku per anggota (saat ini 5)" — bukan raw JSON.
5. Buka Pengembalian → pilih peminjaman → verifikasi tombol cepat: `Rp 1.500 / Rp 3.000 / Rp 4.500`.
6. Klik tombol `Rp 3.000` → field Bayar Denda terisi `3000`.
7. (Optional) Set tanggal_jatuh_tempo ke masa lalu manual via DB browser, kembalikan peminjaman, verifikasi denda yang tercatat di kas meng-skip hari Sabtu + Minggu dalam rentang keterlambatan.

### Notes
- Bagian dari batch v1.0.7. PR berikutnya per `.devin/handoff/v1.0.7-bugs-batch/WORKFLOW.md`:
  - PR C: KTA (BUG-02, BUG-06, FEAT-03, FEAT-04)
  - PR D: UI/Layout polish (BUG-05, BUG-12, BUG-14, BUG-16, FEAT-13, FEAT-15)
  - PR E: Dashboard quote rotation (FEAT-11)
