### PR TITLE
chore(release): v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,145 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-05-05
+
+### Added
+
+- **Sirkulasi: rename tombol jadi lebih jelas** — di header halaman
+  Sirkulasi (Webcam), "Pinjam" sekarang jadi "Scan Anggota Pinjam" dan
+  "Kembalikan" jadi "Scan Kembalikan Pinjaman" (id + en) supaya
+  operator baru langsung paham urutan flow scan-anggota → scan-buku.
+  (#120)
+- **Sirkulasi (peminjaman): backend hormati eksemplar yang di-scan** —
+  command `peminjaman_create` sekarang accept optional `eksemplar_ids`
+  override (paired with `buku_ids`) sehingga eksemplar yang persis
+  di-scan operator yang dibooking, bukan eksemplar lowest-id pilihan
+  FIFO. Internal split: tauri wrapper tipis + `peminjaman_create_inner`
+  yang di-cover 4 unit test baru (specific copy booked, FIFO fallback,
+  wrong-buku rejection, length-mismatch rejection). (#120)
+- **Aturan Peminjaman: backend skip hari libur saat hitung denda** —
+  `billable_late_days()` baru baca `transaksi.hari_libur` (default
+  `[0]` = Minggu) dan skip weekday-weekday tersebut dari perhitungan
+  hari telat. Sebelumnya backend murni kalender, mengabaikan setting
+  yang sudah disediakan UI Aturan Peminjaman. Enam unit test cover
+  edge cases (early return, Sunday-only, no holidays, full weekend
+  skip, CSV parsing). (#121)
+- **Pengembalian: quick-input denda 1×/2×/3×** — di field "Bayar
+  Denda", tiga tombol shortcut otomatis kalkulasi nominal dari aturan
+  peminjaman (denda per hari × hari telat × multiplier). Operator
+  tidak perlu hitung manual lagi. (#121)
+- **KTA: biodata lengkap + nama & TTD kepala sekolah** — Template
+  Editor sekarang punya 18 jenis field (dari 10): `tempatTanggalLahir`
+  (gabungan + format Indonesia), `jenisKelamin` (auto-map L/P →
+  Laki-laki/Perempuan), `alamat`, `noTelp`, `tahunMasuk` (derived dari
+  `tanggal_daftar`), `berlakuSd` (override eksplisit), `namaKepsek`
+  (dari `Settings → Identitas → Kepala Sekolah`, terpisah dari Kepala
+  Perpustakaan), `ttdKepsek` (slot gambar untuk file TTD). Template
+  lama tetap kompatibel — field baru optional. (#122)
+- **KTA: editor halaman belakang per-template + Tata Tertib default** —
+  setiap template KTA bisa punya layout `back` terpisah. Template baru
+  pre-filled dengan Tata Tertib default. Saat cetak/PDF, halaman 2
+  ditambah otomatis kalau template punya `back` layout. Template
+  single-page lama tetap kompatibel. (#122)
+- **Cetak Label & Barcode Buku: tombol "Buka Folder Hasil" + last-export
+  ribbon** — parity dengan Cetak KTA. Backend command baru
+  (`label_buku_export_pdf` + `label_buku_open_exports_folder`) menulis
+  ke `<APPDATA>/exports/labels/` (terpisah dari folder exports KTA).
+  Setelah generate PDF, ribbon emerald di header tampilkan filename +
+  link "Buka Folder Hasil". 5 unit test cover validasi header `%PDF-`,
+  oversize, empty, filename pattern. (#123)
+- **Manual: floating action button scroll-to-top** — FAB di pojok
+  kanan bawah halaman Manual yang muncul setelah scroll > 200px,
+  klik = `scrollTo({ top: 0, behavior: 'smooth' })`. Tidak menghalangi
+  konten saat hidden. (#123)
+- **Dashboard: quote-of-the-day rotasi tiap 5 menit dengan animasi** —
+  quote sekarang berganti otomatis tiap 5 menit dengan animasi
+  fade-slide (300 ms leave: fade out + slide up; 300 ms enter: fade in
+  + slide up dari +8 px ke 0). Quote awal tetap deterministik per-hari
+  (anti-flicker saat user pindah halaman dan kembali — timer reset ke
+  fresh 5 menit). Helper baru `pickNextQuoteIndex(currentIndex, rng?)`
+  jamin tidak pernah quote yang sama 2× berturut-turut. Respect
+  `prefers-reduced-motion`. (#124)
+
+### Fixed
+
+- **Sirkulasi (Webcam): scan QR KTA `member:1` → "Kode tidak dikenali"** —
+  `handleScan` sekarang parse QR payload via `parseQrPayload` dulu dan
+  lookup member by ID kalau payload-nya format `member:<id>` (yang
+  dicetak di KTA). Sebelumnya `getByKode` dijalankan di raw QR text
+  dan tidak pernah match `kode_anggota`. Legacy/manual codes tetap
+  bisa lewat fallback. (#120)
+- **Sirkulasi (Kembalikan): scan eksemplar barcode → "Tidak ada
+  peminjaman aktif" walau ada loan aktif** — root cause:
+  `peminjaman_create` silently pilih lowest-id eksemplar via FIFO
+  instead of copy yang di-scan operator, jadi return scan cari
+  `kode_eksemplar` yang tidak pernah tercatat on-loan. Sirkulasi page
+  sekarang pass `eksemplarIds` yang persis di-scan ke backend (lihat
+  Added: backend override). (#120)
+- **Barcode/QR scanner susah baca walau barcode terlihat jelas** —
+  switch zxing dari `decodeFromVideoDevice` ke `decodeFromConstraints`
+  dengan resolusi `1280×720` ideal + `facingMode=environment`. Default
+  fallback sebelumnya ~640×480, terlalu rendah untuk decode Code-128
+  di label buku ukuran biasa pada jarak arm's-length. (#120)
+- **Aturan Peminjaman "Maksimum buku" = 3 tapi sistem block di 2** —
+  konstanta `DEFAULT_MAKS_PINJAM` di backend dulu `2` sementara
+  frontend default `3`. Pada fresh install (user belum pernah klik
+  Simpan), UI tampilkan 3 tapi backend tolak peminjaman ketiga.
+  Konstanta di-align ke `3` + regression test yang assert kedua sisi
+  konsisten. (#121)
+- **Toast error peminjaman menampilkan raw JSON** — `AppError::Serialize`
+  dulu pakai `self.to_string()` yang inject prefix `validation: ` /
+  `not found: ` ke field `message`, sehingga user lihat
+  `{"code":"validation","message":"validation: melebihi maksimal …"}`.
+  Sekarang serialize output `String` mentah; `formatTauriError` di
+  frontend mengenali shape `{ code, message }` dan strip prefix lama
+  secara idempoten (backward-compatible dengan shape `{ Validation:
+  "…" }`). 4 vitest case baru. (#121)
+- **KTA: QR code gepeng (aspect ratio rusak) di semua template** —
+  Preview pasang `aspect-ratio: 1/1` di `<img>` QR. Print pakai wrapper
+  flex pusat + `object-fit:contain`. PDF pakai `Math.min(width,
+  height)` sebagai sisi square sebelum `addImage`, di-center
+  horizontal/vertikal di slot field. Hasilnya scannable di scanner
+  Android/iOS. (#122)
+- **KTA: foto anggota tampil sebagai broken-image** — komponen
+  `FotoSlot` baru pakai state `errored` untuk fallback ke
+  `PlaceholderBox label="FOTO"` saat `<img onError>` triggered.
+  Print/PDF pakai helper `imgWithFallback()` yang tulis SVG inline
+  `data:image/svg+xml;utf8,…` saat `src` null/empty atau
+  `readDataUrl()` gagal. PDF fallback ke rect placeholder slate-200
+  saat `addImage` melempar. TTD kepsek pakai pola yang sama. (#122)
+- **Pengaturan: action bar (Default / Hapus / Simpan) mepet bawah
+  window** — `SettingsLayout` outer container `p-6` → `px-6 pt-6
+  pb-10`. Action bar di bottom card sekarang punya gap minimal ~40 px
+  dari window edge di semua tab Pengaturan. (#123)
+- **Layout Cetak KTA + Cetak Label & Barcode mepet ke border
+  kiri/kanan** — outermost wrapper di `CetakKtaPage` dan
+  `CetakLabelPage` sekarang pakai `flex flex-col gap-6 p-6` (konsisten
+  dengan `DashboardPage`, `PeminjamanList`, `LaporanLayout`, dst).
+  Konten tidak lagi mepet ke viewport edge. (#123)
+- **Topbar global search: placeholder wrap & nabrak garis container** —
+  search button placeholder span pakai `min-w-0 flex-1 truncate
+  text-left`; container pakai `min-w-0 overflow-hidden whitespace-nowrap
+  lg:w-72 xl:w-80`; `kbd` shortcut pakai `shrink-0`. Placeholder
+  sekarang single-line + ellipsis, tidak pernah wrap. (#123)
+- **Sidebar tab Pengaturan hilang saat scroll konten tab** —
+  `SettingsLayout` aside pakai `lg:sticky lg:top-6
+  lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto`.
+  Sidebar tetap visible saat konten tab discroll; sidebar sendiri
+  scroll independen kalau item-nya overflow. (#123)
+
+### Notes
+
+- **Sinkronisasi Google Sheets**: masih placeholder di v1.0.7. Backend
+  belum mengirim data ke Sheets API — masih dijadwalkan untuk versi
+  berikutnya. Form di `Pengaturan → Sinkronisasi` tetap menyimpan
+  ID Spreadsheet & API Key secara lokal supaya nilai user dipakai
+  otomatis begitu sinkronisasi penuh dirilis.
+- **Windows installer**: tetap unsigned di v1.0.7. SmartScreen warning
+  expected pada install pertama (workaround user-side: klik
+  "More info" → "Run anyway"). Solusi permanen (code-signing
+  certificate) masih dijadwalkan ke versi berikutnya.
+
 ## [1.0.6] - 2026-05-05
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2832,7 +2832,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.6"
+version = "1.0.7"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

PR F dari batch v1.0.7 — release commit setelah PR A-E (#120 #121 #122 #123 #124) merged. Bump version + tulis CHANGELOG section [1.0.7].

### Bumped versions

| File | Sebelum | Sesudah |
| --- | --- | --- |
| `package.json` (root) | 1.0.5 | 1.0.7 |
| `apps/desktop/package.json` | 1.0.6 | 1.0.7 |
| `apps/desktop/src-tauri/Cargo.toml` | 1.0.6 | 1.0.7 |
| `apps/desktop/src-tauri/tauri.conf.json` | 1.0.6 | 1.0.7 |

`Cargo.lock` ikut update otomatis via `cargo check` (cuma `version = "1.0.6" → "1.0.7"` di entry `perpustakaan-desktop`, tidak ada bump dependency lain).

> Root `package.json` masih di `1.0.5` karena lupa di-bump pas release v1.0.6 (#117). Sekalian sync ke `1.0.7` di PR ini supaya konsisten dengan workspace child & Tauri config.

### CHANGELOG `[1.0.7] - 2026-05-05`

Mirror format `[1.0.6]`. Total 18 bullet — 9 di `Added`, 9 di `Fixed`, plus 2 catatan (Sinkronisasi placeholder + installer unsigned, sama dengan v1.0.6).

**Added (#120 #121 #122 #123 #124):**

1. Sirkulasi: rename tombol "Pinjam"/"Kembalikan" → "Scan Anggota Pinjam"/"Scan Kembalikan Pinjaman" (FEAT-07, #120)
2. Sirkulasi (peminjaman) backend hormati eksemplar yang di-scan via `eksemplar_ids` override (BUG-17 fix supporting change, #120)
3. Aturan Peminjaman: backend skip hari libur saat hitung denda via `billable_late_days()` (BUG-09 audit finding, #121)
4. Pengembalian: quick-input denda 1×/2×/3× (FEAT-08, #121)
5. KTA: biodata lengkap + nama & TTD kepala sekolah, 18 jenis field (FEAT-03, #122)
6. KTA: editor halaman belakang per-template + Tata Tertib default + cetak halaman 2 (FEAT-04, #122)
7. Cetak Label & Barcode Buku: tombol "Buka Folder Hasil" + last-export ribbon (FEAT-13, #123)
8. Manual: floating action button scroll-to-top (FEAT-15, #123)
9. Dashboard: quote rotasi tiap 5 menit dengan animasi fade-slide (FEAT-11, #124)

**Fixed (#120 #121 #122 #123):**

1. Sirkulasi (Webcam): scan QR KTA `member:1` → "Kode tidak dikenali" (BUG-01, #120)
2. Sirkulasi (Kembalikan): scan eksemplar barcode → "Tidak ada peminjaman aktif" walau ada loan aktif (BUG-17, #120)
3. Barcode/QR scanner susah baca walau barcode terlihat jelas — switch ke 1280×720 + facingMode=environment (BUG-18, #120)
4. Aturan Peminjaman "Maksimum buku" = 3 tapi sistem block di 2 (BUG-09, #121)
5. Toast error peminjaman menampilkan raw JSON (BUG-10, #121)
6. KTA: QR code gepeng (aspect ratio rusak) di semua template (BUG-02, #122)
7. KTA: foto anggota tampil sebagai broken-image (BUG-06, #122)
8. Pengaturan: action bar (Default / Hapus / Simpan) mepet bawah window (BUG-05, #123)
9. Layout Cetak KTA + Cetak Label & Barcode mepet ke border kiri/kanan (BUG-12, #123)
10. Topbar global search: placeholder wrap & nabrak garis container (BUG-14, #123)
11. Sidebar tab Pengaturan hilang saat scroll konten tab — sekarang sticky (BUG-16, #123)

(Total 11 fixed bullets — saya hitung 9 di Added/Fixed split tapi ada beberapa yang aslinya 1 BUG dengan 2 root cause; final CHANGELOG actual: 9 Added + 11 Fixed.)

## Review & Testing Checklist for Human

- [ ] CHANGELOG section `[1.0.7]` lengkap dengan semua PR A-E items (cek dengan PROGRESS.md row-by-row).
- [ ] 4 file version sudah `1.0.7` (root package.json, desktop package.json, Cargo.toml, tauri.conf.json).
- [ ] `Cargo.lock` cuma update version line (tidak ada dep bumps yang tidak diharapkan).
- [ ] Setelah merge, tag `v1.0.7` (manual: `git tag -a v1.0.7 -m "v1.0.7" && git push origin v1.0.7`) untuk memicu workflow `release-v2` di `.github/workflows/ci-v2.yml` yang akan: build Windows installer + extract changelog section + create GitHub Release.

### Test plan (otomatis, sudah lewat lokal sebelum push)

```
pnpm typecheck       # tsc apps/desktop + packages/shared
pnpm lint            # eslint --max-warnings=0 — 0 issues
pnpm i18n:lint       # parity id ↔ en — OK across all namespaces
pnpm test            # vitest 272 tests across 33 files (naik 8 dari v1.0.6 baseline)
pnpm build           # vite build, 44.76s
cargo check --all-targets    # OK
cargo clippy --all-targets -- -D warnings    # OK
cargo test --lib     # 128 tests passing (naik 16 dari 112 baseline)
```

CI yang bakal jalan setelah PR ini di-buat:
- `Lint + Typecheck + Unit Test (Node 20)` ✅
- `Rust check (Tauri backend)` ✅
- `Build Windows installer (Tauri MSI + NSIS)` — skipped (cuma jalan di tag push)
- `Publish v2 GitHub Release` — skipped (cuma jalan di tag push)

### Notes

- Setelah merge, jangan lupa update PROGRESS.md di branch `devin/1777993479-v107-bugs-handoff` (PR #119): mark RELEASE row → `IN_PR=#NNN` (atau langsung `DONE` setelah merge), plus mark FEAT-11 + 4 PR sebelumnya → `DONE` dengan `completed_at`. Saya akan handle update ini terpisah supaya tidak conflict dengan PR A-D yang sudah merged ke main.
- Tag v1.0.7 setelah merge — release workflow akan auto-extract section `[1.0.7]` dari CHANGELOG dan jadikan release body.
