### PR TITLE
feat(dashboard): rotate quote-of-the-day every 5 minutes with fade-slide animation (FEAT-11)

### DIFF
--- a/apps/desktop/src/features/dashboard/DashboardPage.tsx
+++ b/apps/desktop/src/features/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
 import { Users, BookOpen, ArrowLeftRight, BookPlus, UserPlus, Sparkles, Quote } from 'lucide-react';
@@ -10,8 +10,9 @@ import { ChartPie } from '@/components/shared/ChartPie';
 import { ChartBar } from '@/components/shared/ChartBar';
 import { LiveClock } from '@/components/shared/LiveClock';
 import { OverduePanel } from '@/features/dashboard/OverduePanel';
-import { getQuoteForDate } from '@/lib/dailyQuote';
+import { getQuoteByIndex, pickNextQuoteIndex, quoteIndexForDate } from '@/lib/dailyQuote';
 import { formatTauriError } from '@/lib/errors';
+import { cn } from '@/lib/utils';
 import {
   dashboardApi,
   type DashboardKpi,
@@ -36,6 +37,19 @@ interface DashboardData {
   topPeminjam: TopPeminjam[];
   topBuku: TopBuku[];
 }
+
+/**
+ * How long the dashboard quote-of-the-day stays on screen before rotating
+ * to a new pick (FEAT-11). 5 minutes is short enough to feel alive but long
+ * enough that users reading the screen aren't distracted.
+ */
+const QUOTE_ROTATE_MS = 5 * 60 * 1000;
+
+/**
+ * Duration of the leave (fade-out + slide-up) phase. Matches the duration
+ * of the corresponding `slide-up` keyframe so leave/enter feel symmetric.
+ */
+const QUOTE_LEAVE_MS = 300;
 
 export function DashboardPage() {
   const { t } = useTranslation(['dashboard', 'common']);
@@ -78,7 +92,33 @@ export function DashboardPage() {
     data.kpi.totalBuku === 0 &&
     data.kpi.bukuDipinjam === 0;
 
-  const dailyQuote = useMemo(() => getQuoteForDate(new Date()), []);
+  // Quote-of-the-day rotation (FEAT-11). Initial index is deterministic per
+  // calendar day (matches the pre-rotation behavior so reload-day-1 always
+  // shows the same first quote). Every QUOTE_ROTATE_MS we trigger a leave
+  // animation, swap the index, then mount the new quote with the
+  // `slide-up` keyframe via `key={quoteIndex}`.
+  const [quoteIndex, setQuoteIndex] = useState(() => quoteIndexForDate(new Date()));
+  const [quoteLeaving, setQuoteLeaving] = useState(false);
+
+  useEffect(() => {
+    let leaveTimer: ReturnType<typeof setTimeout> | null = null;
+    const rotateTimer = setInterval(() => {
+      setQuoteLeaving(true);
+      leaveTimer = setTimeout(() => {
+        // setState updater form is required: the interval closure captures
+        // the original quoteIndex but we want to rotate from whichever
+        // index is current right now.
+        setQuoteIndex((prev) => pickNextQuoteIndex(prev));
+        setQuoteLeaving(false);
+      }, QUOTE_LEAVE_MS);
+    }, QUOTE_ROTATE_MS);
+    return () => {
+      clearInterval(rotateTimer);
+      if (leaveTimer !== null) clearTimeout(leaveTimer);
+    };
+  }, []);
+
+  const dailyQuote = getQuoteByIndex(quoteIndex);
 
   return (
     <div className="flex flex-col gap-6 p-6" data-testid="dashboard-page">
@@ -104,7 +144,27 @@ export function DashboardPage() {
       >
         <CardContent className="flex items-start gap-3 p-4">
           <Quote className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary" aria-hidden="true" />
-          <div className="flex flex-col gap-1">
+          {/*
+            Two-phase fade-slide animation:
+            - When `quoteLeaving` is true, the existing element transitions
+              to `opacity-0 -translate-y-2` over 300 ms (slide up + fade out).
+            - When the timer fires we flip `quoteIndex`, which changes the
+              `key` and forces React to remount this div. The fresh mount
+              plays `animate-slide-up` (300 ms), entering from below with a
+              fade-in. Net effect: ≈600 ms swap, no flicker.
+            `motion-reduce` users get the new quote without animation.
+          */}
+          <div
+            key={quoteIndex}
+            className={cn(
+              'flex flex-col gap-1',
+              quoteLeaving
+                ? '-translate-y-2 opacity-0 transition-all duration-300 ease-out'
+                : 'motion-safe:animate-slide-up',
+              'motion-reduce:translate-y-0 motion-reduce:opacity-100 motion-reduce:transition-none motion-reduce:animate-none',
+            )}
+            aria-live="polite"
+          >
             <p className="text-sm italic leading-relaxed text-foreground">
               {`"${dailyQuote.text}"`}
             </p>

--- a/apps/desktop/src/lib/dailyQuote.ts
+++ b/apps/desktop/src/lib/dailyQuote.ts
@@ -34,6 +34,18 @@ export function getQuoteForDate(date: Date): Quote {
 }
 
 /**
+ * Look up a bundled quote by its position in the pool. Used by the
+ * dashboard rotation (FEAT-11) which holds the index in component state
+ * and re-renders whenever it changes.
+ */
+export function getQuoteByIndex(index: number): Quote {
+  // Same modulo guard as quoteIndexForDate so out-of-range arguments
+  // never throw — the rotation should be best-effort, not crash-prone.
+  const safe = ((index % QUOTES.length) + QUOTES.length) % QUOTES.length;
+  return QUOTES[safe] as Quote;
+}
+
+/**
  * 1-indexed day-of-year in the date's local calendar (Asia/Jakarta in our
  * deployment). Calculated by walking the local day boundaries — Date.UTC
  * would mis-bucket the last day of the year for users east of UTC.
@@ -45,4 +57,29 @@ function computeDayOfYear(date: Date): number {
   // Indonesia (no DST) but the rounding is robust against future relocations.
   const dayMs = 24 * 60 * 60 * 1000;
   return Math.floor(diffMs / dayMs) + 1;
+}
+
+/**
+ * Pick the next quote index for the dashboard rotation, biased so the
+ * result is never equal to `currentIndex`. Used by `DashboardPage` to
+ * rotate the quote-of-the-day card every 5 minutes (FEAT-11).
+ *
+ * `rng` is the random source — defaults to `Math.random` but injected by
+ * tests for determinism. The returned index is always in `[0, QUOTE_COUNT)`.
+ *
+ * Edge case: when `QUOTE_COUNT === 1` we have nothing to rotate to, so we
+ * return that single index regardless of `currentIndex`. The bundle ships
+ * 122 quotes so this branch never trips in practice, but it guards against
+ * future refactors that might prune the list.
+ */
+export function pickNextQuoteIndex(
+  currentIndex: number,
+  rng: () => number = Math.random,
+): number {
+  if (QUOTES.length <= 1) return 0;
+  // Sample uniformly from the (length-1) candidate indexes that aren't the
+  // current one; mapping `pick >= currentIndex → pick + 1` skips it without
+  // a rejection loop, so the function always terminates in O(1).
+  const pick = Math.floor(rng() * (QUOTES.length - 1));
+  return pick >= currentIndex ? pick + 1 : pick;
 }

--- a/apps/desktop/tests/unit/dailyQuote.test.ts
+++ b/apps/desktop/tests/unit/dailyQuote.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { QUOTE_COUNT, getQuoteForDate, quoteIndexForDate } from '@/lib/dailyQuote';
+import {
+  QUOTE_COUNT,
+  getQuoteForDate,
+  pickNextQuoteIndex,
+  quoteIndexForDate,
+} from '@/lib/dailyQuote';
 
 describe('dailyQuote', () => {
   it('bundles a non-trivial number of quotes', () => {
@@ -45,6 +50,59 @@ describe('dailyQuote', () => {
     // Not strictly guaranteed if 367 % QUOTE_COUNT === 0, so guard against it.
     if (367 % QUOTE_COUNT !== 0) {
       expect(a).not.toEqual(b);
+    }
+  });
+});
+
+describe('pickNextQuoteIndex', () => {
+  it('never returns the current index', () => {
+    // Sweep all possible RNG outputs in [0, 1): with 122 quotes the
+    // candidate space has 121 buckets, and we want to confirm none of
+    // them collide with the input.
+    for (const current of [0, 1, 5, QUOTE_COUNT - 1]) {
+      for (const r of [0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.999_999]) {
+        const next = pickNextQuoteIndex(current, () => r);
+        expect(next).not.toBe(current);
+      }
+    }
+  });
+
+  it('always returns an in-range index', () => {
+    for (const current of [0, Math.floor(QUOTE_COUNT / 2), QUOTE_COUNT - 1]) {
+      for (const r of [0, 0.5, 0.999_999]) {
+        const next = pickNextQuoteIndex(current, () => r);
+        expect(next).toBeGreaterThanOrEqual(0);
+        expect(next).toBeLessThan(QUOTE_COUNT);
+      }
+    }
+  });
+
+  it('is deterministic given a seeded RNG', () => {
+    // Two calls with the same RNG factory and same input must agree —
+    // tests rely on this for stable snapshots.
+    const a = pickNextQuoteIndex(7, () => 0.42);
+    const b = pickNextQuoteIndex(7, () => 0.42);
+    expect(a).toBe(b);
+  });
+
+  it('walks through distinct indexes when chained', () => {
+    // Drive the helper through 10 rotations using a deterministic RNG;
+    // the dashboard will do the same at runtime. No two consecutive
+    // indexes should match.
+    let current = quoteIndexForDate(new Date(2026, 0, 1));
+    let r = 0.13;
+    const seen: number[] = [current];
+    for (let i = 0; i < 10; i += 1) {
+      const next = pickNextQuoteIndex(current, () => r);
+      expect(next).not.toBe(current);
+      seen.push(next);
+      current = next;
+      // Step the pseudo-RNG so each rotation samples a different bucket.
+      r = (r + 0.197) % 1;
+    }
+    // No consecutive duplicates anywhere in the chain.
+    for (let i = 1; i < seen.length; i += 1) {
+      expect(seen[i]).not.toBe(seen[i - 1]);
     }
   });
 });


### PR DESCRIPTION
## Summary

Dashboard quote-of-the-day sekarang rotasi tiap 5 menit dengan animasi fade-slide (v1.0.7 PR E, FEAT-11 — closes last item dari handoff `.devin/handoff/v1.0.7-bugs-batch/`).

### Behavior

- Initial state pakai `quoteIndexForDate(new Date())` — **identik dengan behavior lama**, jadi quote pertama yang dilihat user setiap kali buka dashboard tetap deterministik per-hari (anti-flicker saat user pindah halaman & balik).
- Setiap 5 menit, `setInterval` fire → set `quoteLeaving=true` → div animasi 300 ms ke `opacity-0 -translate-y-2` (fade out + slide up) → setelah 300 ms, swap `quoteIndex` ke pick baru → `key={quoteIndex}` ganti → React remount div baru → mount play `animate-slide-up` (300 ms, dari +8px ke 0). Total swap: ~600 ms, tidak ada flicker.
- Helper baru `pickNextQuoteIndex(currentIndex, rng?)` jamin tidak ada quote yang sama 2× berturut-turut (sampling `rng() * (length-1)` lalu `+1` kalau >= currentIndex — O(1), tidak ada rejection loop).
- `motion-reduce` users skip animasi sepenuhnya via `motion-safe:animate-slide-up` + override `motion-reduce:translate-y-0 motion-reduce:opacity-100 motion-reduce:transition-none motion-reduce:animate-none`.
- Timer auto-cleanup di `useEffect` cleanup, jadi pindah halaman dan balik = timer fresh (5 menit lagi sampai swap pertama).

### Files

- `apps/desktop/src/lib/dailyQuote.ts` — tambah `pickNextQuoteIndex` (eksposed RNG injection) + `getQuoteByIndex` (lookup dari state).
- `apps/desktop/src/features/dashboard/DashboardPage.tsx` — state-driven quote rotation menggantikan `useMemo` deterministic-per-render.
- `apps/desktop/tests/unit/dailyQuote.test.ts` — 4 test baru (10 total): never-equal-current, in-range, deterministik dengan seeded RNG, walked chain tanpa duplikat berurutan.

Tidak menyentuh:
- `apps/desktop/src/content/quotes.json` — pool sudah 122 quotes (cukup banyak; spec OK kalau ≥ 30).
- `tailwind.config.ts` — `slide-up` keyframe sudah ada (300 ms ease-out).

## Review & Testing Checklist for Human

- [ ] Buka dashboard → quote awal sama dengan hari sebelumnya kalau user buka di waktu berbeda yang masih hari yang sama (deterministic per-day).
- [ ] Tunggu 5 menit di dashboard → quote berubah dengan animasi fade-out + slide-up + fade-in dari bottom. Smooth, tidak ada layout shift.
- [ ] 10× rotasi (atau lebih kalau sabar): tidak pernah dapat quote yang sama 2× berturut-turut.
- [ ] Pencet F5 (refresh) sebelum 5 menit → quote awal sama (= quote-of-the-day deterministik), timer reset.
- [ ] Pindah ke halaman lain (e.g. Anggota), tunggu 4 menit, kembali → masih quote awal (initial = deterministik per-day), timer fresh ke 5 menit lagi.
- [ ] OS / browser dengan setting "reduce motion" enabled → quote tetap berubah tiap 5 menit, tapi tanpa animasi (instant swap).

### Test plan (otomatis, sudah lewat lokal)

```
pnpm typecheck       # tsc apps/desktop + packages/shared
pnpm lint            # eslint --max-warnings=0
pnpm i18n:lint       # parity id ↔ en
pnpm test            # vitest 268 tests across 33 files (10 di dailyQuote.test.ts)
pnpm build           # vite build
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
```

### Notes

- `pickNextQuoteIndex` sengaja accept RNG injection biar test bisa deterministik. Default `Math.random` tetap dipakai di runtime.
- Pakai `key={quoteIndex}` di div quote — React unmount + remount untuk fresh `animate-slide-up`. Lebih sederhana dibanding pakai react-transition-group atau Framer Motion (tambah dependency).
- Animasi durasi total ≈600 ms (300 leave + 300 enter). Kalau dirasa terlalu cepat, bisa naik ke 800 atau pakai keyframe baru di `tailwind.config.ts`.
- Update PROGRESS.md (mark FEAT-11 sebagai IN_PR=#NNN) akan di-push ke branch `devin/1777993479-v107-bugs-handoff` (PR #119) sesudah PR ini punya nomor — pola yang sama dengan PR A/B/C/D.
- Setelah PR A-E merged, PR F (release v1.0.7) tinggal bump version + update CHANGELOG + tag.
