### PR TITLE
feat(anggota,buku): bulk import anggota overwrite + ISBN bulk import (FEAT-19, FEAT-20)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1829,7 +1829,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2996,6 +2996,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "ureq",
 ]
 
 [[package]]
@@ -3579,7 +3580,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3768,6 +3769,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5490,6 +5492,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5808,6 +5827,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -44,6 +44,10 @@ pbkdf2 = { version = "0.12", features = ["simple"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 jsonwebtoken = "9"
 tokio = { version = "1", features = ["sync"] }
+# FEAT-20 — Bulk import buku via ISBN. ureq provides a small synchronous HTTP
+# client used by the backend to call Open Library + Google Books from inside a
+# blocking Tauri command without dragging tokio into the request path.
+ureq = { version = "2.10", default-features = false, features = ["json", "tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/desktop/src-tauri/src/commands/anggota.rs
+++ b/apps/desktop/src-tauri/src/commands/anggota.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, params_from_iter, OptionalExtension, ToSql};
+use rusqlite::{params, params_from_iter, Connection, OptionalExtension, ToSql};
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
@@ -390,6 +390,10 @@ pub struct AnggotaImportItem {
 #[serde(rename_all = "camelCase")]
 pub struct AnggotaImportResult {
     pub inserted: i64,
+    /// FEAT-19 — count of rows that updated an existing anggota when
+    /// `update_existing=true` was passed. Always 0 when overwrite mode is off
+    /// so older clients that ignore the field see no surprises.
+    pub updated: i64,
     pub skipped: i64,
     pub errors: Vec<AnggotaImportError>,
 }
@@ -406,11 +410,23 @@ pub struct AnggotaImportError {
 pub fn anggota_import(
     state: State<'_, AppState>,
     items: Vec<AnggotaImportItem>,
+    update_existing: Option<bool>,
 ) -> AppResult<AnggotaImportResult> {
     let mut conn = state
         .db
         .lock()
         .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    anggota_import_into_conn(&mut conn, items, update_existing.unwrap_or(false))
+}
+
+/// FEAT-19 — extracted import logic that operates directly on a `Connection`
+/// so unit tests can hit it without spinning up a full Tauri `State`. Mirrors
+/// `anggota_import` exactly.
+pub fn anggota_import_into_conn(
+    conn: &mut Connection,
+    items: Vec<AnggotaImportItem>,
+    overwrite: bool,
+) -> AppResult<AnggotaImportResult> {
     let tx = conn.transaction()?;
     let mut result = AnggotaImportResult::default();
 
@@ -426,23 +442,6 @@ pub fn anggota_import(
             continue;
         }
 
-        let exists: Option<i64> = tx
-            .query_row(
-                "SELECT id FROM anggota WHERE kode_anggota = ?1",
-                params![item.kode_anggota.trim()],
-                |row| row.get(0),
-            )
-            .optional()?;
-        if exists.is_some() {
-            result.errors.push(AnggotaImportError {
-                row: row_no,
-                kode_anggota: item.kode_anggota.clone(),
-                message: "kode_anggota sudah ada".into(),
-            });
-            result.skipped += 1;
-            continue;
-        }
-
         let jk = item
             .jenis_kelamin
             .as_deref()
@@ -450,6 +449,54 @@ pub fn anggota_import(
             .filter(|s| !s.is_empty())
             .map(str::to_uppercase)
             .filter(|s| s == "L" || s == "P");
+
+        let existing_id: Option<i64> = tx
+            .query_row(
+                "SELECT id FROM anggota WHERE kode_anggota = ?1",
+                params![item.kode_anggota.trim()],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        if let Some(id) = existing_id {
+            if !overwrite {
+                result.errors.push(AnggotaImportError {
+                    row: row_no,
+                    kode_anggota: item.kode_anggota.clone(),
+                    message: "kode_anggota sudah ada".into(),
+                });
+                result.skipped += 1;
+                continue;
+            }
+            // FEAT-19 overwrite mode: update the row in place. Use COALESCE
+            // so empty/None columns in the spreadsheet don't blow away an
+            // existing value (the admin's clear-intent path is editing the
+            // anggota row directly, not bulk-blanking via a re-imported file).
+            tx.execute(
+                "UPDATE anggota SET
+                    nama = ?2,
+                    jenis_kelamin = COALESCE(?3, jenis_kelamin),
+                    kelas         = COALESCE(?4, kelas),
+                    jurusan       = COALESCE(?5, jurusan),
+                    agama         = COALESCE(?6, agama),
+                    no_telp       = COALESCE(?7, no_telp),
+                    email         = COALESCE(?8, email),
+                    updated_at    = datetime('now')
+                 WHERE id = ?1",
+                params![
+                    id,
+                    item.nama.trim(),
+                    jk,
+                    item.kelas,
+                    item.jurusan,
+                    item.agama,
+                    item.no_telp,
+                    item.email,
+                ],
+            )?;
+            result.updated += 1;
+            continue;
+        }
 
         tx.execute(
             "INSERT INTO anggota (kode_anggota, nama, jenis_kelamin, kelas, jurusan, agama, no_telp, email, aktif)
@@ -525,4 +572,176 @@ pub fn kelas_list(state: State<'_, AppState>) -> AppResult<Vec<KelasItem>> {
         })?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::run_migrations;
+
+    fn fresh_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.pragma_update(None, "foreign_keys", "ON").expect("fk on");
+        run_migrations(&conn).expect("migrations");
+        conn
+    }
+
+    fn item(kode: &str, nama: &str) -> AnggotaImportItem {
+        AnggotaImportItem {
+            kode_anggota: kode.into(),
+            nama: nama.into(),
+            kelas: None,
+            jurusan: None,
+            agama: None,
+            jenis_kelamin: None,
+            no_telp: None,
+            email: None,
+        }
+    }
+
+    fn count_rows(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM anggota", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn import_inserts_new_rows() {
+        let mut conn = fresh_conn();
+        let before = count_rows(&conn);
+        let result = anggota_import_into_conn(
+            &mut conn,
+            vec![item("IMP1", "Imported 1"), item("IMP2", "Imported 2")],
+            false,
+        )
+        .expect("import ok");
+        assert_eq!(result.inserted, 2);
+        assert_eq!(result.updated, 0);
+        assert_eq!(result.skipped, 0);
+        assert_eq!(result.errors.len(), 0);
+        assert_eq!(count_rows(&conn) - before, 2);
+    }
+
+    #[test]
+    fn feat19_skips_existing_when_overwrite_disabled() {
+        let mut conn = fresh_conn();
+        anggota_import_into_conn(&mut conn, vec![item("OW1", "Original")], false).unwrap();
+
+        let mut row = item("OW1", "Replacement");
+        row.kelas = Some("12 IPA 1".into());
+        let result =
+            anggota_import_into_conn(&mut conn, vec![row], false).expect("import ok");
+        assert_eq!(result.inserted, 0);
+        assert_eq!(result.updated, 0);
+        assert_eq!(result.skipped, 1);
+        assert_eq!(result.errors.len(), 1);
+        let nama: String = conn
+            .query_row(
+                "SELECT nama FROM anggota WHERE kode_anggota = ?1",
+                params!["OW1"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(nama, "Original");
+    }
+
+    #[test]
+    fn feat19_overwrites_existing_when_overwrite_enabled() {
+        let mut conn = fresh_conn();
+        let mut original = item("OW2", "Original");
+        original.kelas = Some("11 IPS 2".into());
+        original.jurusan = Some("IPS".into());
+        anggota_import_into_conn(&mut conn, vec![original], false).unwrap();
+
+        let mut replacement = item("OW2", "Replacement");
+        replacement.kelas = Some("12 IPA 1".into());
+        // jurusan intentionally None — must NOT clear the existing value.
+        let result = anggota_import_into_conn(&mut conn, vec![replacement], true)
+            .expect("import ok");
+        assert_eq!(result.inserted, 0);
+        assert_eq!(result.updated, 1);
+        assert_eq!(result.skipped, 0);
+        assert_eq!(result.errors.len(), 0);
+
+        let (nama, kelas, jurusan): (String, String, String) = conn
+            .query_row(
+                "SELECT nama, kelas, jurusan FROM anggota WHERE kode_anggota = ?1",
+                params!["OW2"],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(nama, "Replacement");
+        assert_eq!(kelas, "12 IPA 1");
+        assert_eq!(jurusan, "IPS");
+    }
+
+    #[test]
+    fn feat19_overwrite_mixes_inserts_and_updates() {
+        let mut conn = fresh_conn();
+        anggota_import_into_conn(&mut conn, vec![item("MIX1", "Existing")], false).unwrap();
+
+        let result = anggota_import_into_conn(
+            &mut conn,
+            vec![
+                item("MIX1", "Updated"),
+                item("MIX2", "Brand New"),
+            ],
+            true,
+        )
+        .expect("import ok");
+        assert_eq!(result.inserted, 1);
+        assert_eq!(result.updated, 1);
+        assert_eq!(result.skipped, 0);
+
+        let nama1: String = conn
+            .query_row(
+                "SELECT nama FROM anggota WHERE kode_anggota = ?1",
+                params!["MIX1"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let nama2: String = conn
+            .query_row(
+                "SELECT nama FROM anggota WHERE kode_anggota = ?1",
+                params!["MIX2"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(nama1, "Updated");
+        assert_eq!(nama2, "Brand New");
+    }
+
+    #[test]
+    fn import_validates_required_fields() {
+        let mut conn = fresh_conn();
+        let result = anggota_import_into_conn(
+            &mut conn,
+            vec![
+                AnggotaImportItem {
+                    kode_anggota: "".into(),
+                    nama: "No kode".into(),
+                    kelas: None,
+                    jurusan: None,
+                    agama: None,
+                    jenis_kelamin: None,
+                    no_telp: None,
+                    email: None,
+                },
+                AnggotaImportItem {
+                    kode_anggota: "OK1".into(),
+                    nama: "".into(),
+                    kelas: None,
+                    jurusan: None,
+                    agama: None,
+                    jenis_kelamin: None,
+                    no_telp: None,
+                    email: None,
+                },
+            ],
+            false,
+        )
+        .expect("import ok");
+        assert_eq!(result.inserted, 0);
+        assert_eq!(result.skipped, 2);
+        assert_eq!(result.errors.len(), 2);
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/buku_isbn.rs
+++ b/apps/desktop/src-tauri/src/commands/buku_isbn.rs
@@ -1,0 +1,510 @@
+//! FEAT-20 — Bulk import buku via ISBN.
+//!
+//! Fetches metadata from Open Library first, falls back to Google Books.
+//! Both are public read-only APIs that do not require authentication.
+//! The batch lookup is rate-limited to ~1 req/sec per upstream guidance.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::error::{AppError, AppResult};
+
+/// Metadata returned by an ISBN lookup. All fields are optional except `isbn`.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IsbnMetadata {
+    pub isbn: String,
+    pub judul: Option<String>,
+    pub pengarang: Option<String>,
+    pub penerbit: Option<String>,
+    pub tahun_terbit: Option<i64>,
+    pub kategori: Option<String>,
+    pub bahasa: Option<String>,
+    /// Optional cover image URL, downloadable separately.
+    pub cover_url: Option<String>,
+    /// Which upstream produced this record. Empty when not found.
+    pub source: String,
+}
+
+/// Result for a single requested ISBN — either a populated metadata or `None`
+/// when both upstreams returned nothing. `error` is set when the lookup itself
+/// failed (network error, unparseable response, etc.).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IsbnLookupResult {
+    pub isbn: String,
+    pub metadata: Option<IsbnMetadata>,
+    pub error: Option<String>,
+}
+
+/// HTTP client abstraction so tests can avoid real network calls.
+pub trait IsbnHttpClient: Send + Sync {
+    fn get_json(&self, url: &str) -> Result<serde_json::Value, String>;
+}
+
+/// Default ureq-backed client used by the Tauri command.
+pub struct UreqClient {
+    pub timeout: Duration,
+}
+
+impl UreqClient {
+    pub fn new() -> Self {
+        Self {
+            timeout: Duration::from_secs(8),
+        }
+    }
+}
+
+impl Default for UreqClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IsbnHttpClient for UreqClient {
+    fn get_json(&self, url: &str) -> Result<serde_json::Value, String> {
+        let agent = ureq::AgentBuilder::new()
+            .timeout(self.timeout)
+            .user_agent(concat!(
+                "perpustakaan-offline/",
+                env!("CARGO_PKG_VERSION"),
+                " (alvi arts)"
+            ))
+            .build();
+        let resp = agent.get(url).call().map_err(|e| e.to_string())?;
+        resp.into_json::<serde_json::Value>().map_err(|e| e.to_string())
+    }
+}
+
+/// Normalize an ISBN-10 or ISBN-13 by stripping spaces and dashes. Returns
+/// `None` when the result is not 10 or 13 digits (with optional trailing `X`
+/// for ISBN-10 check digit).
+pub fn normalize_isbn(raw: &str) -> Option<String> {
+    let cleaned: String = raw
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_uppercase();
+    if cleaned.len() == 10 {
+        let valid = cleaned.chars().enumerate().all(|(i, c)| {
+            if i < 9 {
+                c.is_ascii_digit()
+            } else {
+                c.is_ascii_digit() || c == 'X'
+            }
+        });
+        if valid {
+            return Some(cleaned);
+        }
+    } else if cleaned.len() == 13 && cleaned.chars().all(|c| c.is_ascii_digit()) {
+        return Some(cleaned);
+    }
+    None
+}
+
+/// Try Open Library first, then Google Books. Returns `Ok(None)` when neither
+/// upstream has a record. Returns `Err` when both upstreams errored.
+pub fn lookup_one(client: &dyn IsbnHttpClient, isbn: &str) -> Result<Option<IsbnMetadata>, String> {
+    let normalized = match normalize_isbn(isbn) {
+        Some(v) => v,
+        None => return Err(format!("ISBN tidak valid: {isbn}")),
+    };
+
+    // 1) Open Library
+    let ol_url = format!(
+        "https://openlibrary.org/api/books?bibkeys=ISBN:{normalized}&format=json&jscmd=data"
+    );
+    let ol_err = match client.get_json(&ol_url) {
+        Ok(json) => match parse_open_library(&normalized, &json) {
+            Some(meta) => return Ok(Some(meta)),
+            None => None,
+        },
+        Err(e) => Some(e),
+    };
+
+    // 2) Google Books fallback
+    let gb_url = format!("https://www.googleapis.com/books/v1/volumes?q=isbn:{normalized}");
+    let gb_err = match client.get_json(&gb_url) {
+        Ok(json) => match parse_google_books(&normalized, &json) {
+            Some(meta) => return Ok(Some(meta)),
+            None => None,
+        },
+        Err(e) => Some(e),
+    };
+
+    // Both responded but neither had a record → not found.
+    if ol_err.is_none() && gb_err.is_none() {
+        return Ok(None);
+    }
+    // Both errored → propagate combined message.
+    let mut messages = Vec::new();
+    if let Some(e) = ol_err {
+        messages.push(format!("OL: {e}"));
+    }
+    if let Some(e) = gb_err {
+        messages.push(format!("GB: {e}"));
+    }
+    Err(messages.join("; "))
+}
+
+fn parse_open_library(isbn: &str, json: &serde_json::Value) -> Option<IsbnMetadata> {
+    let key = format!("ISBN:{isbn}");
+    let book = json.get(&key)?;
+    let judul = book
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let pengarang = book
+        .get("authors")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            let names: Vec<String> = arr
+                .iter()
+                .filter_map(|a| a.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+                .collect();
+            if names.is_empty() {
+                None
+            } else {
+                Some(names.join(", "))
+            }
+        });
+    let penerbit = book
+        .get("publishers")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            let names: Vec<String> = arr
+                .iter()
+                .filter_map(|a| a.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+                .collect();
+            if names.is_empty() {
+                None
+            } else {
+                Some(names.join(", "))
+            }
+        });
+    let tahun_terbit = book
+        .get("publish_date")
+        .and_then(|v| v.as_str())
+        .and_then(extract_year);
+    let kategori = book
+        .get("subjects")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.first()
+                .and_then(|s| s.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+        });
+    let cover_url = book
+        .get("cover")
+        .and_then(|c| c.get("medium").or_else(|| c.get("large")).or_else(|| c.get("small")))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    if judul.is_none() && pengarang.is_none() && penerbit.is_none() {
+        return None;
+    }
+    Some(IsbnMetadata {
+        isbn: isbn.to_string(),
+        judul,
+        pengarang,
+        penerbit,
+        tahun_terbit,
+        kategori,
+        bahasa: None,
+        cover_url,
+        source: "openlibrary".into(),
+    })
+}
+
+fn parse_google_books(isbn: &str, json: &serde_json::Value) -> Option<IsbnMetadata> {
+    let items = json.get("items")?.as_array()?;
+    let first = items.first()?;
+    let info = first.get("volumeInfo")?;
+    let judul = info
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let pengarang = info
+        .get("authors")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            let names: Vec<String> = arr
+                .iter()
+                .filter_map(|a| a.as_str().map(|s| s.to_string()))
+                .collect();
+            if names.is_empty() {
+                None
+            } else {
+                Some(names.join(", "))
+            }
+        });
+    let penerbit = info
+        .get("publisher")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let tahun_terbit = info
+        .get("publishedDate")
+        .and_then(|v| v.as_str())
+        .and_then(extract_year);
+    let kategori = info
+        .get("categories")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first().and_then(|s| s.as_str()).map(|s| s.to_string()));
+    let bahasa = info
+        .get("language")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let cover_url = info
+        .get("imageLinks")
+        .and_then(|c| c.get("thumbnail").or_else(|| c.get("smallThumbnail")))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    if judul.is_none() && pengarang.is_none() && penerbit.is_none() {
+        return None;
+    }
+    Some(IsbnMetadata {
+        isbn: isbn.to_string(),
+        judul,
+        pengarang,
+        penerbit,
+        tahun_terbit,
+        kategori,
+        bahasa,
+        cover_url,
+        source: "googlebooks".into(),
+    })
+}
+
+fn extract_year(s: &str) -> Option<i64> {
+    let digits: String = s.chars().filter(|c| c.is_ascii_digit()).take(4).collect();
+    if digits.len() < 4 {
+        return None;
+    }
+    digits.parse::<i64>().ok().filter(|y| (1000..=2100).contains(y))
+}
+
+/// Tauri command: batch ISBN metadata lookup. Throttles ~1 req/sec to respect
+/// Open Library rate limits.
+#[tauri::command]
+pub fn buku_isbn_lookup_batch(isbns: Vec<String>) -> AppResult<Vec<IsbnLookupResult>> {
+    let client = UreqClient::new();
+    let mut out = Vec::with_capacity(isbns.len());
+    for (idx, isbn) in isbns.iter().enumerate() {
+        if idx > 0 {
+            // Throttle to be polite to OL.
+            std::thread::sleep(Duration::from_millis(1000));
+        }
+        let result = match lookup_one(&client, isbn) {
+            Ok(opt) => IsbnLookupResult {
+                isbn: isbn.clone(),
+                metadata: opt,
+                error: None,
+            },
+            Err(e) => IsbnLookupResult {
+                isbn: isbn.clone(),
+                metadata: None,
+                error: Some(e),
+            },
+        };
+        out.push(result);
+    }
+    Ok(out)
+}
+
+/// Tauri command: download a cover URL into base64. Returned as `data:image/...;base64,...`
+/// The frontend can persist it via the existing buku cover save path or attach it later.
+#[tauri::command]
+pub fn buku_isbn_fetch_cover(url: String) -> AppResult<String> {
+    let agent = ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(10))
+        .user_agent(concat!(
+            "perpustakaan-offline/",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .build();
+    let resp = agent
+        .get(&url)
+        .call()
+        .map_err(|e| AppError::Internal(format!("cover fetch: {e}")))?;
+    let mime = resp
+        .header("Content-Type")
+        .unwrap_or("image/jpeg")
+        .to_string();
+    let mut buf: Vec<u8> = Vec::with_capacity(64 * 1024);
+    use std::io::Read;
+    resp.into_reader()
+        .take(2 * 1024 * 1024) // 2 MiB cap
+        .read_to_end(&mut buf)
+        .map_err(|e| AppError::Internal(format!("cover read: {e}")))?;
+    use base64::Engine as _;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&buf);
+    Ok(format!("data:{mime};base64,{b64}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct MockClient {
+        responses: Mutex<HashMap<String, Result<serde_json::Value, String>>>,
+    }
+
+    impl MockClient {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(HashMap::new()),
+            }
+        }
+        fn with(self, url: &str, value: serde_json::Value) -> Self {
+            self.responses.lock().unwrap().insert(url.into(), Ok(value));
+            self
+        }
+        fn with_err(self, url: &str, err: &str) -> Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .insert(url.into(), Err(err.into()));
+            self
+        }
+    }
+
+    impl IsbnHttpClient for MockClient {
+        fn get_json(&self, url: &str) -> Result<serde_json::Value, String> {
+            self.responses
+                .lock()
+                .unwrap()
+                .get(url)
+                .cloned()
+                .unwrap_or_else(|| Err(format!("no mock for {url}")))
+        }
+    }
+
+    #[test]
+    fn normalize_isbn_strips_dashes_and_spaces() {
+        assert_eq!(
+            normalize_isbn("978-602-7888-71-2").as_deref(),
+            Some("9786027888712")
+        );
+        assert_eq!(normalize_isbn("0 306 40615 2").as_deref(), Some("0306406152"));
+        assert_eq!(normalize_isbn("020161622X").as_deref(), Some("020161622X"));
+    }
+
+    #[test]
+    fn normalize_isbn_rejects_invalid() {
+        assert_eq!(normalize_isbn("123"), None);
+        assert_eq!(normalize_isbn("abc"), None);
+        assert_eq!(normalize_isbn("978-FOO-BAR"), None);
+    }
+
+    #[test]
+    fn extract_year_handles_various_formats() {
+        assert_eq!(extract_year("1980"), Some(1980));
+        assert_eq!(extract_year("1980-04-15"), Some(1980));
+        assert_eq!(extract_year("April 1980"), Some(1980));
+        assert_eq!(extract_year("April"), None);
+        assert_eq!(extract_year("9999"), None);
+    }
+
+    #[test]
+    fn lookup_one_uses_open_library_when_available() {
+        let isbn = "9786027888712";
+        let ol_url = format!(
+            "https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
+        );
+        let ol_payload = serde_json::json!({
+            format!("ISBN:{isbn}"): {
+                "title": "Bumi Manusia",
+                "authors": [{"name": "Pramoedya Ananta Toer"}],
+                "publishers": [{"name": "Hasta Mitra"}],
+                "publish_date": "1980",
+                "subjects": [{"name": "Fiction"}],
+                "cover": {"medium": "https://covers.openlibrary.org/b/id/123-M.jpg"}
+            }
+        });
+        let client = MockClient::new().with(&ol_url, ol_payload);
+        let result = lookup_one(&client, isbn).unwrap().unwrap();
+        assert_eq!(result.judul.as_deref(), Some("Bumi Manusia"));
+        assert_eq!(result.pengarang.as_deref(), Some("Pramoedya Ananta Toer"));
+        assert_eq!(result.penerbit.as_deref(), Some("Hasta Mitra"));
+        assert_eq!(result.tahun_terbit, Some(1980));
+        assert_eq!(result.source, "openlibrary");
+        assert!(result.cover_url.is_some());
+    }
+
+    #[test]
+    fn lookup_one_falls_back_to_google_books() {
+        let isbn = "9780321125217";
+        let ol_url = format!(
+            "https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
+        );
+        let gb_url = format!("https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}");
+        // OL responds with an empty object → not found.
+        let ol_payload = serde_json::json!({});
+        // GB returns a hit.
+        let gb_payload = serde_json::json!({
+            "items": [{
+                "volumeInfo": {
+                    "title": "Domain-Driven Design",
+                    "authors": ["Eric Evans"],
+                    "publisher": "Addison-Wesley",
+                    "publishedDate": "2003-08-30",
+                    "categories": ["Computers"],
+                    "language": "en",
+                    "imageLinks": {
+                        "thumbnail": "https://example.com/cover.jpg"
+                    }
+                }
+            }]
+        });
+        let client = MockClient::new()
+            .with(&ol_url, ol_payload)
+            .with(&gb_url, gb_payload);
+        let result = lookup_one(&client, isbn).unwrap().unwrap();
+        assert_eq!(result.judul.as_deref(), Some("Domain-Driven Design"));
+        assert_eq!(result.pengarang.as_deref(), Some("Eric Evans"));
+        assert_eq!(result.tahun_terbit, Some(2003));
+        assert_eq!(result.source, "googlebooks");
+    }
+
+    #[test]
+    fn lookup_one_returns_none_when_both_upstreams_empty() {
+        let isbn = "9999999999999";
+        let ol_url = format!(
+            "https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
+        );
+        let gb_url = format!("https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}");
+        let client = MockClient::new()
+            .with(&ol_url, serde_json::json!({}))
+            .with(&gb_url, serde_json::json!({"items": []}));
+        let result = lookup_one(&client, isbn).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_one_returns_err_when_both_upstreams_fail() {
+        let isbn = "9786027888712";
+        let ol_url = format!(
+            "https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
+        );
+        let gb_url = format!("https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}");
+        let client = MockClient::new()
+            .with_err(&ol_url, "timeout")
+            .with_err(&gb_url, "503");
+        let result = lookup_one(&client, isbn);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("OL"));
+        assert!(msg.contains("GB"));
+    }
+
+    #[test]
+    fn lookup_one_rejects_invalid_isbn_without_calling_upstream() {
+        let client = MockClient::new();
+        let result = lookup_one(&client, "abc-not-an-isbn");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("ISBN tidak valid"));
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod backup;
 pub mod backup_extra;
 pub mod backup_runner;
 pub mod buku;
+pub mod buku_isbn;
 pub mod close_behavior;
 pub mod dashboard;
 pub mod export;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -126,6 +126,8 @@ pub fn run() {
             commands::buku::buku_update,
             commands::buku::buku_delete,
             commands::buku::buku_import,
+            commands::buku_isbn::buku_isbn_lookup_batch,
+            commands::buku_isbn::buku_isbn_fetch_cover,
             commands::buku::eksemplar_create,
             commands::buku::eksemplar_delete,
             commands::master_data::master_list,

--- a/apps/desktop/src/components/shared/ImportWizard.tsx
+++ b/apps/desktop/src/components/shared/ImportWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CheckCircle2, AlertTriangle, Download, FileSpreadsheet, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -49,6 +49,12 @@ export interface ImportWizardImportError {
 
 export interface ImportWizardResult {
   inserted: number;
+  /**
+   * Optional count of rows that updated an existing record (e.g. anggota
+   * import overwrite mode). Backends that don't support overwrite simply
+   * omit this field.
+   */
+  updated?: number;
   skipped: number;
   errors: ImportWizardImportError[];
 }
@@ -72,6 +78,11 @@ export interface ImportWizardProps<TItem> {
   onImport: (items: TItem[]) => Promise<ImportWizardResult>;
   /** Called once submission completes successfully. */
   onImported: (result: ImportWizardResult) => void;
+  /**
+   * Optional extra controls rendered above the preview submit row, e.g.
+   * an "update existing rows" toggle for the anggota import.
+   */
+  extras?: ReactNode;
 }
 
 type Step = 'upload' | 'map' | 'preview' | 'result';
@@ -90,6 +101,7 @@ export function ImportWizard<TItem>(
     rowParser,
     onImport,
     onImported,
+    extras,
   } = props;
 
   const { t } = useTranslation(['common']);
@@ -159,6 +171,7 @@ export function ImportWizard<TItem>(
       // original spreadsheet row (header is row 1, first data is row 2).
       const rebased: ImportWizardResult = {
         inserted: r.inserted,
+        updated: r.updated,
         skipped: r.skipped + invalidRows.length,
         errors: [
           ...invalidRows.map((row) => ({
@@ -240,6 +253,7 @@ export function ImportWizard<TItem>(
             mapping={mapping}
             invalidCount={invalidRows.length}
             validCount={validRows.length}
+            extras={extras}
           />
         )}
 
@@ -492,6 +506,7 @@ interface PreviewStepProps<TItem> {
   mapping: Mapping;
   validCount: number;
   invalidCount: number;
+  extras?: ReactNode;
 }
 
 function PreviewStep<TItem>({
@@ -499,6 +514,7 @@ function PreviewStep<TItem>({
   fields,
   validCount,
   invalidCount,
+  extras,
 }: PreviewStepProps<TItem>) {
   const { t } = useTranslation(['common']);
   const visibleFields = fields.slice(0, 5);
@@ -531,6 +547,7 @@ function PreviewStep<TItem>({
           })}
         </span>
       </div>
+      {extras && <div className="rounded-md border bg-muted/30 p-3">{extras}</div>}
       <div className="rounded-md border">
         <div className="max-h-[40vh] overflow-y-auto">
           <Table>
@@ -583,13 +600,21 @@ function ResultStep({ result, onDownloadErrors }: ResultStepProps) {
   const { t } = useTranslation(['common']);
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <div className="rounded-md border bg-emerald-50 p-3 text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-200">
           <p className="text-xs uppercase tracking-wide">
             {t('common:importWizard.result.inserted', 'Ditambahkan')}
           </p>
           <p className="text-2xl font-semibold">{result.inserted}</p>
         </div>
+        {result.updated != null && (
+          <div className="rounded-md border bg-sky-50 p-3 text-sky-800 dark:bg-sky-500/10 dark:text-sky-200">
+            <p className="text-xs uppercase tracking-wide">
+              {t('common:importWizard.result.updated', 'Diperbarui')}
+            </p>
+            <p className="text-2xl font-semibold">{result.updated}</p>
+          </div>
+        )}
         <div className="rounded-md border p-3">
           <p className="text-xs uppercase tracking-wide text-muted-foreground">
             {t('common:importWizard.result.skipped', 'Dilewati')}

--- a/apps/desktop/src/features/anggota/ImportExcelDialog.tsx
+++ b/apps/desktop/src/features/anggota/ImportExcelDialog.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Checkbox } from '@/components/ui/checkbox';
 import { ImportWizard } from '@/components/shared/ImportWizard';
 import { anggotaApi, type AnggotaImportItem } from '@/lib/anggota';
 import type { ImportWizardResult } from '@/components/shared/ImportWizard';
@@ -12,6 +14,7 @@ interface ImportExcelDialogProps {
 
 export function ImportExcelDialog({ open, onOpenChange, onImported }: ImportExcelDialogProps) {
   const { t } = useTranslation(['anggota', 'common']);
+  const [updateExisting, setUpdateExisting] = useState(false);
 
   const fields: ImportFieldDef<AnggotaImportItem>[] = [
     {
@@ -101,6 +104,28 @@ export function ImportExcelDialog({ open, onOpenChange, onImported }: ImportExce
     return item;
   };
 
+  const overwriteToggle = (
+    <label className="flex items-start gap-3" data-testid="anggota-import-overwrite-toggle">
+      <Checkbox
+        checked={updateExisting}
+        onCheckedChange={(v) => setUpdateExisting(v === true)}
+      />
+      <span className="space-y-1 text-sm leading-tight">
+        <span className="block font-medium">
+          {t('anggota:import.overwriteLabel', {
+            defaultValue: 'Perbarui anggota yang sudah ada',
+          })}
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          {t('anggota:import.overwriteHelp', {
+            defaultValue:
+              'Jika kode anggota sudah ada di database, baris akan menimpa data lama (mode update). Default: dilewati.',
+          })}
+        </span>
+      </span>
+    </label>
+  );
+
   return (
     <ImportWizard<AnggotaImportItem>
       open={open}
@@ -114,10 +139,12 @@ export function ImportExcelDialog({ open, onOpenChange, onImported }: ImportExce
       templateSheetName="Anggota"
       templateFilename="template-impor-anggota.xlsx"
       rowParser={rowParser}
+      extras={overwriteToggle}
       onImport={async (items) => {
-        const r = await anggotaApi.importBatch(items);
+        const r = await anggotaApi.importBatch(items, { updateExisting });
         return {
           inserted: r.inserted,
+          updated: r.updated,
           skipped: r.skipped,
           errors: r.errors.map((e) => ({
             row: e.row,

--- a/apps/desktop/src/features/buku/BukuList.tsx
+++ b/apps/desktop/src/features/buku/BukuList.tsx
@@ -10,6 +10,7 @@ import {
   Pencil,
   Plus,
   Printer,
+  ScanLine,
   Search,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -28,6 +29,7 @@ import { bukuApi, type Buku, type BukuDetail } from '@/lib/buku';
 import { masterDataApi, type MasterItem } from '@/lib/masterData';
 import { useToast } from '@/components/ui/toast-manager';
 import { ImportBukuDialog } from './ImportBukuDialog';
+import { IsbnImportDialog } from './IsbnImportDialog';
 
 const PAGE_SIZE = 20;
 
@@ -70,6 +72,7 @@ export function BukuList({ search, onSearchChange }: BukuListProps) {
   const [kategoriOptions, setKategoriOptions] = useState<MasterItem[]>([]);
   const [bahasaOptions, setBahasaOptions] = useState<MasterItem[]>([]);
   const [importOpen, setImportOpen] = useState(false);
+  const [isbnImportOpen, setIsbnImportOpen] = useState(false);
   const [detail, setDetail] = useState<BukuDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
 
@@ -207,6 +210,14 @@ export function BukuList({ search, onSearchChange }: BukuListProps) {
             <FileSpreadsheet className="mr-2 h-4 w-4" />
             {t('buku:list.import')}
           </Button>
+          <Button
+            variant="outline"
+            onClick={() => setIsbnImportOpen(true)}
+            data-testid="buku-import-isbn"
+          >
+            <ScanLine className="mr-2 h-4 w-4" />
+            {t('buku:list.importIsbn', { defaultValue: 'Impor via ISBN' })}
+          </Button>
           <Button variant="outline" asChild data-testid="buku-cetak-label">
             <Link to="/buku/cetak-label">
               <Printer className="mr-2 h-4 w-4" />
@@ -330,6 +341,13 @@ export function BukuList({ search, onSearchChange }: BukuListProps) {
       <ImportBukuDialog
         open={importOpen}
         onOpenChange={setImportOpen}
+        onImported={() => {
+          void reload();
+        }}
+      />
+      <IsbnImportDialog
+        open={isbnImportOpen}
+        onOpenChange={setIsbnImportOpen}
         onImported={() => {
           void reload();
         }}

--- a/apps/desktop/src/features/buku/IsbnImportDialog.tsx
+++ b/apps/desktop/src/features/buku/IsbnImportDialog.tsx
@@ -1,0 +1,429 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, CheckCircle2, Loader2, Upload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast-manager';
+import { formatTauriError } from '@/lib/errors';
+import {
+  bukuApi,
+  bukuIsbnApi,
+  metadataToImportItem,
+  type BukuImportItem,
+  type IsbnLookupResult,
+  type IsbnMetadata,
+} from '@/lib/buku';
+
+interface IsbnImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImported: () => void;
+}
+
+type Step = 'input' | 'preview' | 'result';
+
+interface PreviewRow {
+  /** ISBN as typed by the user, kept verbatim for the row label. */
+  raw: string;
+  /** Result returned by the backend; null while still loading. */
+  result: IsbnLookupResult | null;
+  /** User-editable kodeBuku (auto-suggested but overridable). */
+  kodeBuku: string;
+  /**
+   * `true` when the row should be inserted on submit. Defaults to true when
+   * the lookup found metadata, false when nothing was found or the lookup
+   * errored.
+   */
+  selected: boolean;
+}
+
+interface ImportSummary {
+  inserted: number;
+  skipped: number;
+  errors: { row: number; message: string }[];
+}
+
+/**
+ * Suggest a kodeBuku based on the ISBN. Format: `B-<last 5 digits>` so admins
+ * see a deterministic, short, mnemonic prefix that they can override.
+ */
+function suggestKode(isbn: string): string {
+  const digits = isbn.replace(/[^0-9]/g, '');
+  const tail = digits.slice(-5).padStart(5, '0');
+  return `B-${tail}`;
+}
+
+/**
+ * Split a free-form textarea into individual ISBN candidates. Splits on
+ * whitespace, commas, semicolons, and newlines; trims and dedupes.
+ */
+export function parseIsbnList(input: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const token of input.split(/[\s,;]+/)) {
+    const trimmed = token.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toUpperCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+export function IsbnImportDialog({ open, onOpenChange, onImported }: IsbnImportDialogProps) {
+  const { t } = useTranslation(['buku', 'common']);
+  const { showToast } = useToast();
+  const [step, setStep] = useState<Step>('input');
+  const [text, setText] = useState('');
+  const [rows, setRows] = useState<PreviewRow[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setStep('input');
+      setText('');
+      setRows([]);
+      setBusy(false);
+      setSummary(null);
+    }
+  }, [open]);
+
+  const isbns = useMemo(() => parseIsbnList(text), [text]);
+
+  const handleLookup = async (): Promise<void> => {
+    if (isbns.length === 0) return;
+    setBusy(true);
+    try {
+      const results = await bukuIsbnApi.lookupBatch(isbns);
+      const next: PreviewRow[] = results.map((r) => ({
+        raw: r.isbn,
+        result: r,
+        kodeBuku: suggestKode(r.metadata?.isbn ?? r.isbn),
+        selected: r.metadata != null,
+      }));
+      setRows(next);
+      setStep('preview');
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('buku:isbnImport.lookupFailedTitle', {
+          defaultValue: 'Gagal mengambil metadata ISBN',
+        }),
+        description: formatTauriError(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const updateRow = (idx: number, patch: Partial<PreviewRow>): void => {
+    setRows((prev) => prev.map((row, i) => (i === idx ? { ...row, ...patch } : row)));
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    const items: BukuImportItem[] = [];
+    const skippedReasons: { row: number; message: string }[] = [];
+    rows.forEach((row, idx) => {
+      const rowNo = idx + 1;
+      if (!row.selected) {
+        skippedReasons.push({
+          row: rowNo,
+          message: t('buku:isbnImport.skipUnselected', {
+            defaultValue: 'Tidak dipilih',
+          }),
+        });
+        return;
+      }
+      const meta: IsbnMetadata | null = row.result?.metadata ?? null;
+      if (!meta) {
+        skippedReasons.push({
+          row: rowNo,
+          message:
+            row.result?.error ??
+            t('buku:isbnImport.notFound', {
+              defaultValue: 'Tidak ada metadata',
+            }),
+        });
+        return;
+      }
+      const item = metadataToImportItem(meta, row.kodeBuku);
+      if (!item) {
+        skippedReasons.push({
+          row: rowNo,
+          message: t('buku:isbnImport.missingJudul', {
+            defaultValue: 'Judul tidak tersedia',
+          }),
+        });
+        return;
+      }
+      items.push(item);
+    });
+
+    if (items.length === 0) {
+      showToast({
+        variant: 'destructive',
+        title: t('buku:isbnImport.nothingToImport', {
+          defaultValue: 'Tidak ada baris yang siap diimpor',
+        }),
+      });
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const r = await bukuApi.importBatch(items);
+      setSummary({
+        inserted: r.inserted,
+        skipped: r.skipped + skippedReasons.length,
+        errors: [
+          ...skippedReasons,
+          ...r.errors.map((e) => ({ row: e.row, message: e.message })),
+        ].sort((a, b) => a.row - b.row),
+      });
+      setStep('result');
+      onImported();
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('buku:isbnImport.importFailedTitle', {
+          defaultValue: 'Gagal menyimpan buku',
+        }),
+        description: formatTauriError(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>
+            {t('buku:isbnImport.title', { defaultValue: 'Impor Buku via ISBN' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('buku:isbnImport.description', {
+              defaultValue:
+                'Tempel daftar ISBN (satu per baris atau dipisah koma). Aplikasi akan mencari metadata di Open Library lalu Google Books.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 'input' && (
+          <div className="space-y-3">
+            <textarea
+              data-testid="isbn-import-textarea"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              spellCheck={false}
+              className="h-48 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="9786020385945&#10;978-602-03-1234-5&#10;0140449132"
+            />
+            <p className="text-xs text-muted-foreground">
+              {t('buku:isbnImport.parsedHint', {
+                defaultValue: '{{count}} ISBN siap dicari',
+                count: isbns.length,
+              })}
+            </p>
+          </div>
+        )}
+
+        {step === 'preview' && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <Badge variant="outline" className="gap-1">
+                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+                {t('buku:isbnImport.previewFound', {
+                  defaultValue: '{{count}} metadata ditemukan',
+                  count: rows.filter((r) => r.result?.metadata).length,
+                })}
+              </Badge>
+              {rows.some((r) => !r.result?.metadata) && (
+                <Badge variant="outline" className="gap-1 border-destructive/40 text-destructive">
+                  <AlertTriangle className="h-3 w-3" />
+                  {t('buku:isbnImport.previewMissing', {
+                    defaultValue: '{{count}} tidak ditemukan',
+                    count: rows.filter((r) => !r.result?.metadata).length,
+                  })}
+                </Badge>
+              )}
+            </div>
+            <div className="rounded-md border">
+              <div className="max-h-[40vh] overflow-y-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-10">#</TableHead>
+                      <TableHead className="w-10" />
+                      <TableHead>ISBN</TableHead>
+                      <TableHead>{t('buku:isbnImport.colKode', { defaultValue: 'Kode Buku' })}</TableHead>
+                      <TableHead>{t('buku:fields.judul', { defaultValue: 'Judul' })}</TableHead>
+                      <TableHead>{t('buku:fields.pengarang', { defaultValue: 'Pengarang' })}</TableHead>
+                      <TableHead>{t('buku:isbnImport.colSource', { defaultValue: 'Sumber' })}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.map((row, idx) => {
+                      const meta = row.result?.metadata;
+                      const err = row.result?.error;
+                      return (
+                        <TableRow
+                          key={`${row.raw}-${idx}`}
+                          className={!meta ? 'bg-destructive/10 hover:bg-destructive/15' : ''}
+                        >
+                          <TableCell className="text-xs text-muted-foreground">{idx + 1}</TableCell>
+                          <TableCell>
+                            <input
+                              type="checkbox"
+                              data-testid={`isbn-import-row-${idx}-selected`}
+                              checked={row.selected}
+                              disabled={!meta}
+                              onChange={(e) => updateRow(idx, { selected: e.target.checked })}
+                            />
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">{row.raw}</TableCell>
+                          <TableCell>
+                            <Input
+                              data-testid={`isbn-import-row-${idx}-kode`}
+                              value={row.kodeBuku}
+                              onChange={(e) => updateRow(idx, { kodeBuku: e.target.value })}
+                              className="h-8 w-32 font-mono text-xs"
+                            />
+                          </TableCell>
+                          <TableCell className="text-xs">
+                            {meta?.judul ?? (
+                              <span className="text-destructive">
+                                {err ??
+                                  t('buku:isbnImport.notFound', {
+                                    defaultValue: 'Tidak ada metadata',
+                                  })}
+                              </span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-xs">{meta?.pengarang ?? '—'}</TableCell>
+                          <TableCell className="text-xs uppercase text-muted-foreground">
+                            {meta?.source ?? '—'}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {step === 'result' && summary && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              <div className="rounded-md border bg-emerald-50 p-3 text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-200">
+                <p className="text-xs uppercase tracking-wide">
+                  {t('common:importWizard.result.inserted', 'Ditambahkan')}
+                </p>
+                <p className="text-2xl font-semibold">{summary.inserted}</p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('common:importWizard.result.skipped', 'Dilewati')}
+                </p>
+                <p className="text-2xl font-semibold">{summary.skipped}</p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('common:importWizard.result.errors', 'Error')}
+                </p>
+                <p className="text-2xl font-semibold">{summary.errors.length}</p>
+              </div>
+            </div>
+            {summary.errors.length > 0 && (
+              <div className="rounded-md border">
+                <div className="max-h-60 overflow-y-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>#</TableHead>
+                        <TableHead>{t('common:importWizard.preview.colError', 'Error')}</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {summary.errors.map((e) => (
+                        <TableRow key={`${e.row}-${e.message}`}>
+                          <TableCell className="text-xs text-muted-foreground">{e.row}</TableCell>
+                          <TableCell className="text-xs text-destructive">{e.message}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          {step === 'input' && (
+            <>
+              <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+                {t('common:actions.cancel', 'Batal')}
+              </Button>
+              <Button
+                onClick={() => void handleLookup()}
+                disabled={busy || isbns.length === 0}
+                data-testid="isbn-import-lookup"
+              >
+                {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
+                {t('buku:isbnImport.lookup', { defaultValue: 'Cari Metadata' })}
+              </Button>
+            </>
+          )}
+          {step === 'preview' && (
+            <>
+              <Button variant="ghost" onClick={() => setStep('input')} disabled={busy}>
+                {t('common:actions.back', 'Kembali')}
+              </Button>
+              <Button
+                onClick={() => void handleSubmit()}
+                disabled={busy || rows.every((r) => !r.selected)}
+                data-testid="isbn-import-submit"
+              >
+                {busy ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : null}
+                {t('buku:isbnImport.import', {
+                  defaultValue: 'Impor {{count}} buku',
+                  count: rows.filter((r) => r.selected).length,
+                })}
+              </Button>
+            </>
+          )}
+          {step === 'result' && (
+            <Button onClick={() => onOpenChange(false)}>
+              {t('common:actions.close', 'Tutup')}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/i18n/en/anggota.json
+++ b/apps/desktop/src/i18n/en/anggota.json
@@ -85,7 +85,9 @@
     "summary": "Imported: {{inserted}} • Skipped: {{skipped}}",
     "errorRow": "Row {{row}}: {{message}}",
     "noFile": "No file selected yet.",
-    "parseError": "Failed to read file: {{message}}"
+    "parseError": "Failed to read file: {{message}}",
+    "overwriteLabel": "Update existing members",
+    "overwriteHelp": "If a member code already exists in the database, the row will overwrite the existing record (update mode). Default: skip duplicates."
   },
   "feedback": {
     "createSuccess": "Member added successfully.",

--- a/apps/desktop/src/i18n/en/buku.json
+++ b/apps/desktop/src/i18n/en/buku.json
@@ -11,7 +11,8 @@
     "empty": "No books yet. Add the first one or import from Excel.",
     "emptyFiltered": "No books match the current filters.",
     "showing": "Showing {{from}}–{{to}} of {{total}}",
-    "loadingDetail": "Loading detail…"
+    "loadingDetail": "Loading detail…",
+    "importIsbn": "Import via ISBN"
   },
   "columns": {
     "kode": "Code",
@@ -102,5 +103,22 @@
   "breadcrumb": {
     "new": "Add",
     "edit": "Edit"
+  },
+  "isbnImport": {
+    "title": "Import Books via ISBN",
+    "description": "Paste a list of ISBNs (one per line or comma-separated). The app will look up metadata from Open Library then Google Books.",
+    "parsedHint": "{{count}} ISBNs ready to look up",
+    "lookup": "Look up metadata",
+    "lookupFailedTitle": "Failed to fetch ISBN metadata",
+    "previewFound": "{{count}} metadata found",
+    "previewMissing": "{{count}} not found",
+    "colKode": "Book Code",
+    "colSource": "Source",
+    "notFound": "No metadata",
+    "skipUnselected": "Not selected",
+    "missingJudul": "Title missing",
+    "nothingToImport": "Nothing to import",
+    "import": "Import {{count}} books",
+    "importFailedTitle": "Failed to save books"
   }
 }

--- a/apps/desktop/src/i18n/en/common.json
+++ b/apps/desktop/src/i18n/en/common.json
@@ -106,6 +106,7 @@
     },
     "result": {
       "inserted": "Inserted",
+      "updated": "Updated",
       "skipped": "Skipped",
       "errors": "Errors",
       "errorListTitle": "Error list",

--- a/apps/desktop/src/i18n/id/anggota.json
+++ b/apps/desktop/src/i18n/id/anggota.json
@@ -85,7 +85,9 @@
     "summary": "Berhasil: {{inserted}} • Dilewati: {{skipped}}",
     "errorRow": "Baris {{row}}: {{message}}",
     "noFile": "Belum ada file yang dipilih.",
-    "parseError": "Gagal membaca file: {{message}}"
+    "parseError": "Gagal membaca file: {{message}}",
+    "overwriteLabel": "Perbarui anggota yang sudah ada",
+    "overwriteHelp": "Jika kode anggota sudah ada di database, baris akan menimpa data lama (mode update). Default: dilewati."
   },
   "feedback": {
     "createSuccess": "Anggota berhasil ditambahkan.",

--- a/apps/desktop/src/i18n/id/buku.json
+++ b/apps/desktop/src/i18n/id/buku.json
@@ -11,7 +11,8 @@
     "empty": "Belum ada buku. Tambahkan buku pertama atau import dari Excel.",
     "emptyFiltered": "Tidak ada buku yang cocok dengan filter.",
     "showing": "Menampilkan {{from}}–{{to}} dari {{total}}",
-    "loadingDetail": "Memuat detail…"
+    "loadingDetail": "Memuat detail…",
+    "importIsbn": "Impor via ISBN"
   },
   "columns": {
     "kode": "Kode",
@@ -102,5 +103,22 @@
   "breadcrumb": {
     "new": "Tambah",
     "edit": "Edit"
+  },
+  "isbnImport": {
+    "title": "Impor Buku via ISBN",
+    "description": "Tempel daftar ISBN (satu per baris atau dipisah koma). Aplikasi akan mencari metadata di Open Library lalu Google Books.",
+    "parsedHint": "{{count}} ISBN siap dicari",
+    "lookup": "Cari Metadata",
+    "lookupFailedTitle": "Gagal mengambil metadata ISBN",
+    "previewFound": "{{count}} metadata ditemukan",
+    "previewMissing": "{{count}} tidak ditemukan",
+    "colKode": "Kode Buku",
+    "colSource": "Sumber",
+    "notFound": "Tidak ada metadata",
+    "skipUnselected": "Tidak dipilih",
+    "missingJudul": "Judul tidak tersedia",
+    "nothingToImport": "Tidak ada baris yang siap diimpor",
+    "import": "Impor {{count}} buku",
+    "importFailedTitle": "Gagal menyimpan buku"
   }
 }

--- a/apps/desktop/src/i18n/id/common.json
+++ b/apps/desktop/src/i18n/id/common.json
@@ -106,6 +106,7 @@
     },
     "result": {
       "inserted": "Ditambahkan",
+      "updated": "Diperbarui",
       "skipped": "Dilewati",
       "errors": "Error",
       "errorListTitle": "Daftar error",

--- a/apps/desktop/src/lib/anggota.ts
+++ b/apps/desktop/src/lib/anggota.ts
@@ -124,8 +124,22 @@ export interface AnggotaImportError {
 
 export interface AnggotaImportResult {
   inserted: number;
+  /**
+   * FEAT-19 — number of rows that updated an existing anggota when
+   * `updateExisting=true` was passed to `importBatch`.
+   */
+  updated: number;
   skipped: number;
   errors: AnggotaImportError[];
+}
+
+export interface AnggotaImportOptions {
+  /**
+   * When true, importing a row whose `kode_anggota` already exists in the
+   * database overwrites the existing record instead of skipping it. Defaults
+   * to false (legacy behaviour).
+   */
+  updateExisting?: boolean;
 }
 
 export interface KelasItem {
@@ -142,7 +156,10 @@ interface AnggotaRpc {
   create(payload: AnggotaInput): Promise<Anggota>;
   update(id: number, payload: AnggotaInput): Promise<Anggota>;
   remove(id: number): Promise<void>;
-  importBatch(items: AnggotaImportItem[]): Promise<AnggotaImportResult>;
+  importBatch(
+    items: AnggotaImportItem[],
+    options?: AnggotaImportOptions,
+  ): Promise<AnggotaImportResult>;
   distinct(field: 'kelas' | 'jurusan' | 'agama'): Promise<string[]>;
   kelasList(): Promise<KelasItem[]>;
 }
@@ -263,9 +280,12 @@ const tauriRpc: AnggotaRpc = {
     const { invoke } = await import('@tauri-apps/api/core');
     await invoke('anggota_delete', { id });
   },
-  async importBatch(items) {
+  async importBatch(items, options) {
     const { invoke } = await import('@tauri-apps/api/core');
-    return invoke<AnggotaImportResult>('anggota_import', { items });
+    return invoke<AnggotaImportResult>('anggota_import', {
+      items,
+      updateExisting: options?.updateExisting ?? false,
+    });
   },
   async distinct(field) {
     const { invoke } = await import('@tauri-apps/api/core');
@@ -383,9 +403,15 @@ const mockRpc: AnggotaRpc = {
     if (!all.some((it) => it.id === id)) throw new Error('not_found');
     writeMock(all.filter((it) => it.id !== id));
   },
-  async importBatch(items) {
+  async importBatch(items, options) {
     const all = readMock();
-    const result: AnggotaImportResult = { inserted: 0, skipped: 0, errors: [] };
+    const overwrite = options?.updateExisting === true;
+    const result: AnggotaImportResult = {
+      inserted: 0,
+      updated: 0,
+      skipped: 0,
+      errors: [],
+    };
     let nextId = (all.reduce((max, it) => Math.max(max, it.id), 0) ?? 0) + 1;
     items.forEach((raw, idx) => {
       const row = idx + 1;
@@ -396,9 +422,22 @@ const mockRpc: AnggotaRpc = {
         result.skipped += 1;
         return;
       }
-      if (all.some((it) => it.kodeAnggota === kode)) {
-        result.errors.push({ row, kodeAnggota: kode, message: 'kode_anggota sudah ada' });
-        result.skipped += 1;
+      const existing = all.find((it) => it.kodeAnggota === kode);
+      if (existing) {
+        if (!overwrite) {
+          result.errors.push({ row, kodeAnggota: kode, message: 'kode_anggota sudah ada' });
+          result.skipped += 1;
+          return;
+        }
+        existing.nama = nama;
+        existing.jenisKelamin = raw.jenisKelamin ?? existing.jenisKelamin;
+        existing.kelas = raw.kelas ?? existing.kelas;
+        existing.jurusan = raw.jurusan ?? existing.jurusan;
+        existing.agama = raw.agama ?? existing.agama;
+        existing.noTelp = raw.noTelp ?? existing.noTelp;
+        existing.email = raw.email ?? existing.email;
+        existing.updatedAt = nowIso();
+        result.updated += 1;
         return;
       }
       const now = nowIso();
@@ -460,7 +499,8 @@ export const anggotaApi = {
   create: (payload: AnggotaInput) => rpc().create(payload),
   update: (id: number, payload: AnggotaInput) => rpc().update(id, payload),
   remove: (id: number) => rpc().remove(id),
-  importBatch: (items: AnggotaImportItem[]) => rpc().importBatch(items),
+  importBatch: (items: AnggotaImportItem[], options?: AnggotaImportOptions) =>
+    rpc().importBatch(items, options),
   distinct: (field: 'kelas' | 'jurusan' | 'agama') => rpc().distinct(field),
   kelasList: () => rpc().kelasList(),
   /**

--- a/apps/desktop/src/lib/buku.ts
+++ b/apps/desktop/src/lib/buku.ts
@@ -435,3 +435,118 @@ const browserRpc: BukuRpc = {
 };
 
 export const bukuApi: BukuRpc = isTauri() ? tauriRpc : browserRpc;
+
+// ----------------------------------------------------------------------------
+// FEAT-20 — Bulk import buku via ISBN
+// ----------------------------------------------------------------------------
+
+/** Metadata returned by the backend ISBN lookup (Open Library + Google Books). */
+export interface IsbnMetadata {
+  isbn: string;
+  judul?: string | null;
+  pengarang?: string | null;
+  penerbit?: string | null;
+  tahunTerbit?: number | null;
+  kategori?: string | null;
+  bahasa?: string | null;
+  /** Optional cover URL — frontend can call `fetchIsbnCover(url)` to embed it. */
+  coverUrl?: string | null;
+  /** Which upstream produced the record. Empty string when not found. */
+  source: string;
+}
+
+/**
+ * One row of `bukuIsbnApi.lookupBatch`. `metadata` is null when neither
+ * upstream had a record. `error` is set when the lookup itself failed.
+ */
+export interface IsbnLookupResult {
+  isbn: string;
+  metadata: IsbnMetadata | null;
+  error: string | null;
+}
+
+interface BukuIsbnRpc {
+  /** Resolve a list of ISBNs to metadata. Backend throttles ~1 req/sec. */
+  lookupBatch(isbns: string[]): Promise<IsbnLookupResult[]>;
+  /**
+   * Download a cover URL into a `data:image/...;base64,...` string suitable
+   * for embedding in `<img src>` or persisting via the buku cover field.
+   */
+  fetchCover(url: string): Promise<string>;
+}
+
+const tauriIsbnRpc: BukuIsbnRpc = {
+  async lookupBatch(isbns) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<IsbnLookupResult[]>('buku_isbn_lookup_batch', { isbns });
+  },
+  async fetchCover(url) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<string>('buku_isbn_fetch_cover', { url });
+  },
+};
+
+/**
+ * Browser/test fallback. Fakes a deterministic record for any ISBN that
+ * normalizes to 13 digits so vitest specs and the in-browser preview can
+ * exercise the dialog without hitting the network.
+ */
+const browserIsbnRpc: BukuIsbnRpc = {
+  async lookupBatch(isbns) {
+    return isbns.map((isbn) => {
+      const cleaned = isbn.replace(/[^0-9Xx]/g, '').toUpperCase();
+      if (cleaned.length !== 10 && cleaned.length !== 13) {
+        return {
+          isbn,
+          metadata: null,
+          error: 'ISBN tidak valid (harus 10 atau 13 digit)',
+        };
+      }
+      return {
+        isbn,
+        metadata: {
+          isbn: cleaned,
+          judul: `Buku ${cleaned}`,
+          pengarang: 'Penulis Demo',
+          penerbit: 'Penerbit Demo',
+          tahunTerbit: 2024,
+          kategori: null,
+          bahasa: 'id',
+          coverUrl: null,
+          source: 'mock',
+        },
+        error: null,
+      } satisfies IsbnLookupResult;
+    });
+  },
+  async fetchCover() {
+    return '';
+  },
+};
+
+export const bukuIsbnApi: BukuIsbnRpc = isTauri() ? tauriIsbnRpc : browserIsbnRpc;
+
+/**
+ * Convert an `IsbnMetadata` row + auto-generated kodeBuku into a
+ * `BukuImportItem` that `bukuApi.importBatch` can consume. Returns null when
+ * `meta` lacks the minimum required field (`judul`).
+ */
+export function metadataToImportItem(
+  meta: IsbnMetadata,
+  kodeBuku: string,
+): BukuImportItem | null {
+  const judul = meta.judul?.trim();
+  if (!judul) return null;
+  return {
+    kodeBuku: kodeBuku.trim(),
+    judul,
+    pengarang: meta.pengarang ?? null,
+    penerbit: meta.penerbit ?? null,
+    tahunTerbit: meta.tahunTerbit ?? null,
+    kodeDdc: null,
+    kategori: meta.kategori ?? null,
+    isbn: meta.isbn,
+    jumlahEksemplar: 1,
+    bahasa: meta.bahasa ?? null,
+  };
+}

--- a/apps/desktop/tests/unit/anggotaApi.test.ts
+++ b/apps/desktop/tests/unit/anggotaApi.test.ts
@@ -62,7 +62,58 @@ describe('anggotaApi (browser mock)', () => {
       { kodeAnggota: 'IMP1', nama: 'Duplicate within batch' },
     ]);
     expect(result.inserted).toBe(1);
+    expect(result.updated).toBe(0);
     expect(result.errors.length + result.skipped).toBeGreaterThanOrEqual(2);
+  });
+
+  it('FEAT-19: skips existing kode_anggota by default and reports them as errors', async () => {
+    await anggotaApi.create({ kodeAnggota: 'OW1', nama: 'Original Name' });
+    const result = await anggotaApi.importBatch([
+      { kodeAnggota: 'OW1', nama: 'Replacement Name', kelas: '12 IPA 1' },
+    ]);
+    expect(result.inserted).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.errors[0]?.message).toMatch(/sudah ada/);
+    const list = await anggotaApi.list({ query: 'OW1' });
+    expect(list.items[0]?.nama).toBe('Original Name');
+  });
+
+  it('FEAT-19: updateExisting=true overwrites existing rows in place', async () => {
+    await anggotaApi.create({
+      kodeAnggota: 'OW2',
+      nama: 'Original Name',
+      kelas: '11 IPS 2',
+      jurusan: 'IPS',
+    });
+    const result = await anggotaApi.importBatch(
+      [{ kodeAnggota: 'OW2', nama: 'Replacement Name', kelas: '12 IPA 1' }],
+      { updateExisting: true },
+    );
+    expect(result.inserted).toBe(0);
+    expect(result.updated).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    const list = await anggotaApi.list({ query: 'OW2' });
+    const row = list.items.find((it) => it.kodeAnggota === 'OW2');
+    expect(row?.nama).toBe('Replacement Name');
+    expect(row?.kelas).toBe('12 IPA 1');
+    // Empty fields shouldn't blow away pre-existing values.
+    expect(row?.jurusan).toBe('IPS');
+  });
+
+  it('FEAT-19: updateExisting still inserts new rows alongside updates', async () => {
+    await anggotaApi.create({ kodeAnggota: 'OW3', nama: 'Existing' });
+    const result = await anggotaApi.importBatch(
+      [
+        { kodeAnggota: 'OW3', nama: 'Updated' },
+        { kodeAnggota: 'OW4', nama: 'Brand New' },
+      ],
+      { updateExisting: true },
+    );
+    expect(result.inserted).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.skipped).toBe(0);
   });
 });
 

--- a/apps/desktop/tests/unit/isbnImport.test.ts
+++ b/apps/desktop/tests/unit/isbnImport.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { bukuIsbnApi, metadataToImportItem, type IsbnMetadata } from '@/lib/buku';
+import { parseIsbnList } from '@/features/buku/IsbnImportDialog';
+
+describe('parseIsbnList (FEAT-20)', () => {
+  it('splits on whitespace, commas and semicolons', () => {
+    const out = parseIsbnList('9780140449136 9786020385945, 9780747532699; 9780451526342');
+    expect(out).toEqual([
+      '9780140449136',
+      '9786020385945',
+      '9780747532699',
+      '9780451526342',
+    ]);
+  });
+
+  it('splits on newlines and trims tokens', () => {
+    const out = parseIsbnList('  9780140449136\n   9786020385945  \n\n');
+    expect(out).toEqual(['9780140449136', '9786020385945']);
+  });
+
+  it('dedupes case-insensitively', () => {
+    const out = parseIsbnList('978014044913X\n978014044913x\n9780140449136');
+    expect(out).toEqual(['978014044913X', '9780140449136']);
+  });
+
+  it('returns an empty list for whitespace-only input', () => {
+    expect(parseIsbnList('   \n\n , ;')).toEqual([]);
+  });
+});
+
+describe('bukuIsbnApi (browser fallback)', () => {
+  it('returns deterministic mock metadata for valid ISBNs', async () => {
+    const result = await bukuIsbnApi.lookupBatch(['9780140449136']);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.metadata?.judul).toContain('9780140449136');
+    expect(result[0]?.error).toBeNull();
+  });
+
+  it('reports an error for an obviously invalid ISBN', async () => {
+    const result = await bukuIsbnApi.lookupBatch(['not-an-isbn']);
+    expect(result[0]?.metadata).toBeNull();
+    expect(result[0]?.error).toMatch(/tidak valid/i);
+  });
+});
+
+describe('metadataToImportItem (FEAT-20)', () => {
+  const meta: IsbnMetadata = {
+    isbn: '9780140449136',
+    judul: 'War and Peace',
+    pengarang: 'Leo Tolstoy',
+    penerbit: 'Penguin Classics',
+    tahunTerbit: 2007,
+    kategori: null,
+    bahasa: 'en',
+    coverUrl: null,
+    source: 'open_library',
+  };
+
+  it('builds a BukuImportItem with the supplied kodeBuku', () => {
+    const item = metadataToImportItem(meta, 'B-12345');
+    expect(item).not.toBeNull();
+    expect(item?.kodeBuku).toBe('B-12345');
+    expect(item?.judul).toBe('War and Peace');
+    expect(item?.isbn).toBe('9780140449136');
+    expect(item?.jumlahEksemplar).toBe(1);
+  });
+
+  it('returns null when judul is missing', () => {
+    const item = metadataToImportItem({ ...meta, judul: '   ' }, 'B-X');
+    expect(item).toBeNull();
+  });
+
+  it('trims kodeBuku before storing', () => {
+    const item = metadataToImportItem(meta, '   B-99   ');
+    expect(item?.kodeBuku).toBe('B-99');
+  });
+});


### PR DESCRIPTION
## Summary

Ships the two remaining bulk-import features for v1.0.8 against `main` (after the rest of the batch landed).

### FEAT-19 — Anggota bulk import: overwrite mode
- Backend `anggota_import` now accepts an optional `update_existing: bool` flag (defaults to `false` for back-compat).
- When `update_existing = true` and a row's `kode_anggota` already exists, the row is `UPDATE`-ed in place via a `COALESCE`-protected statement so blank cells in the spreadsheet **don't** blow away existing values.
- `AnggotaImportResult` exposes a new `updated: i64` counter alongside `inserted` / `skipped`.
- Frontend: `ImportExcelDialog` adds a checkbox in the preview step ("Perbarui anggota yang sudah ada"). The result panel surfaces a 4th "Diperbarui" tile when overwrite is on, or skips it gracefully.
- `lib/anggota.ts` browser mock mirrors backend semantics so vitest specs and the in-browser preview both exercise the new mode.

### FEAT-20 — Buku bulk import via ISBN
- New `IsbnImportDialog` opens from the Buku list page ("Impor via ISBN" button next to the existing "Import Excel" button).
- Admin pastes a free-form list of ISBNs (newline / comma / semicolon separated). Frontend parses + dedupes, then calls the existing `buku_isbn_lookup_batch` Tauri command (Open Library → Google Books fallback, ~1 req/sec throttle).
- Preview step shows resolved metadata per row, lets the admin tweak the auto-suggested `kodeBuku` and unselect rows. Submit funnels selected rows through the existing `buku_import` Tauri command — no schema change.
- `lib/buku.ts` exports a `bukuIsbnApi` namespace plus a `metadataToImportItem` helper. Browser fallback returns deterministic mock metadata so vitest can drive the dialog without network access.

### Shared
- `ImportWizard` exposes an `extras` slot for custom controls (used by anggota's overwrite toggle today, ready for future importers) and an optional `updated` counter on the result panel.
- New i18n keys for both languages (`anggota.import.overwrite{Label,Help}`, `buku.list.importIsbn`, `buku.isbnImport.*`, `common.importWizard.result.updated`). i18n parity lint passes.

## Test plan

Local gates (all green):

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm -w run i18n:lint`
- [x] `pnpm test` — **442 / 442** vitest specs pass (incl. 4 new `anggotaApi` overwrite cases + 9 new ISBN import cases).
- [x] `pnpm build` — Vite production build succeeds.
- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` — **247 / 247** Rust tests pass (incl. 5 new `anggota_import_into_conn` cases covering insert / skip-existing / overwrite-existing / mixed insert+update / validation).

## Notes

- The backend `anggota_import` Tauri command is now a thin wrapper around `anggota_import_into_conn(conn, items, overwrite)` so unit tests can hit the import logic directly with an in-memory SQLite connection (matches the pattern used by `commands/peminjaman.rs`, `commands/wishlist.rs`, etc.).
- ISBN dialog reuses existing components only (`Dialog`, `Table`, `Input`, `Button`) — no new shadcn primitives added.
