### PR TITLE
feat(layout): UI polish PR D — sticky settings sidebar, padded cetak pages, manual scroll-FAB, label exports folder (BUG-05, BUG-12, BUG-14, BUG-16, FEAT-13, FEAT-15)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/label_buku_export.rs
+++ b/apps/desktop/src-tauri/src/commands/label_buku_export.rs
@@ -1,0 +1,144 @@
+//! Persists Cetak Label & Barcode output as PDF under
+//! `<app_data>/exports/labels/` and exposes a cross-platform helper for
+//! opening that folder in the OS file manager. Mirrors `kta_export.rs`
+//! exactly so the two flows behave identically; the only differences
+//! are the destination subfolder and the filename prefix. Frontend
+//! builds the PDF bytes itself (jsPDF) and hands the blob in as
+//! `bytes: Vec<u8>`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use chrono::Local;
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+use crate::error::{AppError, AppResult};
+
+/// Hard cap so a runaway export can't fill the user's disk. Generous enough
+/// for batches of every eksemplar in a school library — labels are tiny but
+/// some libraries print thousands at a time.
+const MAX_PDF_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// Same `%PDF-` magic check as `kta_export.rs`.
+const PDF_MAGIC: &[u8] = b"%PDF-";
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelBukuExportResult {
+    pub filename: String,
+    pub abs_path: String,
+    pub dir_abs_path: String,
+}
+
+fn exports_dir(app: &AppHandle) -> AppResult<PathBuf> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::Internal(format!("gagal resolve app_data_dir: {e}")))?;
+    let dir = base.join("exports").join("labels");
+    if !dir.exists() {
+        fs::create_dir_all(&dir).map_err(|e| {
+            AppError::Internal(format!(
+                "gagal membuat folder exports {}: {e}",
+                dir.to_string_lossy()
+            ))
+        })?;
+    }
+    Ok(dir)
+}
+
+fn validate_pdf_bytes(bytes: &[u8]) -> AppResult<()> {
+    if bytes.is_empty() {
+        return Err(AppError::Validation("payload PDF kosong".into()));
+    }
+    if bytes.len() > MAX_PDF_BYTES {
+        return Err(AppError::Validation(format!(
+            "payload terlalu besar ({} bytes, maks {} bytes)",
+            bytes.len(),
+            MAX_PDF_BYTES
+        )));
+    }
+    if !bytes.starts_with(PDF_MAGIC) {
+        return Err(AppError::Validation(
+            "payload bukan PDF yang valid (header %PDF- tidak ditemukan)".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn generate_filename(now: chrono::DateTime<Local>) -> String {
+    let stamp = now.format("%Y%m%d-%H%M%S").to_string();
+    format!("label-buku-{stamp}.pdf")
+}
+
+#[tauri::command]
+pub fn label_buku_export_pdf(app: AppHandle, bytes: Vec<u8>) -> AppResult<LabelBukuExportResult> {
+    validate_pdf_bytes(&bytes)?;
+    let dir = exports_dir(&app)?;
+    let filename = generate_filename(Local::now());
+    let dest = dir.join(&filename);
+    fs::write(&dest, &bytes)
+        .map_err(|e| AppError::Internal(format!("gagal menulis PDF: {e}")))?;
+
+    Ok(LabelBukuExportResult {
+        filename,
+        abs_path: dest.to_string_lossy().into_owned(),
+        dir_abs_path: dir.to_string_lossy().into_owned(),
+    })
+}
+
+#[tauri::command]
+pub fn label_buku_open_exports_folder(app: AppHandle) -> AppResult<String> {
+    let dir = exports_dir(&app)?;
+    opener::open(&dir).map_err(|e| {
+        AppError::Internal(format!(
+            "gagal membuka folder {}: {e}",
+            dir.to_string_lossy()
+        ))
+    })?;
+    Ok(dir.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_payload() {
+        let err = validate_pdf_bytes(&[]).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn rejects_oversize_payload() {
+        let big = vec![b'%'; MAX_PDF_BYTES + 1];
+        let err = validate_pdf_bytes(&big).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn rejects_payload_without_pdf_magic() {
+        let bogus = b"<html>not a pdf</html>".to_vec();
+        let err = validate_pdf_bytes(&bogus).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    #[test]
+    fn accepts_minimal_pdf_header() {
+        validate_pdf_bytes(b"%PDF-1.7\nminimal").unwrap();
+    }
+
+    #[test]
+    fn filename_pattern_is_label_date_time() {
+        let fixed = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0)
+            .expect("timestamp")
+            .with_timezone(&Local);
+        let name = generate_filename(fixed);
+        assert!(name.starts_with("label-buku-"), "{name}");
+        assert!(name.ends_with(".pdf"), "{name}");
+        let stem = &name["label-buku-".len()..name.len() - ".pdf".len()];
+        // 8 (date) + 1 (dash) + 6 (time) = 15
+        assert_eq!(stem.len(), 15, "{stem}");
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod kta;
 pub mod kta_export;
 pub mod kunjungan;
 pub mod label_buku;
+pub mod label_buku_export;
 pub mod laporan;
 pub mod master_data;
 pub mod peminjaman;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -180,6 +180,8 @@ pub fn run() {
             commands::label_buku::label_buku_template_update,
             commands::label_buku::label_buku_template_delete,
             commands::label_buku::label_buku_template_set_default,
+            commands::label_buku_export::label_buku_export_pdf,
+            commands::label_buku_export::label_buku_open_exports_folder,
             commands::settings::settings_get_many,
             commands::settings::settings_set_many,
             commands::settings::settings_users_list,

--- a/apps/desktop/src/components/layout/Header.tsx
+++ b/apps/desktop/src/components/layout/Header.tsx
@@ -171,16 +171,16 @@ export function Header() {
           type="button"
           onClick={() => setSearchOpen(true)}
           aria-label={t('common:globalSearch.title', { defaultValue: 'Pencarian Global' })}
-          className="border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground hidden h-9 w-64 items-center gap-2 rounded-md border px-3 text-sm transition-colors md:flex"
+          className="border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground hidden h-9 w-64 min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md border px-3 text-sm transition-colors md:flex lg:w-72 xl:w-80"
           data-testid="header-search"
         >
           <Search className="h-4 w-4 shrink-0" />
-          <span className="flex-1 text-left">
+          <span className="min-w-0 flex-1 truncate text-left">
             {t('common:globalSearch.placeholder', {
               defaultValue: 'Cari anggota, buku, peminjaman…',
             })}
           </span>
-          <kbd className="border-border bg-muted rounded border px-1.5 py-0.5 font-mono text-[10px]">
+          <kbd className="border-border bg-muted shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px]">
             ⌃K
           </kbd>
         </button>

--- a/apps/desktop/src/features/kta/CetakKtaPage.tsx
+++ b/apps/desktop/src/features/kta/CetakKtaPage.tsx
@@ -186,7 +186,7 @@ export function CetakKtaPage() {
   };
 
   return (
-    <div className="space-y-6" data-testid="cetak-kta-page">
+    <div className="flex flex-col gap-6 p-6" data-testid="cetak-kta-page">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold">{t('kta:cetakTitle', 'Cetak KTA')}</h1>

--- a/apps/desktop/src/features/label-buku/CetakLabelPage.tsx
+++ b/apps/desktop/src/features/label-buku/CetakLabelPage.tsx
@@ -46,6 +46,10 @@ export function CetakLabelPage() {
   const [search, setSearch] = useState('');
   const [printing, setPrinting] = useState(false);
   const [savingPdf, setSavingPdf] = useState(false);
+  const [openingFolder, setOpeningFolder] = useState(false);
+  const [lastExport, setLastExport] = useState<{ filename: string; dirAbsPath: string } | null>(
+    null,
+  );
 
   useEffect(() => {
     void (async () => {
@@ -222,24 +226,11 @@ export function CetakLabelPage() {
         return;
       }
       const bytes = await buildLabelBukuPdfBytes({ layout, items, identity });
-      const stamp = new Date()
-        .toISOString()
-        .replace(/[-:T]/g, '')
-        .replace(/\..+$/, '')
-        .replace(/(\d{8})(\d{6})/, '$1-$2');
-      const filename = `label-buku-${stamp}.pdf`;
-      const blob = new Blob([new Uint8Array(bytes)], { type: 'application/pdf' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      const result = await labelBukuApi.exportPdf(new Uint8Array(bytes));
+      setLastExport({ filename: result.filename, dirAbsPath: result.dirAbsPath });
       showToast({
         title: t('toast.pdfSaved', { defaultValue: 'PDF tersimpan' }),
-        description: filename,
+        description: result.filename,
       });
     } catch (e) {
       showToast({
@@ -252,19 +243,68 @@ export function CetakLabelPage() {
     }
   };
 
+  const handleOpenFolder = async () => {
+    setOpeningFolder(true);
+    try {
+      await labelBukuApi.openExportsFolder();
+    } catch (e) {
+      showToast({
+        title: t('toast.openFolderFailed', { defaultValue: 'Gagal membuka folder hasil' }),
+        description: e instanceof Error ? e.message : String(e),
+        variant: 'destructive',
+      });
+    } finally {
+      setOpeningFolder(false);
+    }
+  };
+
   return (
-    <div className="space-y-6" data-testid="cetak-label-page">
-      <div>
-        <h1 className="text-2xl font-semibold">
-          {t('cetak.title', { defaultValue: 'Cetak Label & Barcode Buku' })}
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          {t('cetak.subtitle', {
-            defaultValue:
-              'Pilih template lalu pilih buku — satu label akan dicetak untuk tiap eksemplar.',
-          })}
-        </p>
+    <div className="flex flex-col gap-6 p-6" data-testid="cetak-label-page">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">
+            {t('cetak.title', { defaultValue: 'Cetak Label & Barcode Buku' })}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {t('cetak.subtitle', {
+              defaultValue:
+                'Pilih template lalu pilih buku — satu label akan dicetak untuk tiap eksemplar.',
+            })}
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          onClick={handleOpenFolder}
+          disabled={openingFolder}
+          data-testid="cetak-label-open-folder"
+        >
+          <FolderOpen className="size-4 mr-1" />
+          {t('cetak.openFolder', { defaultValue: 'Buka Folder Hasil' })}
+        </Button>
       </div>
+
+      {lastExport ? (
+        <div
+          className="flex flex-wrap items-center gap-3 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200"
+          data-testid="cetak-label-last-export"
+          role="status"
+        >
+          <FileDown className="size-4" />
+          <span>
+            {t('cetak.lastExport', { defaultValue: 'PDF terakhir disimpan' })}:{' '}
+            <code className="font-mono">{lastExport.filename}</code>
+          </span>
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-emerald-900 underline dark:text-emerald-200"
+            onClick={handleOpenFolder}
+            disabled={openingFolder}
+          >
+            {t('cetak.openFolder', { defaultValue: 'Buka Folder Hasil' })}
+          </Button>
+        </div>
+      ) : null}
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="space-y-4">

--- a/apps/desktop/src/features/settings/ManualPage.tsx
+++ b/apps/desktop/src/features/settings/ManualPage.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Search } from 'lucide-react';
+import { ArrowUp, Search } from 'lucide-react';
 import manualSrc from '@docs/manual.md?raw';
+import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { SettingsSection } from './SettingsSection';
@@ -87,9 +88,34 @@ function extractToc(markdown: string): TocEntry[] {
 
 const TOC = extractToc(manualSrc);
 
+/**
+ * Scroll threshold (in pixels) at which the floating "scroll to top" button
+ * fades in. Tuned so a user has to scroll past the first paragraph or two
+ * before it appears — otherwise it would flicker on every tiny scroll.
+ */
+const SCROLL_TO_TOP_THRESHOLD = 200;
+
 export function ManualPage(): JSX.Element {
   const { t } = useTranslation('settings');
   const [query, setQuery] = React.useState('');
+  const [showScrollTop, setShowScrollTop] = React.useState(false);
+  // Lazily resolved on first scroll event so we don't depend on render order.
+  // The Manual sits inside the global app `<main>` which is the actual
+  // scroll container (set via `overflow-y-auto` in `AppShell`). `window`
+  // never scrolls in this app.
+  const scrollerRef = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    const scroller = document.querySelector<HTMLElement>('[data-testid="app-main"]');
+    if (!scroller) return undefined;
+    scrollerRef.current = scroller;
+    const onScroll = (): void => {
+      setShowScrollTop(scroller.scrollTop > SCROLL_TO_TOP_THRESHOLD);
+    };
+    onScroll();
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    return () => scroller.removeEventListener('scroll', onScroll);
+  }, []);
 
   const trimmedQuery = query.trim().toLowerCase();
   const filteredToc = React.useMemo(() => {
@@ -101,6 +127,12 @@ export function ManualPage(): JSX.Element {
     const node = document.getElementById(id);
     if (!node) return;
     node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const handleScrollToTop = (): void => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    scroller.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (
@@ -252,6 +284,20 @@ export function ManualPage(): JSX.Element {
           </ReactMarkdown>
         </article>
       </div>
+
+      <Button
+        type="button"
+        size="icon"
+        onClick={handleScrollToTop}
+        aria-label={t('sections.manual.scrollToTop', { defaultValue: 'Naik ke atas' })}
+        className={cn(
+          'fixed bottom-6 right-6 z-30 h-11 w-11 rounded-full shadow-lg transition-opacity duration-200',
+          showScrollTop ? 'opacity-100' : 'pointer-events-none opacity-0',
+        )}
+        data-testid="manual-scroll-top"
+      >
+        <ArrowUp className="h-5 w-5" />
+      </Button>
     </SettingsSection>
   );
 }

--- a/apps/desktop/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/features/settings/SettingsLayout.tsx
@@ -24,7 +24,7 @@ export function SettingsLayout(): JSX.Element {
 
   return (
     <div
-      className="flex h-full min-h-0 flex-col gap-6 p-6"
+      className="flex h-full min-h-0 flex-col gap-6 px-6 pb-10 pt-6"
       data-testid="settings-layout"
     >
       <header className="flex flex-col gap-2">
@@ -39,7 +39,10 @@ export function SettingsLayout(): JSX.Element {
       </header>
 
       <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
-        <aside className="flex flex-col gap-3">
+        <aside
+          className="flex flex-col gap-3 lg:sticky lg:top-6 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto"
+          data-testid="settings-sidebar"
+        >
           <div className="relative">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input

--- a/apps/desktop/src/i18n/en/label-buku.json
+++ b/apps/desktop/src/i18n/en/label-buku.json
@@ -35,6 +35,8 @@
     "savePdf": "Save PDF",
     "saving": "Saving…",
     "manageTemplates": "Manage Templates",
+    "openFolder": "Open Output Folder",
+    "lastExport": "Last saved PDF",
     "summary": "{{books}} books selected · {{labels}} labels to print",
     "empty": "No matching books",
     "col": {
@@ -55,6 +57,7 @@
     "printing": "Printing {{count}} labels",
     "printFailed": "Failed to print",
     "pdfSaved": "PDF saved",
-    "pdfFailed": "Failed to save PDF"
+    "pdfFailed": "Failed to save PDF",
+    "openFolderFailed": "Failed to open output folder"
   }
 }

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -232,7 +232,8 @@
       "summary": "Full user guide, searchable via the table of contents.",
       "toc": "Table of contents",
       "searchPlaceholder": "Search section titles…",
-      "noMatches": "No matching sections."
+      "noMatches": "No matching sections.",
+      "scrollToTop": "Back to top"
     },
     "tentang": {
       "label": "About",

--- a/apps/desktop/src/i18n/id/label-buku.json
+++ b/apps/desktop/src/i18n/id/label-buku.json
@@ -35,6 +35,8 @@
     "savePdf": "Simpan PDF",
     "saving": "Menyimpan…",
     "manageTemplates": "Kelola Template",
+    "openFolder": "Buka Folder Hasil",
+    "lastExport": "PDF terakhir disimpan",
     "summary": "{{books}} buku terpilih · {{labels}} label akan dicetak",
     "empty": "Tidak ada buku yang cocok",
     "col": {
@@ -55,6 +57,7 @@
     "printing": "Mencetak {{count}} label",
     "printFailed": "Gagal mencetak",
     "pdfSaved": "PDF tersimpan",
-    "pdfFailed": "Gagal menyimpan PDF"
+    "pdfFailed": "Gagal menyimpan PDF",
+    "openFolderFailed": "Gagal membuka folder hasil"
   }
 }

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -232,7 +232,8 @@
       "summary": "Panduan pengguna lengkap, bisa dicari dari daftar isi.",
       "toc": "Daftar isi",
       "searchPlaceholder": "Cari judul bagian…",
-      "noMatches": "Tidak ada bagian yang cocok."
+      "noMatches": "Tidak ada bagian yang cocok.",
+      "scrollToTop": "Naik ke atas"
     },
     "tentang": {
       "label": "Tentang",

--- a/apps/desktop/src/lib/labelBuku.ts
+++ b/apps/desktop/src/lib/labelBuku.ts
@@ -66,6 +66,16 @@ export interface LabelBukuTemplateInput {
   isDefault?: boolean;
 }
 
+/**
+ * Result from `label_buku_export_pdf`. Mirrors the KTA shape; UI uses
+ * `dirAbsPath` to wire up an "Open folder" button on the success toast.
+ */
+export interface LabelBukuExportResult {
+  filename: string;
+  absPath: string;
+  dirAbsPath: string;
+}
+
 export interface LabelBukuRpc {
   list: () => Promise<LabelBukuTemplate[]>;
   get: (id: number) => Promise<LabelBukuTemplate>;
@@ -73,6 +83,15 @@ export interface LabelBukuRpc {
   update: (id: number, input: LabelBukuTemplateInput) => Promise<LabelBukuTemplate>;
   delete: (id: number) => Promise<void>;
   setDefault: (id: number) => Promise<LabelBukuTemplate>;
+  /**
+   * Persists a PDF blob (built by jsPDF) under
+   * `<app_data>/exports/labels/label-buku-YYYYMMDD-HHMMSS.pdf` and
+   * returns the resolved paths so the UI can show a "buka folder"
+   * follow-up. Browser/mock mode falls back to a Blob download.
+   */
+  exportPdf: (bytes: Uint8Array) => Promise<LabelBukuExportResult>;
+  /** Open the labels exports folder in the OS file manager. */
+  openExportsFolder: () => Promise<string>;
 }
 
 const tauriRpc: LabelBukuRpc = {
@@ -82,6 +101,8 @@ const tauriRpc: LabelBukuRpc = {
   update: (id, input) => invoke('label_buku_template_update', { id, input }),
   delete: (id) => invoke('label_buku_template_delete', { id }),
   setDefault: (id) => invoke('label_buku_template_set_default', { id }),
+  exportPdf: (bytes) => invoke('label_buku_export_pdf', { bytes: Array.from(bytes) }),
+  openExportsFolder: () => invoke('label_buku_open_exports_folder'),
 };
 
 const STORAGE_KEY = 'po:label-buku:templates';
@@ -178,6 +199,31 @@ const mockRpc: LabelBukuRpc = {
     const found = rows.find((r) => r.id === id);
     if (!found) throw new Error(`template id=${id} tidak ditemukan`);
     return found;
+  },
+  async exportPdf(bytes) {
+    // Browser/mock fallback: trigger a Blob download. We can't write to the
+    // user's filesystem so `absPath` / `dirAbsPath` are best-effort hints.
+    const stamp = new Date()
+      .toISOString()
+      .replace(/[-:T]/g, '')
+      .replace(/\..+$/, '')
+      .replace(/(\d{8})(\d{6})/, '$1-$2');
+    const filename = `label-buku-${stamp}.pdf`;
+    const blob = new Blob([new Uint8Array(bytes)], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+    return { filename, absPath: filename, dirAbsPath: '' };
+  },
+  async openExportsFolder() {
+    // Mock: nothing to open. Surface the same path string the Tauri impl
+    // would return so callers can branch on empty string for "no folder".
+    return '';
   },
 };
 


### PR DESCRIPTION
## Summary

Layout & UX polish batch (v1.0.7 PR D), 6 items dari `.devin/handoff/v1.0.7-bugs-batch/BUGS.md`:

### BUG-05 — Action bar Pengaturan mepet bawah window
`SettingsLayout` outer container: `p-6` → `px-6 pt-6 pb-10`. Action bar di bottom card sekarang punya minimal ~40 px gap dari window edge di semua tab Pengaturan.

### BUG-12 — Cetak KTA + Cetak Label & Barcode mepet ke border kiri/kanan
Outermost wrapper di `CetakKtaPage` dan `CetakLabelPage` sekarang pakai `flex flex-col gap-6 p-6` (sama dengan `DashboardPage`, `PeminjamanList`, `LaporanLayout`, dst). Konten tidak lagi mepet ke border viewport.

### BUG-14 — Topbar global search placeholder wrap & nabrak garis container
Header search button:
- placeholder span dapat `min-w-0 flex-1 truncate text-left`
- container dapat `min-w-0 overflow-hidden whitespace-nowrap` + `lg:w-72 xl:w-80`
- `kbd` dapat `shrink-0` supaya tidak ikut tergencet
Placeholder sekarang single-line + ellipsis, tidak nabrak border container.

### BUG-16 — Sidebar tab Pengaturan hilang saat scroll
`SettingsLayout` aside:
```
lg:sticky lg:top-6 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto
```
Sidebar tetap visible saat konten tab discroll; sidebar sendiri scroll independen kalau item-nya overflow.

### FEAT-13 — Cetak Label & Barcode Buku: tombol "Buka Folder Hasil" + last-export ribbon
Parity dengan Cetak KTA. Perubahan:
- Backend: `label_buku_export.rs` baru dengan command `label_buku_export_pdf` & `label_buku_open_exports_folder`. Folder output: `<app_data>/exports/labels/` (terpisah dari `<app_data>/exports/` punya KTA). 5 unit test (validasi header `%PDF-`, oversize, empty, filename pattern).
- Frontend (`labelBukuApi`): tambah `exportPdf` & `openExportsFolder` di Tauri RPC + mock fallback (Blob download untuk dev/browser).
- UI (`CetakLabelPage`): tombol "Buka Folder Hasil" di header sejajar dengan "Cetak Label & Barcode Buku" title; setelah simpan PDF, ribbon emerald dengan filename + link "Buka Folder Hasil".
- i18n: `cetak.openFolder`, `cetak.lastExport`, `toast.openFolderFailed` di label-buku/{id,en}.json.

### FEAT-15 — Manual: FAB scroll-to-top
`ManualPage` dapat floating Button (lucide `ArrowUp`) di `fixed bottom-6 right-6 z-30 h-11 w-11 rounded-full`. Visibility dikontrol scrollTop dari `[data-testid="app-main"]` (scroll container global, bukan window) dengan threshold 200 px. Klik = `scroller.scrollTo({ top: 0, behavior: 'smooth' })`. Fade in/out via `opacity-100`/`opacity-0` + `pointer-events-none`. i18n key `sections.manual.scrollToTop`.

## Review & Testing Checklist for Human

- [ ] BUG-05: buka Pengaturan → tab Identitas / Aturan Peminjaman → scroll ke bawah, pastikan tombol "Simpan" (action bar) punya gap ≥24 px dari edge window. Cek di tab apapun yang punya Save button.
- [ ] BUG-12: buka Anggota → Cetak KTA dan Buku → Cetak Label & Barcode. Konten sekarang punya horizontal padding ≥24 px dari kiri/kanan border, sama seperti halaman Dashboard / Anggota / Buku.
- [ ] BUG-14: lihat topbar search input "Cari anggota, buku, peminjaman…" pada viewport 1024px / 1280px / 1440px. Placeholder harus single-line + ellipsis kalau perlu, tidak overflow container vertikal.
- [ ] BUG-16: Pengaturan → Manual (atau tab dengan konten panjang) → scroll konten ke bawah. Sidebar tab list tetap visible. Sidebar sendiri scrollable kalau item-nya overflow tinggi viewport.
- [ ] FEAT-13: Buku → Cetak Label & Barcode Buku → klik "Simpan PDF" satu kali. PDF tersimpan di `<app_data>/exports/labels/label-buku-YYYYMMDD-HHMMSS.pdf`. Tombol "Buka Folder Hasil" di header & link di ribbon emerald keduanya membuka folder di OS file manager.
- [ ] FEAT-15: Pengaturan → Manual → scroll ke bawah. FAB arrow-up muncul setelah scroll > 200 px. Klik = smooth scroll ke top. Saat di top, FAB hilang lagi.

### Test plan (otomatis, sudah lewat lokal)

```
pnpm typecheck      # tsc apps/desktop + packages/shared
pnpm lint           # eslint --max-warnings=0
pnpm i18n:lint      # parity id ↔ en
pnpm test           # vitest 264 tests across 33 files
pnpm build          # vite build
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test --lib    # 117 backend tests (5 baru di label_buku_export.rs)
```

### Notes

- Folder split (`exports/` vs `exports/labels/`) intentional — KTA dan label punya format/aspect ratio berbeda; campur ke satu folder confusing user.
- FAB di ManualPage attach scroll listener ke `[data-testid="app-main"]` (scroll container global), bukan window — `window.scroll` tidak pernah fire di app ini karena AppShell pakai `<main className="flex-1 overflow-y-auto">`.
- Sticky positioning di SettingsLayout aside cuma aktif di `lg:` breakpoint. Di mobile/tablet narrow viewport, sidebar tetap di atas content (1-column grid) — sticky tidak diperlukan.
- Update PROGRESS.md (mark D items sebagai IN_PR=#NNN) akan di-push ke branch `devin/1777993479-v107-bugs-handoff` sesudah PR ini punya nomor, sama persis pola PR A/B/C.
