### PR TITLE
feat(surat,wishlist): SBP + wishlist anggota (FEAT-21, FEAT-22)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -20,5 +20,7 @@ pub mod master_data;
 pub mod peminjaman;
 pub mod reservasi;
 pub mod settings;
+pub mod surat;
 pub mod user_profile;
 pub mod window_state;
+pub mod wishlist;

--- a/apps/desktop/src-tauri/src/commands/surat.rs
+++ b/apps/desktop/src-tauri/src/commands/surat.rs
@@ -1,0 +1,665 @@
+//! Surat keterangan bebas pustaka (FEAT-21).
+//!
+//! Auto-generates a "library clearance letter" PDF for an anggota who has no
+//! active loans and no outstanding denda. Eligibility is checked server-side
+//! so the frontend can't accidentally print a surat for an anggota who still
+//! owes books or fines.
+//!
+//! Design notes:
+//! - `nomor_surat` is rendered from `surat.format_nomor` (printf-style
+//!   template, default `{tahun}/{bulan}/SBP-{nomor:04d}`) plus
+//!   `surat.nomor_terakhir` (last-used sequence number). `surat_generate`
+//!   atomically `+1`s `nomor_terakhir` inside a transaction so two
+//!   concurrent calls can never produce the same nomor.
+//! - The PDF itself is rendered on the frontend (jsPDF) so the backend
+//!   stays thin and platform-independent. The backend only owns the
+//!   eligibility check, the nomor allocation, and the audit log entry.
+//! - `surat_log` is purely for history; deletion is intentionally not
+//!   exposed via a Tauri command so the audit trail of nomor_surat →
+//!   anggota assignments stays intact.
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tauri::State;
+
+use crate::commands::kas::insert_audit_log;
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+/// Default `surat.format_nomor` placeholder template. Year + month +
+/// 4-digit zero-padded sequence is the most common Indonesian school
+/// administration convention.
+const DEFAULT_FORMAT_NOMOR: &str = "{tahun}/{bulan}/SBP-{nomor:04d}";
+
+/// Default Indonesian template body. Plain text with `\n` paragraph breaks
+/// and `{placeholder}` substitution. The frontend's `lib/suratPdf.ts` is the
+/// single owner of HTML→PDF rendering; this template is intentionally simple
+/// so it round-trips through the Settings textarea editor without escaping.
+const DEFAULT_TEMPLATE_HTML: &str = "Yang bertanda tangan di bawah ini, Kepala Perpustakaan {nama_perpustakaan}, dengan ini menerangkan bahwa:\n\nNama         : {nama}\nNo. Anggota  : {kode_anggota}\nKelas        : {kelas}\n\nbenar telah menyelesaikan seluruh kewajiban peminjaman buku di Perpustakaan ini dan tidak memiliki tanggungan apapun.\n\nSurat keterangan bebas pustaka ini dibuat untuk dapat dipergunakan sebagaimana mestinya.\n\nDikeluarkan di : {kota}\nPada tanggal   : {tanggal}";
+
+/// Settings keys touched by this module. Kept as constants so we don't
+/// scatter magic strings.
+const KEY_TEMPLATE_HTML: &str = "surat.template_html";
+const KEY_NOMOR_TERAKHIR: &str = "surat.nomor_terakhir";
+const KEY_FORMAT_NOMOR: &str = "surat.format_nomor";
+const KEY_KEPSEK_NAMA: &str = "surat.kepala_sekolah_nama";
+const KEY_KEPSEK_NIP: &str = "surat.kepala_sekolah_nip";
+const KEY_KEPSEK_TTD_PATH: &str = "surat.kepala_sekolah_ttd_path";
+
+/// Idempotently seed the default surat settings rows. Called from
+/// `db::apply_additive_migrations` so existing databases get the defaults
+/// on first launch after upgrade, but manual edits in Settings persist.
+pub(crate) fn seed_default_surat_settings(conn: &Connection) -> AppResult<()> {
+    let pairs: [(&str, &str); 6] = [
+        (KEY_TEMPLATE_HTML, DEFAULT_TEMPLATE_HTML),
+        (KEY_NOMOR_TERAKHIR, "0"),
+        (KEY_FORMAT_NOMOR, DEFAULT_FORMAT_NOMOR),
+        (KEY_KEPSEK_NAMA, ""),
+        (KEY_KEPSEK_NIP, ""),
+        (KEY_KEPSEK_TTD_PATH, ""),
+    ];
+    for (k, v) in pairs {
+        conn.execute(
+            "INSERT OR IGNORE INTO settings (key, value) VALUES (?1, ?2)",
+            params![k, v],
+        )?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SuratEligibility {
+    pub eligible: bool,
+    pub anggota_id: i64,
+    pub anggota_nama: String,
+    pub anggota_kode: String,
+    pub anggota_aktif: bool,
+    pub active_loans: i64,
+    /// `total_denda - total_bayar` summed across all loans. Positive means
+    /// the anggota still owes money.
+    pub outstanding_denda: i64,
+    /// Human-readable list of blocking reasons, locale="id". Empty when
+    /// `eligible == true`.
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SuratGenerateResult {
+    pub log_id: i64,
+    pub nomor_surat: String,
+    pub tanggal_cetak: String,
+    pub anggota_id: i64,
+    pub anggota_nama: String,
+    pub anggota_kode: String,
+    pub anggota_kelas: Option<String>,
+    pub template_html: String,
+    pub kepala_sekolah_nama: String,
+    pub kepala_sekolah_nip: String,
+    pub kepala_sekolah_ttd_path: String,
+    /// `nomor_terakhir` after the increment — kept so the frontend can
+    /// optimistically update its settings cache.
+    pub nomor_terakhir: i64,
+    pub format_nomor: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SuratLogRow {
+    pub id: i64,
+    pub anggota_id: i64,
+    pub anggota_nama: String,
+    pub anggota_kode: String,
+    pub nomor_surat: String,
+    pub tanggal_cetak: String,
+    pub petugas_id: Option<i64>,
+    pub petugas_username: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SuratLogQuery {
+    pub anggota_id: Option<i64>,
+    pub limit: Option<i64>,
+}
+
+/// Compute eligibility for `anggota_id` without mutating the DB. Used by
+/// the dialog to decide whether to enable the "Cetak" button and, again,
+/// inside `surat_generate_inner` to prevent TOCTOU races.
+pub(crate) fn compute_eligibility(conn: &Connection, anggota_id: i64) -> AppResult<SuratEligibility> {
+    let row: Option<(i64, String, String, i64)> = conn
+        .query_row(
+            "SELECT id, kode_anggota, nama, aktif FROM anggota WHERE id = ?1",
+            params![anggota_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .optional()?;
+    let (id, kode, nama, aktif_int) =
+        row.ok_or_else(|| AppError::NotFound(format!("anggota id {anggota_id}")))?;
+    let aktif = aktif_int != 0;
+
+    let active_loans: i64 = conn.query_row(
+        "SELECT COALESCE(SUM(CASE WHEN pi.status = 'dipinjam' THEN 1 ELSE 0 END), 0) \
+         FROM peminjaman_item pi \
+         JOIN peminjaman p ON p.id = pi.peminjaman_id \
+         WHERE p.anggota_id = ?1",
+        params![id],
+        |r| r.get(0),
+    )?;
+
+    let outstanding_denda: i64 = conn.query_row(
+        "SELECT COALESCE(SUM(total_denda) - SUM(total_bayar), 0) \
+         FROM peminjaman WHERE anggota_id = ?1",
+        params![id],
+        |r| r.get(0),
+    )?;
+
+    let mut reasons: Vec<String> = Vec::new();
+    if !aktif {
+        reasons.push("Status anggota tidak aktif.".to_string());
+    }
+    if active_loans > 0 {
+        reasons.push(format!(
+            "Masih ada {active_loans} buku yang belum dikembalikan."
+        ));
+    }
+    if outstanding_denda > 0 {
+        reasons.push(format!(
+            "Masih ada tunggakan denda sebesar Rp{outstanding_denda}."
+        ));
+    }
+
+    let eligible = reasons.is_empty();
+    Ok(SuratEligibility {
+        eligible,
+        anggota_id: id,
+        anggota_nama: nama,
+        anggota_kode: kode,
+        anggota_aktif: aktif,
+        active_loans,
+        outstanding_denda,
+        reasons,
+    })
+}
+
+fn get_setting(conn: &Connection, key: &str) -> AppResult<Option<String>> {
+    Ok(conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = ?1",
+            params![key],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten())
+}
+
+/// Render a `format_nomor` template by substituting `{tahun}`, `{bulan}`,
+/// and `{nomor:NNd}` (zero-padded). Unknown placeholders are left as-is so
+/// users can introduce custom segments without the backend rejecting them.
+fn render_nomor(format_nomor: &str, tahun: i32, bulan: u32, nomor: i64) -> String {
+    let mut out = format_nomor.to_string();
+    out = out.replace("{tahun}", &format!("{tahun:04}"));
+    out = out.replace("{bulan}", &format!("{bulan:02}"));
+    // Pad-aware {nomor:NNd}. Falls back to plain `{nomor}` if no width.
+    let mut buf = String::with_capacity(out.len());
+    let mut rest = out.as_str();
+    while let Some(start) = rest.find("{nomor") {
+        buf.push_str(&rest[..start]);
+        let after = &rest[start..];
+        let Some(end_rel) = after.find('}') else {
+            buf.push_str(after);
+            rest = "";
+            break;
+        };
+        let token = &after[..=end_rel];
+        let inner = &token[1..token.len() - 1];
+        let pad = inner
+            .strip_prefix("nomor:")
+            .and_then(|tail| tail.strip_suffix('d'))
+            .and_then(|n| n.parse::<usize>().ok())
+            .unwrap_or(0);
+        let formatted = if pad > 0 {
+            format!("{nomor:0width$}", width = pad)
+        } else {
+            nomor.to_string()
+        };
+        buf.push_str(&formatted);
+        rest = &after[end_rel + 1..];
+    }
+    buf.push_str(rest);
+    buf
+}
+
+fn parse_today(conn: &Connection) -> AppResult<(String, i32, u32)> {
+    let today: String =
+        conn.query_row("SELECT date('now', 'localtime')", [], |r| r.get(0))?;
+    let parts: Vec<&str> = today.split('-').collect();
+    let tahun = parts
+        .first()
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(0);
+    let bulan = parts
+        .get(1)
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(0);
+    Ok((today, tahun, bulan))
+}
+
+pub(crate) fn surat_generate_inner(
+    conn: &mut Connection,
+    anggota_id: i64,
+    user_id: Option<i64>,
+) -> AppResult<SuratGenerateResult> {
+    // Re-check eligibility under the same conn so a denda paid five seconds
+    // ago is reflected. The dialog also calls `surat_check_eligibility` for
+    // the prelim UX, but that's just hint UI — the source of truth is here.
+    let eligibility = compute_eligibility(conn, anggota_id)?;
+    if !eligibility.eligible {
+        return Err(AppError::Validation(format!(
+            "anggota tidak memenuhi syarat surat bebas pustaka: {}",
+            eligibility.reasons.join(" ")
+        )));
+    }
+
+    let format_nomor = get_setting(conn, KEY_FORMAT_NOMOR)?
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_FORMAT_NOMOR.to_string());
+    let template_html = get_setting(conn, KEY_TEMPLATE_HTML)?
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_TEMPLATE_HTML.to_string());
+    let kepala_sekolah_nama = get_setting(conn, KEY_KEPSEK_NAMA)?.unwrap_or_default();
+    let kepala_sekolah_nip = get_setting(conn, KEY_KEPSEK_NIP)?.unwrap_or_default();
+    let kepala_sekolah_ttd_path = get_setting(conn, KEY_KEPSEK_TTD_PATH)?.unwrap_or_default();
+
+    let kelas: Option<String> = conn
+        .query_row(
+            "SELECT kelas FROM anggota WHERE id = ?1",
+            params![anggota_id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+
+    let (today, tahun, bulan) = parse_today(conn)?;
+
+    let tx = conn.transaction()?;
+
+    // Atomic increment of nomor_terakhir.
+    let prev: i64 = tx
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM settings WHERE key = ?1",
+            params![KEY_NOMOR_TERAKHIR],
+            |r| r.get(0),
+        )
+        .optional()?
+        .unwrap_or(0);
+    let nomor_terakhir = prev + 1;
+    tx.execute(
+        "INSERT INTO settings (key, value) VALUES (?1, ?2) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![KEY_NOMOR_TERAKHIR, nomor_terakhir.to_string()],
+    )?;
+
+    let nomor_surat = render_nomor(&format_nomor, tahun, bulan, nomor_terakhir);
+
+    tx.execute(
+        "INSERT INTO surat_log (anggota_id, nomor_surat, tanggal_cetak, petugas_id) \
+         VALUES (?1, ?2, ?3, ?4)",
+        params![anggota_id, nomor_surat, today, user_id],
+    )?;
+    let log_id = tx.last_insert_rowid();
+
+    let detail = json!({
+        "nomor_surat": nomor_surat,
+        "anggota_id": anggota_id,
+        "anggota_nama": eligibility.anggota_nama,
+        "tanggal_cetak": today,
+    });
+    insert_audit_log(
+        &tx,
+        user_id,
+        "cetak_surat_bebas_pustaka",
+        "surat_log",
+        Some(log_id),
+        &detail,
+    )?;
+    tx.commit()?;
+
+    Ok(SuratGenerateResult {
+        log_id,
+        nomor_surat,
+        tanggal_cetak: today,
+        anggota_id,
+        anggota_nama: eligibility.anggota_nama,
+        anggota_kode: eligibility.anggota_kode,
+        anggota_kelas: kelas,
+        template_html,
+        kepala_sekolah_nama,
+        kepala_sekolah_nip,
+        kepala_sekolah_ttd_path,
+        nomor_terakhir,
+        format_nomor,
+    })
+}
+
+pub(crate) fn surat_log_list_inner(
+    conn: &Connection,
+    query: &SuratLogQuery,
+) -> AppResult<Vec<SuratLogRow>> {
+    let limit = query.limit.unwrap_or(200).clamp(1, 1000);
+    let mut sql = String::from(
+        "SELECT s.id, s.anggota_id, a.nama, a.kode_anggota, s.nomor_surat, s.tanggal_cetak, \
+                s.petugas_id, u.username \
+         FROM surat_log s \
+         LEFT JOIN anggota a ON a.id = s.anggota_id \
+         LEFT JOIN users u ON u.id = s.petugas_id",
+    );
+    let mut binds: Vec<i64> = Vec::new();
+    if let Some(aid) = query.anggota_id {
+        sql.push_str(" WHERE s.anggota_id = ?1");
+        binds.push(aid);
+    }
+    sql.push_str(" ORDER BY s.id DESC LIMIT ");
+    sql.push_str(&limit.to_string());
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = if binds.is_empty() {
+        stmt.query_map([], map_log_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        stmt.query_map(rusqlite::params_from_iter(binds.iter()), map_log_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    Ok(rows)
+}
+
+fn map_log_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<SuratLogRow> {
+    Ok(SuratLogRow {
+        id: r.get(0)?,
+        anggota_id: r.get(1)?,
+        anggota_nama: r.get::<_, Option<String>>(2)?.unwrap_or_default(),
+        anggota_kode: r.get::<_, Option<String>>(3)?.unwrap_or_default(),
+        nomor_surat: r.get(4)?,
+        tanggal_cetak: r.get(5)?,
+        petugas_id: r.get(6)?,
+        petugas_username: r.get(7)?,
+    })
+}
+
+fn current_user_id(state: &AppState) -> Option<i64> {
+    state
+        .current_user
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().map(|u| u.id))
+}
+
+#[tauri::command]
+pub fn surat_check_eligibility(
+    state: State<'_, AppState>,
+    anggota_id: i64,
+) -> AppResult<SuratEligibility> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    compute_eligibility(&conn, anggota_id)
+}
+
+#[tauri::command]
+pub fn surat_generate(
+    state: State<'_, AppState>,
+    anggota_id: i64,
+) -> AppResult<SuratGenerateResult> {
+    let user_id = current_user_id(&state);
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    surat_generate_inner(&mut conn, anggota_id, user_id)
+}
+
+#[tauri::command]
+pub fn surat_log_list(
+    state: State<'_, AppState>,
+    query: Option<SuratLogQuery>,
+) -> AppResult<Vec<SuratLogRow>> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    surat_log_list_inner(&conn, &query.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .expect("enable foreign_keys");
+        crate::db::run_migrations(&conn).expect("run migrations");
+        conn
+    }
+
+    fn seed_anggota(conn: &Connection, kode: &str, nama: &str, aktif: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO anggota (kode_anggota, nama, kelas, aktif) \
+             VALUES (?1, ?2, '10 IPA 1', ?3)",
+            params![kode, nama, aktif],
+        )
+        .expect("seed anggota");
+        conn.last_insert_rowid()
+    }
+
+    fn seed_buku(conn: &Connection, kode: &str, judul: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO buku (kode_buku, judul, jumlah_eksemplar) VALUES (?1, ?2, 1)",
+            params![kode, judul],
+        )
+        .expect("seed buku");
+        conn.last_insert_rowid()
+    }
+
+    fn seed_active_loan(conn: &Connection, anggota_id: i64, buku_id: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO peminjaman (nomor_pinjam, anggota_id, tanggal_pinjam, tanggal_jatuh_tempo, status, total_denda, total_bayar) \
+             VALUES ('P-001', ?1, date('now'), date('now', '+7 days'), 'dipinjam', 0, 0)",
+            params![anggota_id],
+        )
+        .expect("seed peminjaman header");
+        let pid = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO peminjaman_item (peminjaman_id, buku_id, status, denda) \
+             VALUES (?1, ?2, 'dipinjam', 0)",
+            params![pid, buku_id],
+        )
+        .expect("seed peminjaman_item");
+        pid
+    }
+
+    fn seed_paid_loan(conn: &Connection, anggota_id: i64, denda: i64, bayar: i64) {
+        conn.execute(
+            "INSERT INTO peminjaman (nomor_pinjam, anggota_id, tanggal_pinjam, tanggal_jatuh_tempo, status, total_denda, total_bayar) \
+             VALUES ('P-002', ?1, date('now'), date('now', '+7 days'), 'dikembalikan', ?2, ?3)",
+            params![anggota_id, denda, bayar],
+        )
+        .expect("seed paid loan");
+    }
+
+    #[test]
+    fn render_nomor_substitutes_year_month_and_padded_sequence() {
+        let s = render_nomor("{tahun}/{bulan}/SBP-{nomor:04d}", 2026, 5, 7);
+        assert_eq!(s, "2026/05/SBP-0007");
+    }
+
+    #[test]
+    fn render_nomor_handles_unpadded_and_unknown_placeholders() {
+        let s = render_nomor("SBP/{tahun}/{nomor}-{custom}", 2026, 5, 42);
+        assert_eq!(s, "SBP/2026/42-{custom}");
+    }
+
+    #[test]
+    fn eligibility_passes_for_anggota_with_no_loans_and_no_denda() {
+        let conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini", 1);
+        let elig = compute_eligibility(&conn, aid).expect("compute");
+        assert!(elig.eligible, "expected eligible: {:?}", elig.reasons);
+        assert_eq!(elig.active_loans, 0);
+        assert_eq!(elig.outstanding_denda, 0);
+        assert!(elig.reasons.is_empty());
+    }
+
+    #[test]
+    fn eligibility_blocks_when_active_loan_exists() {
+        let conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini", 1);
+        let bid = seed_buku(&conn, "B-001", "Belajar Rust");
+        seed_active_loan(&conn, aid, bid);
+        let elig = compute_eligibility(&conn, aid).expect("compute");
+        assert!(!elig.eligible);
+        assert_eq!(elig.active_loans, 1);
+        assert!(elig
+            .reasons
+            .iter()
+            .any(|r| r.contains("belum dikembalikan")));
+    }
+
+    #[test]
+    fn eligibility_blocks_when_outstanding_denda() {
+        let conn = setup_db();
+        let aid = seed_anggota(&conn, "A0002", "Bagas", 1);
+        seed_paid_loan(&conn, aid, 5_000, 0);
+        let elig = compute_eligibility(&conn, aid).expect("compute");
+        assert!(!elig.eligible);
+        assert_eq!(elig.outstanding_denda, 5_000);
+        assert!(elig.reasons.iter().any(|r| r.contains("denda")));
+    }
+
+    #[test]
+    fn eligibility_blocks_when_anggota_inactive() {
+        let conn = setup_db();
+        let aid = seed_anggota(&conn, "A0003", "Citra", 0);
+        let elig = compute_eligibility(&conn, aid).expect("compute");
+        assert!(!elig.eligible);
+        assert!(!elig.anggota_aktif);
+        assert!(elig
+            .reasons
+            .iter()
+            .any(|r| r.contains("tidak aktif")));
+    }
+
+    #[test]
+    fn generate_increments_nomor_and_writes_audit_log() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0004", "Dina", 1);
+        let res = surat_generate_inner(&mut conn, aid, None).expect("generate");
+        assert_eq!(res.nomor_terakhir, 1);
+        assert!(res.nomor_surat.contains("SBP-0001"));
+        assert_eq!(res.anggota_kode, "A0004");
+
+        // nomor_terakhir persisted
+        let stored: String = conn
+            .query_row(
+                "SELECT value FROM settings WHERE key = ?1",
+                params![KEY_NOMOR_TERAKHIR],
+                |r| r.get(0),
+            )
+            .expect("read nomor_terakhir");
+        assert_eq!(stored, "1");
+
+        // surat_log row written
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM surat_log WHERE anggota_id = ?1", params![aid], |r| r.get(0))
+            .expect("count");
+        assert_eq!(count, 1);
+
+        // audit_log entry
+        let aksi: String = conn
+            .query_row(
+                "SELECT aksi FROM audit_log ORDER BY id DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read audit");
+        assert_eq!(aksi, "cetak_surat_bebas_pustaka");
+    }
+
+    #[test]
+    fn generate_assigns_sequential_nomor() {
+        let mut conn = setup_db();
+        let a1 = seed_anggota(&conn, "A0005", "Eko", 1);
+        let a2 = seed_anggota(&conn, "A0006", "Fani", 1);
+        let r1 = surat_generate_inner(&mut conn, a1, None).expect("generate 1");
+        let r2 = surat_generate_inner(&mut conn, a2, None).expect("generate 2");
+        assert_eq!(r1.nomor_terakhir, 1);
+        assert_eq!(r2.nomor_terakhir, 2);
+        assert_ne!(r1.nomor_surat, r2.nomor_surat);
+    }
+
+    #[test]
+    fn generate_blocks_when_ineligible() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0007", "Gilang", 1);
+        let bid = seed_buku(&conn, "B-002", "Rust 101");
+        seed_active_loan(&conn, aid, bid);
+        let err = surat_generate_inner(&mut conn, aid, None).expect_err("should reject");
+        assert!(matches!(err, AppError::Validation(_)));
+
+        // No surat_log row, no nomor increment.
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM surat_log", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(count, 0);
+        let prev: Option<String> = conn
+            .query_row(
+                "SELECT value FROM settings WHERE key = ?1",
+                params![KEY_NOMOR_TERAKHIR],
+                |r| r.get(0),
+            )
+            .optional()
+            .expect("read nomor")
+            .flatten();
+        // Default seed leaves it at "0".
+        assert_eq!(prev.as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn log_list_filters_by_anggota_and_orders_desc() {
+        let mut conn = setup_db();
+        let a1 = seed_anggota(&conn, "A0008", "Hana", 1);
+        let a2 = seed_anggota(&conn, "A0009", "Ivan", 1);
+        surat_generate_inner(&mut conn, a1, None).expect("g1");
+        surat_generate_inner(&mut conn, a2, None).expect("g2");
+        surat_generate_inner(&mut conn, a1, None).expect("g3");
+
+        let all = surat_log_list_inner(&conn, &SuratLogQuery::default()).expect("all");
+        assert_eq!(all.len(), 3);
+        // Desc order by id
+        assert!(all[0].id > all[1].id);
+
+        let only_a1 = surat_log_list_inner(
+            &conn,
+            &SuratLogQuery {
+                anggota_id: Some(a1),
+                limit: None,
+            },
+        )
+        .expect("filter");
+        assert_eq!(only_a1.len(), 2);
+        assert!(only_a1.iter().all(|r| r.anggota_id == a1));
+    }
+
+    #[test]
+    fn default_settings_seeded_after_migrations() {
+        let conn = setup_db();
+        let format = get_setting(&conn, KEY_FORMAT_NOMOR).expect("read");
+        assert_eq!(format.as_deref(), Some(DEFAULT_FORMAT_NOMOR));
+        let template = get_setting(&conn, KEY_TEMPLATE_HTML).expect("read");
+        assert!(template.unwrap().contains("{nama}"));
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/wishlist.rs
+++ b/apps/desktop/src-tauri/src/commands/wishlist.rs
@@ -1,0 +1,738 @@
+//! Wishlist anggota / request pengadaan buku (FEAT-22).
+//!
+//! Lets anggota request that the library acquire a specific book. The admin
+//! reviews the queue and transitions each entry through a small state
+//! machine (`pending → disetujui → sudah_diadakan` with rejection/cancel
+//! escape hatches). Upvote count lets the admin prioritise frequently
+//! requested titles.
+//!
+//! Design notes:
+//! - Status transitions are validated server-side via `is_valid_transition`.
+//!   The frontend disables disallowed buttons but we don't trust client
+//!   payloads.
+//! - `wishlist_upvote` is intentionally simple: increment-only, no
+//!   per-anggota dedup. The acceptance criteria mark dedup as an explicit
+//!   v2 follow-up so we keep this commit focused.
+//! - Every status transition writes an `audit_log` row so the admin can
+//!   trace why a request was rejected or marked acquired.
+
+use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tauri::State;
+
+use crate::commands::kas::insert_audit_log;
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+const ALLOWED_STATUS: &[&str] = &[
+    "pending",
+    "disetujui",
+    "ditolak",
+    "sudah_diadakan",
+    "dibatalkan",
+];
+
+const MAX_FIELD_LEN: usize = 500;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WishlistRow {
+    pub id: i64,
+    pub anggota_id: i64,
+    pub anggota_nama: String,
+    pub anggota_kode: String,
+    pub judul: String,
+    pub pengarang: Option<String>,
+    pub isbn: Option<String>,
+    pub alasan: Option<String>,
+    pub status: String,
+    pub catatan_admin: Option<String>,
+    pub buku_id: Option<i64>,
+    pub buku_judul: Option<String>,
+    pub upvote_count: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WishlistCreateInput {
+    pub anggota_id: i64,
+    pub judul: String,
+    pub pengarang: Option<String>,
+    pub isbn: Option<String>,
+    pub alasan: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WishlistUpdateStatusInput {
+    pub id: i64,
+    pub status: String,
+    pub catatan_admin: Option<String>,
+    pub buku_id: Option<i64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WishlistListQuery {
+    pub status: Option<String>,
+    pub anggota_id: Option<i64>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// Allowed (from, to) status edges. Returning false here surfaces a clear
+/// validation error to the operator instead of silently corrupting state.
+fn is_valid_transition(from: &str, to: &str) -> bool {
+    match (from, to) {
+        ("pending", "disetujui")
+        | ("pending", "ditolak")
+        | ("pending", "dibatalkan")
+        | ("disetujui", "sudah_diadakan")
+        | ("disetujui", "dibatalkan")
+        | ("ditolak", "pending")
+        | ("dibatalkan", "pending") => true,
+        // Idempotent: marking a row to its current status is a no-op rather
+        // than an error so the UI doesn't have to special-case double-clicks.
+        (a, b) if a == b => true,
+        _ => false,
+    }
+}
+
+fn validate_text_field(name: &str, value: &str, required: bool) -> AppResult<()> {
+    let trimmed = value.trim();
+    if required && trimmed.is_empty() {
+        return Err(AppError::Validation(format!("{name} tidak boleh kosong")));
+    }
+    if trimmed.chars().count() > MAX_FIELD_LEN {
+        return Err(AppError::Validation(format!(
+            "{name} terlalu panjang (maks {MAX_FIELD_LEN} karakter)"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_create(input: &WishlistCreateInput) -> AppResult<()> {
+    if input.anggota_id <= 0 {
+        return Err(AppError::Validation(format!(
+            "anggota_id invalid: {}",
+            input.anggota_id
+        )));
+    }
+    validate_text_field("Judul", &input.judul, true)?;
+    if let Some(p) = input.pengarang.as_deref() {
+        validate_text_field("Pengarang", p, false)?;
+    }
+    if let Some(i) = input.isbn.as_deref() {
+        validate_text_field("ISBN", i, false)?;
+    }
+    if let Some(a) = input.alasan.as_deref() {
+        validate_text_field("Alasan", a, false)?;
+    }
+    Ok(())
+}
+
+fn fetch_row(conn: &Connection, id: i64) -> AppResult<WishlistRow> {
+    conn.query_row(
+        "SELECT w.id, w.anggota_id, COALESCE(a.nama, ''), COALESCE(a.kode_anggota, ''), \
+                w.judul, w.pengarang, w.isbn, w.alasan, w.status, w.catatan_admin, \
+                w.buku_id, b.judul, w.upvote_count, w.created_at, w.updated_at \
+         FROM wishlist_buku w \
+         LEFT JOIN anggota a ON a.id = w.anggota_id \
+         LEFT JOIN buku b ON b.id = w.buku_id \
+         WHERE w.id = ?1",
+        params![id],
+        map_row,
+    )
+    .optional()?
+    .ok_or_else(|| AppError::NotFound(format!("wishlist id {id}")))
+}
+
+fn map_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<WishlistRow> {
+    Ok(WishlistRow {
+        id: r.get(0)?,
+        anggota_id: r.get(1)?,
+        anggota_nama: r.get(2)?,
+        anggota_kode: r.get(3)?,
+        judul: r.get(4)?,
+        pengarang: r.get(5)?,
+        isbn: r.get(6)?,
+        alasan: r.get(7)?,
+        status: r.get(8)?,
+        catatan_admin: r.get(9)?,
+        buku_id: r.get(10)?,
+        buku_judul: r.get(11)?,
+        upvote_count: r.get(12)?,
+        created_at: r.get(13)?,
+        updated_at: r.get(14)?,
+    })
+}
+
+pub(crate) fn wishlist_create_inner(
+    conn: &mut Connection,
+    input: &WishlistCreateInput,
+    user_id: Option<i64>,
+) -> AppResult<WishlistRow> {
+    validate_create(input)?;
+    let exists: bool = conn
+        .query_row(
+            "SELECT 1 FROM anggota WHERE id = ?1",
+            params![input.anggota_id],
+            |_| Ok(true),
+        )
+        .optional()?
+        .unwrap_or(false);
+    if !exists {
+        return Err(AppError::NotFound(format!(
+            "anggota id {}",
+            input.anggota_id
+        )));
+    }
+
+    let tx = conn.transaction()?;
+    let judul = input.judul.trim();
+    let pengarang = input.pengarang.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let isbn = input.isbn.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let alasan = input.alasan.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    tx.execute(
+        "INSERT INTO wishlist_buku (anggota_id, judul, pengarang, isbn, alasan, status, upvote_count) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 'pending', 1)",
+        params![input.anggota_id, judul, pengarang, isbn, alasan],
+    )?;
+    let id = tx.last_insert_rowid();
+
+    let detail = json!({
+        "after": {
+            "anggota_id": input.anggota_id,
+            "judul": judul,
+            "pengarang": pengarang,
+            "isbn": isbn,
+            "status": "pending",
+        }
+    });
+    insert_audit_log(&tx, user_id, "create", "wishlist_buku", Some(id), &detail)?;
+    tx.commit()?;
+
+    fetch_row(conn, id)
+}
+
+pub(crate) fn wishlist_update_status_inner(
+    conn: &mut Connection,
+    input: &WishlistUpdateStatusInput,
+    user_id: Option<i64>,
+) -> AppResult<WishlistRow> {
+    if !ALLOWED_STATUS.contains(&input.status.as_str()) {
+        return Err(AppError::Validation(format!(
+            "status tidak dikenal: {}",
+            input.status
+        )));
+    }
+    if let Some(c) = input.catatan_admin.as_deref() {
+        validate_text_field("Catatan", c, false)?;
+    }
+    let before = fetch_row(conn, input.id)?;
+    if !is_valid_transition(&before.status, &input.status) {
+        return Err(AppError::Validation(format!(
+            "transisi status tidak diizinkan: {} → {}",
+            before.status, input.status
+        )));
+    }
+
+    if let Some(buku_id) = input.buku_id {
+        let exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM buku WHERE id = ?1",
+                params![buku_id],
+                |_| Ok(true),
+            )
+            .optional()?
+            .unwrap_or(false);
+        if !exists {
+            return Err(AppError::NotFound(format!("buku id {buku_id}")));
+        }
+    }
+
+    let tx = conn.transaction()?;
+    let catatan = input
+        .catatan_admin
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    tx.execute(
+        "UPDATE wishlist_buku SET status = ?1, catatan_admin = ?2, buku_id = ?3, \
+                                  updated_at = datetime('now') \
+         WHERE id = ?4",
+        params![input.status, catatan, input.buku_id, input.id],
+    )?;
+
+    let detail = json!({
+        "before": { "status": before.status },
+        "after": { "status": input.status, "catatan_admin": catatan, "buku_id": input.buku_id },
+    });
+    insert_audit_log(
+        &tx,
+        user_id,
+        "update_status",
+        "wishlist_buku",
+        Some(input.id),
+        &detail,
+    )?;
+    tx.commit()?;
+
+    fetch_row(conn, input.id)
+}
+
+pub(crate) fn wishlist_upvote_inner(
+    conn: &mut Connection,
+    id: i64,
+    user_id: Option<i64>,
+) -> AppResult<WishlistRow> {
+    if id <= 0 {
+        return Err(AppError::Validation(format!("invalid id: {id}")));
+    }
+    let _before = fetch_row(conn, id)?;
+
+    let tx = conn.transaction()?;
+    let updated = tx.execute(
+        "UPDATE wishlist_buku SET upvote_count = upvote_count + 1, updated_at = datetime('now') \
+         WHERE id = ?1",
+        params![id],
+    )?;
+    if updated == 0 {
+        return Err(AppError::NotFound(format!("wishlist id {id}")));
+    }
+    let detail = json!({ "wishlist_id": id });
+    insert_audit_log(&tx, user_id, "upvote", "wishlist_buku", Some(id), &detail)?;
+    tx.commit()?;
+
+    fetch_row(conn, id)
+}
+
+pub(crate) fn wishlist_delete_inner(
+    conn: &mut Connection,
+    id: i64,
+    user_id: Option<i64>,
+) -> AppResult<()> {
+    if id <= 0 {
+        return Err(AppError::Validation(format!("invalid id: {id}")));
+    }
+    let before = fetch_row(conn, id)?;
+
+    let tx = conn.transaction()?;
+    let deleted = tx.execute("DELETE FROM wishlist_buku WHERE id = ?1", params![id])?;
+    if deleted == 0 {
+        return Err(AppError::NotFound(format!("wishlist id {id}")));
+    }
+    let detail = json!({
+        "before": {
+            "anggota_id": before.anggota_id,
+            "judul": before.judul,
+            "status": before.status,
+        }
+    });
+    insert_audit_log(&tx, user_id, "delete", "wishlist_buku", Some(id), &detail)?;
+    tx.commit()?;
+    Ok(())
+}
+
+pub(crate) fn wishlist_list_inner(
+    conn: &Connection,
+    query: &WishlistListQuery,
+) -> AppResult<Vec<WishlistRow>> {
+    let limit = query.limit.unwrap_or(200).clamp(1, 1000);
+    let offset = query.offset.unwrap_or(0).max(0);
+
+    let mut clauses: Vec<String> = Vec::new();
+    let mut binds: Vec<rusqlite::types::Value> = Vec::new();
+    if let Some(s) = query.status.as_deref().filter(|s| !s.trim().is_empty()) {
+        if !ALLOWED_STATUS.contains(&s) {
+            return Err(AppError::Validation(format!("status tidak dikenal: {s}")));
+        }
+        clauses.push("w.status = ?".into());
+        binds.push(rusqlite::types::Value::Text(s.to_string()));
+    }
+    if let Some(aid) = query.anggota_id {
+        clauses.push("w.anggota_id = ?".into());
+        binds.push(rusqlite::types::Value::Integer(aid));
+    }
+    let where_sql = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", clauses.join(" AND "))
+    };
+    let sql = format!(
+        "SELECT w.id, w.anggota_id, COALESCE(a.nama, ''), COALESCE(a.kode_anggota, ''), \
+                w.judul, w.pengarang, w.isbn, w.alasan, w.status, w.catatan_admin, \
+                w.buku_id, b.judul, w.upvote_count, w.created_at, w.updated_at \
+         FROM wishlist_buku w \
+         LEFT JOIN anggota a ON a.id = w.anggota_id \
+         LEFT JOIN buku b ON b.id = w.buku_id \
+         {where_sql} \
+         ORDER BY w.upvote_count DESC, w.id DESC \
+         LIMIT {limit} OFFSET {offset}"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(params_from_iter(binds.iter()), map_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+fn current_user_id(state: &AppState) -> Option<i64> {
+    state
+        .current_user
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().map(|u| u.id))
+}
+
+#[tauri::command]
+pub fn wishlist_create(
+    state: State<'_, AppState>,
+    input: WishlistCreateInput,
+) -> AppResult<WishlistRow> {
+    let user_id = current_user_id(&state);
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    wishlist_create_inner(&mut conn, &input, user_id)
+}
+
+#[tauri::command]
+pub fn wishlist_list(
+    state: State<'_, AppState>,
+    query: Option<WishlistListQuery>,
+) -> AppResult<Vec<WishlistRow>> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    wishlist_list_inner(&conn, &query.unwrap_or_default())
+}
+
+#[tauri::command]
+pub fn wishlist_update_status(
+    state: State<'_, AppState>,
+    input: WishlistUpdateStatusInput,
+) -> AppResult<WishlistRow> {
+    let user_id = current_user_id(&state);
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    wishlist_update_status_inner(&mut conn, &input, user_id)
+}
+
+#[tauri::command]
+pub fn wishlist_upvote(state: State<'_, AppState>, id: i64) -> AppResult<WishlistRow> {
+    let user_id = current_user_id(&state);
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    wishlist_upvote_inner(&mut conn, id, user_id)
+}
+
+#[tauri::command]
+pub fn wishlist_delete(state: State<'_, AppState>, id: i64) -> AppResult<()> {
+    let user_id = current_user_id(&state);
+    let mut conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    wishlist_delete_inner(&mut conn, id, user_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("open db");
+        conn.pragma_update(None, "foreign_keys", "ON").expect("fk on");
+        crate::db::run_migrations(&conn).expect("migrations");
+        conn
+    }
+
+    fn seed_anggota(conn: &Connection, kode: &str, nama: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO anggota (kode_anggota, nama, aktif) VALUES (?1, ?2, 1)",
+            params![kode, nama],
+        )
+        .expect("seed anggota");
+        conn.last_insert_rowid()
+    }
+
+    fn seed_buku(conn: &Connection, kode: &str, judul: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO buku (kode_buku, judul, jumlah_eksemplar) VALUES (?1, ?2, 1)",
+            params![kode, judul],
+        )
+        .expect("seed buku");
+        conn.last_insert_rowid()
+    }
+
+    fn create_input(anggota_id: i64, judul: &str) -> WishlistCreateInput {
+        WishlistCreateInput {
+            anggota_id,
+            judul: judul.into(),
+            pengarang: Some("Tere Liye".into()),
+            isbn: Some("978-602-03".into()),
+            alasan: Some("Sering ditanya siswa".into()),
+        }
+    }
+
+    #[test]
+    fn create_persists_row_and_audits() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let row = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("create");
+        assert_eq!(row.judul, "Bumi");
+        assert_eq!(row.status, "pending");
+        assert_eq!(row.upvote_count, 1);
+        let aksi: String = conn
+            .query_row(
+                "SELECT aksi FROM audit_log ORDER BY id DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("audit");
+        assert_eq!(aksi, "create");
+    }
+
+    #[test]
+    fn create_rejects_blank_judul_and_unknown_anggota() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let mut bad = create_input(aid, "  ");
+        assert!(matches!(
+            wishlist_create_inner(&mut conn, &bad, None),
+            Err(AppError::Validation(_))
+        ));
+        bad.judul = "Bumi".into();
+        bad.anggota_id = 999;
+        assert!(matches!(
+            wishlist_create_inner(&mut conn, &bad, None),
+            Err(AppError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn update_status_accepts_pending_to_disetujui_and_records_audit() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let row = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("create");
+        let updated = wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: row.id,
+                status: "disetujui".into(),
+                catatan_admin: Some("Akan dipesan minggu depan".into()),
+                buku_id: None,
+            },
+            None,
+        )
+        .expect("update");
+        assert_eq!(updated.status, "disetujui");
+        assert_eq!(
+            updated.catatan_admin.as_deref(),
+            Some("Akan dipesan minggu depan")
+        );
+    }
+
+    #[test]
+    fn update_status_blocks_disetujui_to_pending() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let row = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("create");
+        wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: row.id,
+                status: "disetujui".into(),
+                catatan_admin: None,
+                buku_id: None,
+            },
+            None,
+        )
+        .expect("approve");
+        let err = wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: row.id,
+                status: "pending".into(),
+                catatan_admin: None,
+                buku_id: None,
+            },
+            None,
+        )
+        .expect_err("should block");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn update_status_links_buku_when_marked_acquired() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let bid = seed_buku(&conn, "B-001", "Bumi");
+        let row = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("create");
+        wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: row.id,
+                status: "disetujui".into(),
+                catatan_admin: None,
+                buku_id: None,
+            },
+            None,
+        )
+        .expect("approve");
+        let acquired = wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: row.id,
+                status: "sudah_diadakan".into(),
+                catatan_admin: None,
+                buku_id: Some(bid),
+            },
+            None,
+        )
+        .expect("acquired");
+        assert_eq!(acquired.status, "sudah_diadakan");
+        assert_eq!(acquired.buku_id, Some(bid));
+        assert_eq!(acquired.buku_judul.as_deref(), Some("Bumi"));
+    }
+
+    #[test]
+    fn update_status_rejects_unknown_buku() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let row = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("create");
+        wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: row.id,
+                status: "disetujui".into(),
+                catatan_admin: None,
+                buku_id: None,
+            },
+            None,
+        )
+        .expect("approve");
+        let err = wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: row.id,
+                status: "sudah_diadakan".into(),
+                catatan_admin: None,
+                buku_id: Some(9999),
+            },
+            None,
+        )
+        .expect_err("should reject");
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn upvote_increments_count() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let row = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("create");
+        let updated = wishlist_upvote_inner(&mut conn, row.id, None).expect("upvote");
+        assert_eq!(updated.upvote_count, 2);
+        let again = wishlist_upvote_inner(&mut conn, row.id, None).expect("upvote 2");
+        assert_eq!(again.upvote_count, 3);
+    }
+
+    #[test]
+    fn delete_removes_row_and_audits() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let row = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("create");
+        wishlist_delete_inner(&mut conn, row.id, None).expect("delete");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM wishlist_buku", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn list_filters_by_status_and_orders_by_upvote_desc() {
+        let mut conn = setup_db();
+        let aid = seed_anggota(&conn, "A0001", "Andini");
+        let r1 = wishlist_create_inner(&mut conn, &create_input(aid, "Bumi"), None).expect("c1");
+        let r2 = wishlist_create_inner(&mut conn, &create_input(aid, "Bulan"), None).expect("c2");
+        wishlist_upvote_inner(&mut conn, r2.id, None).expect("upvote r2");
+        wishlist_upvote_inner(&mut conn, r2.id, None).expect("upvote r2 again");
+
+        let pending = wishlist_list_inner(
+            &conn,
+            &WishlistListQuery {
+                status: Some("pending".into()),
+                anggota_id: None,
+                limit: None,
+                offset: None,
+            },
+        )
+        .expect("list");
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].id, r2.id, "highest upvote first");
+
+        wishlist_update_status_inner(
+            &mut conn,
+            &WishlistUpdateStatusInput {
+                id: r1.id,
+                status: "disetujui".into(),
+                catatan_admin: None,
+                buku_id: None,
+            },
+            None,
+        )
+        .expect("approve");
+        let approved = wishlist_list_inner(
+            &conn,
+            &WishlistListQuery {
+                status: Some("disetujui".into()),
+                anggota_id: None,
+                limit: None,
+                offset: None,
+            },
+        )
+        .expect("list");
+        assert_eq!(approved.len(), 1);
+        assert_eq!(approved[0].id, r1.id);
+    }
+
+    #[test]
+    fn list_rejects_unknown_status_filter() {
+        let conn = setup_db();
+        let err = wishlist_list_inner(
+            &conn,
+            &WishlistListQuery {
+                status: Some("haram".into()),
+                anggota_id: None,
+                limit: None,
+                offset: None,
+            },
+        )
+        .expect_err("should reject");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn transition_table_is_correct() {
+        // Sanity-check matrix the UI mirrors.
+        assert!(is_valid_transition("pending", "disetujui"));
+        assert!(is_valid_transition("pending", "ditolak"));
+        assert!(is_valid_transition("disetujui", "sudah_diadakan"));
+        assert!(is_valid_transition("ditolak", "pending"));
+        assert!(!is_valid_transition("sudah_diadakan", "pending"));
+        assert!(!is_valid_transition("disetujui", "ditolak"));
+        // Idempotent
+        assert!(is_valid_transition("pending", "pending"));
+    }
+}

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -31,13 +31,58 @@ pub fn run_migrations(conn: &Connection) -> AppResult<()> {
     conn.execute_batch(KTA_SQL)?;
     conn.execute_batch(LABEL_BUKU_SQL)?;
     conn.execute_batch(BACKUP_HISTORY_SQL)?;
+    conn.execute_batch(SURAT_SQL)?;
+    conn.execute_batch(WISHLIST_SQL)?;
     apply_additive_migrations(conn)?;
     seed_master_data(conn)?;
     seed_kta_default_template(conn)?;
     seed_label_buku_default_template(conn)?;
+    crate::commands::surat::seed_default_surat_settings(conn)?;
     log::info!("schema migrations applied (idempotent)");
     Ok(())
 }
+
+/// Surat keterangan bebas pustaka log (FEAT-21). Each row is one printed
+/// surat; deletion is intentionally not exposed via a Tauri command so the
+/// audit trail of nomor_surat → anggota assignments is preserved.
+const SURAT_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS surat_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    anggota_id    INTEGER NOT NULL,
+    nomor_surat   TEXT    NOT NULL UNIQUE,
+    tanggal_cetak TEXT    NOT NULL DEFAULT (date('now')),
+    pdf_path      TEXT,
+    petugas_id    INTEGER,
+    created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (anggota_id) REFERENCES anggota(id) ON DELETE CASCADE,
+    FOREIGN KEY (petugas_id) REFERENCES users(id)   ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_surat_log_anggota ON surat_log(anggota_id);
+CREATE INDEX IF NOT EXISTS idx_surat_log_tanggal ON surat_log(tanggal_cetak);
+"#;
+
+/// Wishlist anggota / request pengadaan buku (FEAT-22). Status enum is
+/// validated server-side in `commands::wishlist::is_valid_transition`.
+const WISHLIST_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS wishlist_buku (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    anggota_id    INTEGER NOT NULL,
+    judul         TEXT    NOT NULL,
+    pengarang     TEXT,
+    isbn          TEXT,
+    alasan        TEXT,
+    status        TEXT    NOT NULL DEFAULT 'pending',
+    catatan_admin TEXT,
+    buku_id       INTEGER,
+    upvote_count  INTEGER NOT NULL DEFAULT 1,
+    created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (anggota_id) REFERENCES anggota(id) ON DELETE CASCADE,
+    FOREIGN KEY (buku_id)    REFERENCES buku(id)    ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_wishlist_status ON wishlist_buku(status);
+CREATE INDEX IF NOT EXISTS idx_wishlist_anggota ON wishlist_buku(anggota_id);
+"#;
 
 const KTA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS kta_templates (

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -222,6 +222,14 @@ pub fn run() {
             commands::assets::assets_refit_anggota_photos,
             commands::user_profile::user_profile_get,
             commands::user_profile::user_profile_update,
+            commands::surat::surat_check_eligibility,
+            commands::surat::surat_generate,
+            commands::surat::surat_log_list,
+            commands::wishlist::wishlist_create,
+            commands::wishlist::wishlist_list,
+            commands::wishlist::wishlist_update_status,
+            commands::wishlist::wishlist_upvote,
+            commands::wishlist::wishlist_delete,
         ])
         .on_window_event(|window, event| {
             // BUG-011: intercept the X-button on the main window and

--- a/apps/desktop/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Library,
   ScanLine,
   BookMarked,
+  Heart,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -38,6 +39,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/sirkulasi', labelKey: 'common:menu.sirkulasi', Icon: ScanLine },
   { to: '/kunjungan', labelKey: 'common:menu.kunjungan', Icon: CalendarCheck },
   { to: '/laporan', labelKey: 'common:menu.laporan', Icon: BarChart3 },
+  { to: '/wishlist', labelKey: 'common:menu.wishlist', Icon: Heart },
   { to: '/settings', labelKey: 'common:menu.settings', Icon: Settings },
 ];
 

--- a/apps/desktop/src/features/surat/SuratBebasPustakaDialog.tsx
+++ b/apps/desktop/src/features/surat/SuratBebasPustakaDialog.tsx
@@ -1,0 +1,194 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { FileText, Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/components/ui/toast-manager';
+import { formatTauriError } from '@/lib/errors';
+import {
+  suratApi,
+  type SuratEligibility,
+  type SuratGenerateResult,
+} from '@/lib/surat';
+import { useIdentityStore } from '@/stores/identityStore';
+import { downloadSuratPdf } from './pdf';
+
+interface SuratBebasPustakaDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  anggotaId: number;
+}
+
+type DialogState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'eligible'; data: SuratEligibility }
+  | { kind: 'ineligible'; data: SuratEligibility }
+  | { kind: 'generated'; data: SuratGenerateResult };
+
+export const SuratBebasPustakaDialog: React.FC<SuratBebasPustakaDialogProps> = ({
+  open,
+  onOpenChange,
+  anggotaId,
+}) => {
+  const { t } = useTranslation(['surat', 'common']);
+  const { showToast } = useToast();
+  const identity = useIdentityStore((s) => s.identity);
+  const [state, setState] = React.useState<DialogState>({ kind: 'idle' });
+
+  React.useEffect(() => {
+    if (!open) {
+      setState({ kind: 'idle' });
+      return;
+    }
+    let cancelled = false;
+    setState({ kind: 'loading' });
+    suratApi
+      .checkEligibility(anggotaId)
+      .then((data) => {
+        if (cancelled) return;
+        setState({ kind: data.eligible ? 'eligible' : 'ineligible', data });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        showToast({
+          variant: 'destructive',
+          title: t('surat:feedback.generateError', {
+            message: formatTauriError(err),
+          }),
+        });
+        onOpenChange(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, anggotaId, showToast, t, onOpenChange]);
+
+  const handleGenerate = React.useCallback(async () => {
+    setState({ kind: 'loading' });
+    try {
+      const data = await suratApi.generate(anggotaId);
+      setState({ kind: 'generated', data });
+      showToast({
+        title: t('surat:feedback.generated', { nomor: data.nomorSurat }),
+      });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('surat:feedback.generateError', { message: formatTauriError(err) }),
+      });
+      setState({ kind: 'idle' });
+    }
+  }, [anggotaId, showToast, t]);
+
+  const handleDownload = React.useCallback(() => {
+    if (state.kind !== 'generated') return;
+    downloadSuratPdf({
+      result: state.data,
+      identity: {
+        namaPerpustakaan: identity.nama,
+        alamat: identity.alamat,
+        kota: undefined,
+      },
+    });
+    showToast({ title: t('surat:feedback.downloadStarted') });
+  }, [state, identity, showToast, t]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" data-testid="surat-bebas-pustaka-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            {t('surat:dialog.title')}
+          </DialogTitle>
+          <DialogDescription>{t('surat:subtitle')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2 text-sm">
+          {state.kind === 'loading' && (
+            <p className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('surat:dialog.checkingEligibility')}
+            </p>
+          )}
+
+          {state.kind === 'eligible' && (
+            <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-emerald-900">
+              {t('surat:dialog.eligible')}
+            </p>
+          )}
+
+          {state.kind === 'ineligible' && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900">
+              <p className="font-medium">{t('surat:dialog.notEligible')}</p>
+              <ul className="mt-1 list-disc pl-5 text-xs">
+                {!state.data.anggotaAktif && (
+                  <li>{t('surat:dialog.summary.inactive')}</li>
+                )}
+                {state.data.activeLoans > 0 && (
+                  <li>
+                    {t('surat:dialog.summary.activeLoans', {
+                      count: state.data.activeLoans,
+                    })}
+                  </li>
+                )}
+                {state.data.outstandingDenda > 0 && (
+                  <li>
+                    {t('surat:dialog.summary.outstandingDenda', {
+                      amount: state.data.outstandingDenda.toLocaleString('id-ID'),
+                    })}
+                  </li>
+                )}
+              </ul>
+            </div>
+          )}
+
+          {state.kind === 'generated' && (
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
+              <dt className="text-muted-foreground">{t('surat:dialog.preview.nomorSurat')}</dt>
+              <dd className="font-mono">{state.data.nomorSurat}</dd>
+              <dt className="text-muted-foreground">{t('surat:dialog.preview.tanggal')}</dt>
+              <dd>{state.data.tanggalCetak}</dd>
+              <dt className="text-muted-foreground">{t('surat:dialog.preview.anggota')}</dt>
+              <dd>
+                {state.data.anggotaNama}{' '}
+                <span className="text-muted-foreground">({state.data.anggotaKode})</span>
+              </dd>
+              {state.data.anggotaKelas && (
+                <>
+                  <dt className="text-muted-foreground">{t('surat:dialog.preview.kelas')}</dt>
+                  <dd>{state.data.anggotaKelas}</dd>
+                </>
+              )}
+            </dl>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t('surat:button.tutup')}
+          </Button>
+          {state.kind === 'eligible' && (
+            <Button onClick={handleGenerate} data-testid="surat-cetak-button">
+              {t('surat:button.cetak')}
+            </Button>
+          )}
+          {state.kind === 'generated' && (
+            <Button onClick={handleDownload} data-testid="surat-download-button">
+              {t('surat:button.download')}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/desktop/src/features/surat/pdf.ts
+++ b/apps/desktop/src/features/surat/pdf.ts
@@ -1,0 +1,117 @@
+/**
+ * Render a "Surat Keterangan Bebas Pustaka" PDF in the WebView via jsPDF.
+ *
+ * Single-page A4 portrait, plain Times-Roman 12pt body. The template is
+ * filled in with `fillSuratTemplate` (placeholders → real values) before
+ * being laid out as paragraphs.
+ *
+ * Why so simple: the user-visible output the librarian will read is dominated
+ * by the body text + nomor surat + signatory block. Anything fancier (custom
+ * fonts, embedded TTD image, headers/footers) lives in v1.0.9+ once we have
+ * data on whether schools actually want it.
+ */
+import jsPDF from 'jspdf';
+
+import { fillSuratTemplate, type SuratGenerateResult } from '@/lib/surat';
+
+export interface SuratPdfIdentity {
+  namaPerpustakaan: string;
+  alamat?: string | null;
+  kota?: string | null;
+}
+
+export interface SuratPdfInput {
+  result: SuratGenerateResult;
+  identity: SuratPdfIdentity;
+}
+
+/**
+ * Replace `\\n`-separated paragraphs in the template with real wrapped text
+ * blocks. Returns a jsPDF document positioned at the bottom of the body so
+ * the caller can append the signatory block.
+ */
+function renderBody(doc: jsPDF, body: string, x: number, yStart: number, width: number): number {
+  let y = yStart;
+  const lineHeight = 6;
+  for (const paragraph of body.split('\n')) {
+    if (paragraph.trim() === '') {
+      y += lineHeight / 2;
+      continue;
+    }
+    const wrapped = doc.splitTextToSize(paragraph, width) as string[];
+    for (const line of wrapped) {
+      if (y > 270) {
+        doc.addPage();
+        y = 20;
+      }
+      doc.text(line, x, y);
+      y += lineHeight;
+    }
+    y += lineHeight / 2;
+  }
+  return y;
+}
+
+/**
+ * Build the surat PDF and return the populated jsPDF doc. The caller is
+ * responsible for `doc.save(...)` / `doc.output(...)` so we don't force a
+ * filesystem path here (lets the dialog show a "Pratinjau" inline blob too).
+ */
+export function buildSuratPdf(input: SuratPdfInput): jsPDF {
+  const { result, identity } = input;
+  const doc = new jsPDF({ unit: 'mm', format: 'a4', orientation: 'portrait' });
+  const margin = 25;
+  const pageWidth = 210;
+  const bodyWidth = pageWidth - margin * 2;
+
+  doc.setFont('times', 'bold');
+  doc.setFontSize(13);
+  doc.text(identity.namaPerpustakaan || 'Perpustakaan', pageWidth / 2, 25, { align: 'center' });
+
+  doc.setFontSize(12);
+  doc.text('SURAT KETERANGAN BEBAS PUSTAKA', pageWidth / 2, 33, { align: 'center' });
+
+  doc.setFont('times', 'normal');
+  doc.setFontSize(11);
+  doc.text(`Nomor: ${result.nomorSurat}`, pageWidth / 2, 40, { align: 'center' });
+
+  doc.setFontSize(12);
+  const filled = fillSuratTemplate(result.templateHtml, {
+    nama: result.anggotaNama,
+    kode_anggota: result.anggotaKode,
+    kelas: result.anggotaKelas ?? '-',
+    tanggal: result.tanggalCetak,
+    nomor_surat: result.nomorSurat,
+    nama_perpustakaan: identity.namaPerpustakaan,
+    kota: identity.kota ?? '-',
+  });
+  const bodyEnd = renderBody(doc, filled, margin, 55, bodyWidth);
+
+  // Signatory block.
+  const ttdY = Math.max(bodyEnd + 10, 230);
+  doc.text('Mengetahui,', pageWidth - margin, ttdY, { align: 'right' });
+  doc.text(
+    result.kepalaSekolahNama || '(_______________________)',
+    pageWidth - margin,
+    ttdY + 28,
+    { align: 'right' },
+  );
+  if (result.kepalaSekolahNip) {
+    doc.text(`NIP. ${result.kepalaSekolahNip}`, pageWidth - margin, ttdY + 34, {
+      align: 'right',
+    });
+  }
+
+  return doc;
+}
+
+/**
+ * Convenience helper: build + trigger a browser-style download. Works inside
+ * Tauri's WebView (the user gets a native save dialog through the WebView's
+ * own download handler).
+ */
+export function downloadSuratPdf(input: SuratPdfInput, filename?: string): void {
+  const doc = buildSuratPdf(input);
+  const safeNomor = input.result.nomorSurat.replace(/[^a-zA-Z0-9._-]/g, '_');
+  doc.save(filename ?? `surat-bebas-pustaka-${safeNomor}.pdf`);
+}

--- a/apps/desktop/src/features/wishlist/WishlistAdminPage.tsx
+++ b/apps/desktop/src/features/wishlist/WishlistAdminPage.tsx
@@ -1,0 +1,458 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Heart, Plus, ThumbsUp, Trash2 } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useToast } from '@/components/ui/toast-manager';
+import { formatTauriError } from '@/lib/errors';
+import { anggotaApi, type Anggota } from '@/lib/anggota';
+import {
+  canTransition,
+  WISHLIST_STATUSES,
+  wishlistApi,
+  type WishlistRow,
+  type WishlistStatus,
+} from '@/lib/wishlist';
+
+type StatusFilter = 'all' | WishlistStatus;
+
+const STATUS_TONE: Record<WishlistStatus, string> = {
+  pending: 'bg-amber-100 text-amber-800 hover:bg-amber-200',
+  disetujui: 'bg-sky-100 text-sky-800 hover:bg-sky-200',
+  ditolak: 'bg-rose-100 text-rose-800 hover:bg-rose-200',
+  sudah_diadakan: 'bg-emerald-100 text-emerald-800 hover:bg-emerald-200',
+  dibatalkan: 'bg-slate-100 text-slate-700 hover:bg-slate-200',
+};
+
+const STATUS_FILTER_KEYS: Record<StatusFilter, string> = {
+  all: 'wishlist:filter.all',
+  pending: 'wishlist:filter.pending',
+  disetujui: 'wishlist:filter.disetujui',
+  ditolak: 'wishlist:filter.ditolak',
+  sudah_diadakan: 'wishlist:filter.sudahDiadakan',
+  dibatalkan: 'wishlist:filter.dibatalkan',
+};
+
+export function WishlistAdminPage(): React.ReactElement {
+  const { t } = useTranslation(['wishlist', 'common']);
+  const { showToast } = useToast();
+
+  const [rows, setRows] = React.useState<WishlistRow[]>([]);
+  const [filter, setFilter] = React.useState<StatusFilter>('all');
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [deleteTarget, setDeleteTarget] = React.useState<WishlistRow | null>(null);
+  const [loading, setLoading] = React.useState(false);
+
+  const refresh = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await wishlistApi.list(
+        filter === 'all' ? {} : { status: filter },
+      );
+      setRows(list);
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: formatTauriError(err),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, showToast]);
+
+  React.useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleUpvote = async (row: WishlistRow): Promise<void> => {
+    try {
+      const updated = await wishlistApi.upvote(row.id);
+      setRows((rs) => rs.map((r) => (r.id === updated.id ? updated : r)));
+      showToast({ title: t('wishlist:upvoteFeedback.success') });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('wishlist:upvoteFeedback.error', { message: formatTauriError(err) }),
+      });
+    }
+  };
+
+  const handleStatusChange = async (
+    row: WishlistRow,
+    status: WishlistStatus,
+  ): Promise<void> => {
+    if (!canTransition(row.status, status)) return;
+    try {
+      const updated = await wishlistApi.updateStatus({ id: row.id, status });
+      setRows((rs) => rs.map((r) => (r.id === updated.id ? updated : r)));
+      showToast({ title: t('wishlist:updateStatus.feedback.success') });
+      if (filter !== 'all' && updated.status !== filter) {
+        setRows((rs) => rs.filter((r) => r.id !== updated.id));
+      }
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('wishlist:updateStatus.feedback.error', {
+          message: formatTauriError(err),
+        }),
+      });
+    }
+  };
+
+  const confirmDelete = async (): Promise<void> => {
+    if (!deleteTarget) return;
+    try {
+      await wishlistApi.delete(deleteTarget.id);
+      setRows((rs) => rs.filter((r) => r.id !== deleteTarget.id));
+      showToast({ title: t('wishlist:deleteConfirm.feedback.success') });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('wishlist:deleteConfirm.feedback.error', {
+          message: formatTauriError(err),
+        }),
+      });
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 p-6 md:p-8" data-testid="wishlist-admin-page">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold">
+            <Heart className="h-5 w-5" />
+            {t('wishlist:title')}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t('wishlist:subtitle')}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={filter} onValueChange={(v) => setFilter(v as StatusFilter)}>
+            <SelectTrigger className="w-44" data-testid="wishlist-filter">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(STATUS_FILTER_KEYS) as StatusFilter[]).map((k) => (
+                <SelectItem key={k} value={k}>
+                  {t(STATUS_FILTER_KEYS[k])}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button onClick={() => setCreateOpen(true)} data-testid="wishlist-create-button">
+            <Plus className="mr-1 h-4 w-4" />
+            {t('wishlist:action.tambah')}
+          </Button>
+        </div>
+      </header>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10 text-center">{t('wishlist:column.upvote')}</TableHead>
+              <TableHead>{t('wishlist:column.judul')}</TableHead>
+              <TableHead>{t('wishlist:column.anggota')}</TableHead>
+              <TableHead>{t('wishlist:column.status')}</TableHead>
+              <TableHead>{t('wishlist:column.tanggal')}</TableHead>
+              <TableHead className="text-right">{t('wishlist:column.aksi')}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading && (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground">
+                  {t('common:states.loading')}
+                </TableCell>
+              </TableRow>
+            )}
+            {!loading && rows.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-center text-muted-foreground"
+                  data-testid="wishlist-empty"
+                >
+                  {filter === 'all'
+                    ? t('wishlist:empty.all')
+                    : t('wishlist:empty.filtered')}
+                </TableCell>
+              </TableRow>
+            )}
+            {!loading &&
+              rows.map((row) => (
+                <TableRow key={row.id} data-testid={`wishlist-row-${row.id}`}>
+                  <TableCell className="text-center font-mono text-sm">
+                    {row.upvoteCount}
+                  </TableCell>
+                  <TableCell>
+                    <div className="font-medium">{row.judul}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {[row.pengarang, row.isbn].filter(Boolean).join(' · ') || '—'}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="text-sm">{row.anggotaNama}</div>
+                    <div className="font-mono text-xs text-muted-foreground">
+                      {row.anggotaKode}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={STATUS_TONE[row.status]}>
+                      {t(`wishlist:status.${row.status}`)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {row.createdAt.slice(0, 10)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="inline-flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => void handleUpvote(row)}
+                        data-testid={`wishlist-upvote-${row.id}`}
+                        title={t('wishlist:action.upvote')}
+                      >
+                        <ThumbsUp className="h-4 w-4" />
+                      </Button>
+                      <StatusActions
+                        row={row}
+                        onChange={(status) => void handleStatusChange(row, status)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDeleteTarget(row)}
+                        data-testid={`wishlist-delete-${row.id}`}
+                        title={t('wishlist:action.hapus')}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <WishlistCreateDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={() => void refresh()}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        destructive
+        title={t('wishlist:deleteConfirm.title')}
+        description={t('wishlist:deleteConfirm.description')}
+        confirmText={t('wishlist:deleteConfirm.confirm')}
+        cancelText={t('wishlist:deleteConfirm.cancel')}
+        onConfirm={confirmDelete}
+      />
+    </div>
+  );
+}
+
+interface StatusActionsProps {
+  row: WishlistRow;
+  onChange: (status: WishlistStatus) => void;
+}
+
+function StatusActions({ row, onChange }: StatusActionsProps): React.ReactElement {
+  const { t } = useTranslation(['wishlist']);
+  return (
+    <Select
+      value={row.status}
+      onValueChange={(v) => onChange(v as WishlistStatus)}
+    >
+      <SelectTrigger className="h-8 w-40" data-testid={`wishlist-status-${row.id}`}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {WISHLIST_STATUSES.map((s) => (
+          <SelectItem key={s} value={s} disabled={!canTransition(row.status, s)}>
+            {t(`wishlist:status.${s}`)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+interface WishlistCreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
+}
+
+function WishlistCreateDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: WishlistCreateDialogProps): React.ReactElement {
+  const { t } = useTranslation(['wishlist', 'common']);
+  const { showToast } = useToast();
+
+  const [members, setMembers] = React.useState<Anggota[]>([]);
+  const [anggotaId, setAnggotaId] = React.useState<string>('');
+  const [judul, setJudul] = React.useState('');
+  const [pengarang, setPengarang] = React.useState('');
+  const [isbn, setIsbn] = React.useState('');
+  const [alasan, setAlasan] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    anggotaApi
+      .list({ aktif: true, limit: 200, sortBy: 'nama', sortDir: 'asc' })
+      .then((res) => {
+        if (cancelled) return;
+        setMembers(res.items);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setMembers([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const reset = (): void => {
+    setAnggotaId('');
+    setJudul('');
+    setPengarang('');
+    setIsbn('');
+    setAlasan('');
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!anggotaId || !judul.trim()) return;
+    setSubmitting(true);
+    try {
+      await wishlistApi.create({
+        anggotaId: Number(anggotaId),
+        judul: judul.trim(),
+        pengarang: pengarang.trim() || undefined,
+        isbn: isbn.trim() || undefined,
+        alasan: alasan.trim() || undefined,
+      });
+      showToast({ title: t('wishlist:create.feedback.success') });
+      onCreated();
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('wishlist:create.feedback.error', { message: formatTauriError(err) }),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('wishlist:create.title')}</DialogTitle>
+          <DialogDescription>{t('wishlist:create.subtitle')}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <Field label={t('wishlist:create.field.anggota')}>
+            <Select value={anggotaId} onValueChange={setAnggotaId}>
+              <SelectTrigger data-testid="wishlist-create-anggota">
+                <SelectValue placeholder={t('wishlist:create.field.anggotaPlaceholder')} />
+              </SelectTrigger>
+              <SelectContent>
+                {members.map((m) => (
+                  <SelectItem key={m.id} value={String(m.id)}>
+                    {m.nama} ({m.kodeAnggota})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field label={t('wishlist:create.field.judul')}>
+            <Input
+              value={judul}
+              onChange={(e) => setJudul(e.target.value)}
+              placeholder={t('wishlist:create.field.judulPlaceholder')}
+              data-testid="wishlist-create-judul"
+            />
+          </Field>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <Field label={t('wishlist:create.field.pengarang')}>
+              <Input value={pengarang} onChange={(e) => setPengarang(e.target.value)} />
+            </Field>
+            <Field label={t('wishlist:create.field.isbn')}>
+              <Input value={isbn} onChange={(e) => setIsbn(e.target.value)} />
+            </Field>
+          </div>
+          <Field label={t('wishlist:create.field.alasan')}>
+            <Input value={alasan} onChange={(e) => setAlasan(e.target.value)} />
+          </Field>
+        </div>
+        <DialogFooter className="gap-2">
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {t('wishlist:create.cancel')}
+          </Button>
+          <Button
+            onClick={() => void handleSubmit()}
+            disabled={submitting || !anggotaId || !judul.trim()}
+            data-testid="wishlist-create-submit"
+          >
+            {t('wishlist:create.submit')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: React.ReactNode;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 inline-block font-medium text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/apps/desktop/src/i18n/en/common.json
+++ b/apps/desktop/src/i18n/en/common.json
@@ -52,6 +52,7 @@
     "kunjungan": "Visits",
     "laporan": "Reports",
     "kta": "Member Card",
+    "wishlist": "Wishlist",
     "settings": "Settings",
     "manualBook": "User Manual",
     "profile": "Profile",

--- a/apps/desktop/src/i18n/en/surat.json
+++ b/apps/desktop/src/i18n/en/surat.json
@@ -1,0 +1,67 @@
+{
+  "title": "Library Clearance Letter",
+  "subtitle": "Print a clearance letter for members who have returned all books and paid all fines.",
+  "button": {
+    "cetak": "Print Clearance Letter",
+    "preview": "Preview",
+    "download": "Download PDF",
+    "tutup": "Close"
+  },
+  "dialog": {
+    "title": "Library Clearance Letter",
+    "checkingEligibility": "Checking eligibility…",
+    "eligible": "Member is eligible. A letter will be issued with an auto-assigned number.",
+    "notEligible": "Member is not yet eligible:",
+    "summary": {
+      "activeLoans": "Books not yet returned: {{count}}",
+      "outstandingDenda": "Outstanding fines: Rp{{amount}}",
+      "inactive": "Member status is inactive"
+    },
+    "preview": {
+      "nomorSurat": "Letter Number",
+      "tanggal": "Date Issued",
+      "anggota": "Member",
+      "kelas": "Class"
+    }
+  },
+  "feedback": {
+    "generated": "Clearance letter created (Number: {{nomor}}).",
+    "generateError": "Failed to create letter: {{message}}",
+    "downloadStarted": "PDF download started."
+  },
+  "settings": {
+    "title": "Library Clearance Letter",
+    "subtitle": "Configure letter number format, template, and signatory identity.",
+    "section": {
+      "format": "Number Format",
+      "template": "Letter Body",
+      "ttd": "Signatory"
+    },
+    "field": {
+      "formatNomor": "Letter number format",
+      "formatNomorHint": "Placeholders: {tahun}, {bulan}, {nomor:04d}",
+      "nomorTerakhir": "Last assigned number",
+      "nomorTerakhirHint": "Filled automatically. The next letter number = last + 1.",
+      "previewNomor": "Preview of next number",
+      "templateHtml": "Letter body template",
+      "templateHint": "Placeholders: {nama}, {kode_anggota}, {kelas}, {tanggal}, {nomor_surat}, {nama_perpustakaan}, {kota}",
+      "kepalaSekolahNama": "Principal's name",
+      "kepalaSekolahNip": "Principal's NIP",
+      "kepalaSekolahTtd": "Signature (PNG)"
+    },
+    "feedback": {
+      "saved": "Letter settings saved.",
+      "saveError": "Save failed: {{message}}"
+    }
+  },
+  "log": {
+    "title": "Clearance Letter History",
+    "empty": "No letters have been printed yet.",
+    "column": {
+      "tanggal": "Date",
+      "nomor": "Number",
+      "anggota": "Member",
+      "petugas": "Officer"
+    }
+  }
+}

--- a/apps/desktop/src/i18n/en/wishlist.json
+++ b/apps/desktop/src/i18n/en/wishlist.json
@@ -1,0 +1,92 @@
+{
+  "title": "Wishlist & Acquisitions",
+  "subtitle": "Member book requests. Staff can approve, reject, or mark as acquired.",
+  "filter": {
+    "all": "All",
+    "pending": "Pending",
+    "disetujui": "Approved",
+    "ditolak": "Rejected",
+    "sudahDiadakan": "Acquired",
+    "dibatalkan": "Cancelled"
+  },
+  "status": {
+    "pending": "Pending",
+    "disetujui": "Approved",
+    "ditolak": "Rejected",
+    "sudah_diadakan": "Acquired",
+    "dibatalkan": "Cancelled"
+  },
+  "column": {
+    "judul": "Title",
+    "pengarang": "Author",
+    "isbn": "ISBN",
+    "anggota": "Member",
+    "alasan": "Reason",
+    "upvote": "Upvotes",
+    "status": "Status",
+    "buku": "Linked Book",
+    "tanggal": "Date",
+    "aksi": "Actions"
+  },
+  "action": {
+    "tambah": "Add Request",
+    "setujui": "Approve",
+    "tolak": "Reject",
+    "tandaiSudahDiadakan": "Mark as Acquired",
+    "batalkan": "Cancel",
+    "kembalikanKePending": "Move back to Pending",
+    "upvote": "Upvote",
+    "hapus": "Delete"
+  },
+  "empty": {
+    "all": "No book requests yet.",
+    "filtered": "No requests match this filter."
+  },
+  "create": {
+    "title": "New Book Request",
+    "subtitle": "Record a new book request. Initial status: Pending.",
+    "field": {
+      "anggota": "Member",
+      "anggotaPlaceholder": "Pick a member",
+      "judul": "Book title",
+      "judulPlaceholder": "e.g. Atomic Habits",
+      "pengarang": "Author (optional)",
+      "isbn": "ISBN (optional)",
+      "alasan": "Reason / notes (optional)"
+    },
+    "submit": "Save Request",
+    "cancel": "Cancel",
+    "feedback": {
+      "success": "Request saved.",
+      "error": "Save failed: {{message}}"
+    }
+  },
+  "updateStatus": {
+    "title": "Change Status",
+    "field": {
+      "catatanAdmin": "Admin notes (optional)",
+      "buku": "Link to book (when marking acquired)",
+      "bukuPlaceholder": "Pick a book"
+    },
+    "submit": "Save",
+    "cancel": "Cancel",
+    "feedback": {
+      "success": "Status updated.",
+      "error": "Update failed: {{message}}"
+    }
+  },
+  "deleteConfirm": {
+    "title": "Delete request?",
+    "description": "This request will be permanently removed.",
+    "confirm": "Delete",
+    "cancel": "Cancel",
+    "feedback": {
+      "success": "Request deleted.",
+      "error": "Delete failed: {{message}}"
+    }
+  },
+  "upvoteFeedback": {
+    "success": "Thanks, your upvote was recorded.",
+    "error": "Upvote failed: {{message}}"
+  }
+}

--- a/apps/desktop/src/i18n/id/common.json
+++ b/apps/desktop/src/i18n/id/common.json
@@ -52,6 +52,7 @@
     "kunjungan": "Kunjungan",
     "laporan": "Laporan",
     "kta": "KTA",
+    "wishlist": "Wishlist",
     "settings": "Pengaturan",
     "manualBook": "Buku Manual",
     "profile": "Profil",

--- a/apps/desktop/src/i18n/id/surat.json
+++ b/apps/desktop/src/i18n/id/surat.json
@@ -1,0 +1,67 @@
+{
+  "title": "Surat Bebas Pustaka",
+  "subtitle": "Cetak surat keterangan bebas pustaka untuk anggota yang sudah menyelesaikan seluruh peminjaman dan denda.",
+  "button": {
+    "cetak": "Cetak Surat Bebas Pustaka",
+    "preview": "Pratinjau",
+    "download": "Unduh PDF",
+    "tutup": "Tutup"
+  },
+  "dialog": {
+    "title": "Surat Bebas Pustaka",
+    "checkingEligibility": "Memeriksa kelayakan…",
+    "eligible": "Anggota memenuhi syarat. Surat akan dibuatkan dengan nomor otomatis.",
+    "notEligible": "Anggota belum memenuhi syarat:",
+    "summary": {
+      "activeLoans": "Buku belum dikembalikan: {{count}}",
+      "outstandingDenda": "Sisa denda: Rp{{amount}}",
+      "inactive": "Status anggota tidak aktif"
+    },
+    "preview": {
+      "nomorSurat": "Nomor Surat",
+      "tanggal": "Tanggal Cetak",
+      "anggota": "Anggota",
+      "kelas": "Kelas"
+    }
+  },
+  "feedback": {
+    "generated": "Surat bebas pustaka berhasil dibuat (Nomor: {{nomor}}).",
+    "generateError": "Gagal membuat surat: {{message}}",
+    "downloadStarted": "PDF surat sedang diunduh."
+  },
+  "settings": {
+    "title": "Surat Bebas Pustaka",
+    "subtitle": "Atur format nomor surat, template isi, dan identitas penandatangan.",
+    "section": {
+      "format": "Format Nomor",
+      "template": "Template Isi",
+      "ttd": "Penandatangan"
+    },
+    "field": {
+      "formatNomor": "Format nomor surat",
+      "formatNomorHint": "Placeholder: {tahun}, {bulan}, {nomor:04d}",
+      "nomorTerakhir": "Nomor terakhir",
+      "nomorTerakhirHint": "Diisi otomatis. Surat berikutnya = nomor terakhir + 1.",
+      "previewNomor": "Pratinjau nomor berikutnya",
+      "templateHtml": "Template isi surat",
+      "templateHint": "Placeholder: {nama}, {kode_anggota}, {kelas}, {tanggal}, {nomor_surat}, {nama_perpustakaan}, {kota}",
+      "kepalaSekolahNama": "Nama Kepala Sekolah",
+      "kepalaSekolahNip": "NIP Kepala Sekolah",
+      "kepalaSekolahTtd": "Tanda tangan (PNG)"
+    },
+    "feedback": {
+      "saved": "Pengaturan surat tersimpan.",
+      "saveError": "Gagal menyimpan: {{message}}"
+    }
+  },
+  "log": {
+    "title": "Riwayat Surat Bebas Pustaka",
+    "empty": "Belum ada surat yang dicetak.",
+    "column": {
+      "tanggal": "Tanggal",
+      "nomor": "Nomor",
+      "anggota": "Anggota",
+      "petugas": "Petugas"
+    }
+  }
+}

--- a/apps/desktop/src/i18n/id/wishlist.json
+++ b/apps/desktop/src/i18n/id/wishlist.json
@@ -1,0 +1,92 @@
+{
+  "title": "Wishlist & Pengadaan",
+  "subtitle": "Daftar permintaan buku dari anggota. Petugas dapat menyetujui, menolak, atau menandai sudah diadakan.",
+  "filter": {
+    "all": "Semua",
+    "pending": "Pending",
+    "disetujui": "Disetujui",
+    "ditolak": "Ditolak",
+    "sudahDiadakan": "Sudah Diadakan",
+    "dibatalkan": "Dibatalkan"
+  },
+  "status": {
+    "pending": "Pending",
+    "disetujui": "Disetujui",
+    "ditolak": "Ditolak",
+    "sudah_diadakan": "Sudah Diadakan",
+    "dibatalkan": "Dibatalkan"
+  },
+  "column": {
+    "judul": "Judul",
+    "pengarang": "Pengarang",
+    "isbn": "ISBN",
+    "anggota": "Anggota",
+    "alasan": "Alasan",
+    "upvote": "Upvote",
+    "status": "Status",
+    "buku": "Buku Terkait",
+    "tanggal": "Tanggal",
+    "aksi": "Aksi"
+  },
+  "action": {
+    "tambah": "Tambah Wishlist",
+    "setujui": "Setujui",
+    "tolak": "Tolak",
+    "tandaiSudahDiadakan": "Tandai Sudah Diadakan",
+    "batalkan": "Batalkan",
+    "kembalikanKePending": "Kembalikan ke Pending",
+    "upvote": "Upvote",
+    "hapus": "Hapus"
+  },
+  "empty": {
+    "all": "Belum ada permintaan buku.",
+    "filtered": "Tidak ada permintaan untuk filter ini."
+  },
+  "create": {
+    "title": "Tambah Permintaan Buku",
+    "subtitle": "Catat permintaan buku dari anggota. Status awal: Pending.",
+    "field": {
+      "anggota": "Anggota",
+      "anggotaPlaceholder": "Pilih anggota",
+      "judul": "Judul buku",
+      "judulPlaceholder": "Contoh: Atomic Habits",
+      "pengarang": "Pengarang (opsional)",
+      "isbn": "ISBN (opsional)",
+      "alasan": "Alasan / catatan (opsional)"
+    },
+    "submit": "Simpan Permintaan",
+    "cancel": "Batal",
+    "feedback": {
+      "success": "Permintaan tersimpan.",
+      "error": "Gagal menyimpan: {{message}}"
+    }
+  },
+  "updateStatus": {
+    "title": "Ubah Status",
+    "field": {
+      "catatanAdmin": "Catatan admin (opsional)",
+      "buku": "Tautkan ke buku (saat sudah diadakan)",
+      "bukuPlaceholder": "Pilih buku"
+    },
+    "submit": "Simpan",
+    "cancel": "Batal",
+    "feedback": {
+      "success": "Status diperbarui.",
+      "error": "Gagal mengubah status: {{message}}"
+    }
+  },
+  "deleteConfirm": {
+    "title": "Hapus permintaan?",
+    "description": "Permintaan ini akan dihapus permanen.",
+    "confirm": "Hapus",
+    "cancel": "Batal",
+    "feedback": {
+      "success": "Permintaan dihapus.",
+      "error": "Gagal menghapus: {{message}}"
+    }
+  },
+  "upvoteFeedback": {
+    "success": "Terima kasih, suara dicatat.",
+    "error": "Gagal upvote: {{message}}"
+  }
+}

--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -17,6 +17,8 @@ import idLabelBuku from './id/label-buku.json';
 import idSirkulasi from './id/sirkulasi.json';
 import idReservasi from './id/reservasi.json';
 import idErrors from './id/errors.json';
+import idSurat from './id/surat.json';
+import idWishlist from './id/wishlist.json';
 
 import enCommon from './en/common.json';
 import enAuth from './en/auth.json';
@@ -34,6 +36,8 @@ import enLabelBuku from './en/label-buku.json';
 import enSirkulasi from './en/sirkulasi.json';
 import enReservasi from './en/reservasi.json';
 import enErrors from './en/errors.json';
+import enSurat from './en/surat.json';
+import enWishlist from './en/wishlist.json';
 
 export const NAMESPACES = [
   'common',
@@ -52,6 +56,8 @@ export const NAMESPACES = [
   'sirkulasi',
   'reservasi',
   'errors',
+  'surat',
+  'wishlist',
 ] as const;
 
 export const SUPPORTED_LOCALES = ['id', 'en'] as const;
@@ -75,6 +81,8 @@ const resources = {
     sirkulasi: idSirkulasi,
     reservasi: idReservasi,
     errors: idErrors,
+    surat: idSurat,
+    wishlist: idWishlist,
   },
   en: {
     common: enCommon,
@@ -93,6 +101,8 @@ const resources = {
     sirkulasi: enSirkulasi,
     reservasi: enReservasi,
     errors: enErrors,
+    surat: enSurat,
+    wishlist: enWishlist,
   },
 } as const;
 

--- a/apps/desktop/src/lib/surat.ts
+++ b/apps/desktop/src/lib/surat.ts
@@ -1,0 +1,190 @@
+/**
+ * Frontend bindings for FEAT-21 (Surat Keterangan Bebas Pustaka).
+ *
+ * The backend is the source of truth for eligibility + nomor allocation. This
+ * file is a thin RPC wrapper plus a browser-mock for `pnpm dev` outside Tauri.
+ */
+import { isTauri } from '@/lib/auth';
+
+export interface SuratEligibility {
+  eligible: boolean;
+  anggotaId: number;
+  anggotaNama: string;
+  anggotaKode: string;
+  anggotaAktif: boolean;
+  activeLoans: number;
+  outstandingDenda: number;
+  reasons: string[];
+}
+
+export interface SuratGenerateResult {
+  logId: number;
+  nomorSurat: string;
+  tanggalCetak: string;
+  anggotaId: number;
+  anggotaNama: string;
+  anggotaKode: string;
+  anggotaKelas?: string | null;
+  templateHtml: string;
+  kepalaSekolahNama: string;
+  kepalaSekolahNip: string;
+  kepalaSekolahTtdPath: string;
+  nomorTerakhir: number;
+  formatNomor: string;
+}
+
+export interface SuratLogRow {
+  id: number;
+  anggotaId: number;
+  anggotaNama: string;
+  anggotaKode: string;
+  nomorSurat: string;
+  tanggalCetak: string;
+  petugasId?: number | null;
+  petugasUsername?: string | null;
+}
+
+export interface SuratLogQuery {
+  anggotaId?: number;
+  limit?: number;
+}
+
+export interface SuratRpc {
+  checkEligibility(anggotaId: number): Promise<SuratEligibility>;
+  generate(anggotaId: number): Promise<SuratGenerateResult>;
+  logList(query?: SuratLogQuery): Promise<SuratLogRow[]>;
+}
+
+const tauriRpc: SuratRpc = {
+  async checkEligibility(anggotaId) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<SuratEligibility>('surat_check_eligibility', { anggotaId });
+  },
+  async generate(anggotaId) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<SuratGenerateResult>('surat_generate', { anggotaId });
+  },
+  async logList(query) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<SuratLogRow[]>('surat_log_list', { query });
+  },
+};
+
+interface MockState {
+  log: SuratLogRow[];
+  nextNomor: number;
+}
+
+const STORAGE_KEY = 'mock.surat';
+
+function readMock(): MockState {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (!raw) return { log: [], nextNomor: 1 };
+    return JSON.parse(raw) as MockState;
+  } catch {
+    return { log: [], nextNomor: 1 };
+  }
+}
+
+function writeMock(state: MockState): void {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* SSR / locked storage */
+  }
+}
+
+const mockRpc: SuratRpc = {
+  async checkEligibility(anggotaId) {
+    return {
+      eligible: true,
+      anggotaId,
+      anggotaNama: `Anggota #${anggotaId}`,
+      anggotaKode: `A${String(anggotaId).padStart(4, '0')}`,
+      anggotaAktif: true,
+      activeLoans: 0,
+      outstandingDenda: 0,
+      reasons: [],
+    };
+  },
+  async generate(anggotaId) {
+    const state = readMock();
+    const seq = state.nextNomor;
+    const today = new Date().toISOString().slice(0, 10);
+    const [yyyy, mm] = today.split('-');
+    const nomorSurat = `${yyyy}/${mm}/SBP-${String(seq).padStart(4, '0')}`;
+    const row: SuratLogRow = {
+      id: state.log.length + 1,
+      anggotaId,
+      anggotaNama: `Anggota #${anggotaId}`,
+      anggotaKode: `A${String(anggotaId).padStart(4, '0')}`,
+      nomorSurat,
+      tanggalCetak: today,
+      petugasId: null,
+      petugasUsername: null,
+    };
+    writeMock({ log: [...state.log, row], nextNomor: seq + 1 });
+    return {
+      logId: row.id,
+      nomorSurat,
+      tanggalCetak: today,
+      anggotaId,
+      anggotaNama: row.anggotaNama,
+      anggotaKode: row.anggotaKode,
+      anggotaKelas: null,
+      templateHtml:
+        'Template browser-mock. Lihat versi Tauri untuk tampilan asli.\n\nNama: {nama}\nNo. Anggota: {kode_anggota}\nTanggal: {tanggal}',
+      kepalaSekolahNama: '',
+      kepalaSekolahNip: '',
+      kepalaSekolahTtdPath: '',
+      nomorTerakhir: seq,
+      formatNomor: '{tahun}/{bulan}/SBP-{nomor:04d}',
+    };
+  },
+  async logList(query) {
+    const state = readMock();
+    const filtered = query?.anggotaId
+      ? state.log.filter((r) => r.anggotaId === query.anggotaId)
+      : state.log;
+    const limit = query?.limit ?? 200;
+    return [...filtered].reverse().slice(0, limit);
+  },
+};
+
+export const suratApi: SuratRpc = isTauri() ? tauriRpc : mockRpc;
+
+/**
+ * Render a `format_nomor` template. Mirrors the Rust implementation —
+ * the frontend uses this only to preview the *next* nomor in Settings.
+ */
+export function previewNomor(
+  format: string,
+  tahun: number,
+  bulan: number,
+  nomor: number,
+): string {
+  const yyyy = String(tahun).padStart(4, '0');
+  const mm = String(bulan).padStart(2, '0');
+  let out = format.replace(/\{tahun\}/g, yyyy).replace(/\{bulan\}/g, mm);
+  out = out.replace(/\{nomor:(\d+)d\}/g, (_m, w) =>
+    String(nomor).padStart(Number(w), '0'),
+  );
+  out = out.replace(/\{nomor\}/g, String(nomor));
+  return out;
+}
+
+/**
+ * Substitute placeholders in the surat template with the per-cetak data
+ * returned from the backend. Used by `lib/suratPdf.ts` during PDF render.
+ */
+export function fillSuratTemplate(
+  template: string,
+  data: Record<string, string>,
+): string {
+  let out = template;
+  for (const [k, v] of Object.entries(data)) {
+    out = out.split(`{${k}}`).join(v);
+  }
+  return out;
+}

--- a/apps/desktop/src/lib/wishlist.ts
+++ b/apps/desktop/src/lib/wishlist.ts
@@ -1,0 +1,219 @@
+/**
+ * Frontend bindings for FEAT-22 (Wishlist anggota / request pengadaan).
+ *
+ * Status state machine (mirrored server-side):
+ *
+ *   pending ──┬──> disetujui ──┬──> sudah_diadakan
+ *             │                └──> dibatalkan
+ *             ├──> ditolak  ─────> pending  (revive)
+ *             └──> dibatalkan ───> pending  (revive)
+ */
+import { isTauri } from '@/lib/auth';
+
+export type WishlistStatus =
+  | 'pending'
+  | 'disetujui'
+  | 'ditolak'
+  | 'sudah_diadakan'
+  | 'dibatalkan';
+
+export const WISHLIST_STATUSES: WishlistStatus[] = [
+  'pending',
+  'disetujui',
+  'ditolak',
+  'sudah_diadakan',
+  'dibatalkan',
+];
+
+export interface WishlistRow {
+  id: number;
+  anggotaId: number;
+  anggotaNama: string;
+  anggotaKode: string;
+  judul: string;
+  pengarang?: string | null;
+  isbn?: string | null;
+  alasan?: string | null;
+  status: WishlistStatus;
+  catatanAdmin?: string | null;
+  bukuId?: number | null;
+  bukuJudul?: string | null;
+  upvoteCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WishlistCreateInput {
+  anggotaId: number;
+  judul: string;
+  pengarang?: string;
+  isbn?: string;
+  alasan?: string;
+}
+
+export interface WishlistUpdateStatusInput {
+  id: number;
+  status: WishlistStatus;
+  catatanAdmin?: string;
+  bukuId?: number;
+}
+
+export interface WishlistListQuery {
+  status?: WishlistStatus;
+  anggotaId?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface WishlistRpc {
+  list(query?: WishlistListQuery): Promise<WishlistRow[]>;
+  create(input: WishlistCreateInput): Promise<WishlistRow>;
+  updateStatus(input: WishlistUpdateStatusInput): Promise<WishlistRow>;
+  upvote(id: number): Promise<WishlistRow>;
+  delete(id: number): Promise<void>;
+}
+
+/**
+ * Pure decision: is `from → to` a permitted status transition? Mirrors
+ * `is_valid_transition` in `commands/wishlist.rs`. Used to dim disallowed
+ * action buttons on the admin queue.
+ */
+export function canTransition(from: WishlistStatus, to: WishlistStatus): boolean {
+  if (from === to) return true;
+  switch (from) {
+    case 'pending':
+      return to === 'disetujui' || to === 'ditolak' || to === 'dibatalkan';
+    case 'disetujui':
+      return to === 'sudah_diadakan' || to === 'dibatalkan';
+    case 'ditolak':
+      return to === 'pending';
+    case 'dibatalkan':
+      return to === 'pending';
+    case 'sudah_diadakan':
+      return false;
+  }
+}
+
+const tauriRpc: WishlistRpc = {
+  async list(query) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<WishlistRow[]>('wishlist_list', { query });
+  },
+  async create(input) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<WishlistRow>('wishlist_create', { input });
+  },
+  async updateStatus(input) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<WishlistRow>('wishlist_update_status', { input });
+  },
+  async upvote(id) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<WishlistRow>('wishlist_upvote', { id });
+  },
+  async delete(id) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke<void>('wishlist_delete', { id });
+  },
+};
+
+const STORAGE_KEY = 'mock.wishlist';
+
+function readMock(): WishlistRow[] {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as WishlistRow[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeMock(rows: WishlistRow[]): void {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(rows));
+  } catch {
+    /* SSR / locked storage */
+  }
+}
+
+function nowIso(): string {
+  return new Date().toISOString().replace('T', ' ').slice(0, 19);
+}
+
+const mockRpc: WishlistRpc = {
+  async list(query) {
+    let rows = readMock();
+    if (query?.status) rows = rows.filter((r) => r.status === query.status);
+    if (query?.anggotaId) rows = rows.filter((r) => r.anggotaId === query.anggotaId);
+    rows = [...rows].sort((a, b) => {
+      if (b.upvoteCount !== a.upvoteCount) return b.upvoteCount - a.upvoteCount;
+      return b.id - a.id;
+    });
+    if (query?.limit) rows = rows.slice(0, query.limit);
+    return rows;
+  },
+  async create(input) {
+    const rows = readMock();
+    const id = rows.reduce((m, r) => Math.max(m, r.id), 0) + 1;
+    const now = nowIso();
+    const row: WishlistRow = {
+      id,
+      anggotaId: input.anggotaId,
+      anggotaNama: `Anggota #${input.anggotaId}`,
+      anggotaKode: `A${String(input.anggotaId).padStart(4, '0')}`,
+      judul: input.judul.trim(),
+      pengarang: input.pengarang?.trim() || null,
+      isbn: input.isbn?.trim() || null,
+      alasan: input.alasan?.trim() || null,
+      status: 'pending',
+      catatanAdmin: null,
+      bukuId: null,
+      bukuJudul: null,
+      upvoteCount: 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    writeMock([...rows, row]);
+    return row;
+  },
+  async updateStatus(input) {
+    const rows = readMock();
+    const idx = rows.findIndex((r) => r.id === input.id);
+    const current = idx >= 0 ? rows[idx] : undefined;
+    if (!current) throw new Error(`wishlist id ${input.id} not found`);
+    if (!canTransition(current.status, input.status)) {
+      throw new Error(
+        `transisi status tidak diizinkan: ${current.status} → ${input.status}`,
+      );
+    }
+    const next: WishlistRow = {
+      ...current,
+      status: input.status,
+      catatanAdmin: input.catatanAdmin ?? current.catatanAdmin ?? null,
+      bukuId: input.bukuId ?? current.bukuId ?? null,
+      updatedAt: nowIso(),
+    };
+    rows[idx] = next;
+    writeMock(rows);
+    return next;
+  },
+  async upvote(id) {
+    const rows = readMock();
+    const idx = rows.findIndex((r) => r.id === id);
+    const current = idx >= 0 ? rows[idx] : undefined;
+    if (!current) throw new Error(`wishlist id ${id} not found`);
+    const next: WishlistRow = {
+      ...current,
+      upvoteCount: current.upvoteCount + 1,
+      updatedAt: nowIso(),
+    };
+    rows[idx] = next;
+    writeMock(rows);
+    return next;
+  },
+  async delete(id) {
+    writeMock(readMock().filter((r) => r.id !== id));
+  },
+};
+
+export const wishlistApi: WishlistRpc = isTauri() ? tauriRpc : mockRpc;

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthedWishlistRouteImport } from './routes/_authed/wishlist'
 import { Route as AuthedSettingsRouteImport } from './routes/_authed/settings'
 import { Route as AuthedLaporanRouteImport } from './routes/_authed/laporan'
 import { Route as AuthedKunjunganRouteImport } from './routes/_authed/kunjungan'
@@ -65,6 +66,11 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthedWishlistRoute = AuthedWishlistRouteImport.update({
+  id: '/wishlist',
+  path: '/wishlist',
+  getParentRoute: () => AuthedRoute,
 } as any)
 const AuthedSettingsRoute = AuthedSettingsRouteImport.update({
   id: '/settings',
@@ -273,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/kunjungan': typeof AuthedKunjunganRoute
   '/laporan': typeof AuthedLaporanRouteWithChildren
   '/settings': typeof AuthedSettingsRouteWithChildren
+  '/wishlist': typeof AuthedWishlistRoute
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/cetak-kta': typeof AuthedAnggotaCetakKtaRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
@@ -314,6 +321,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/dashboard': typeof AuthedDashboardRoute
   '/kunjungan': typeof AuthedKunjunganRoute
+  '/wishlist': typeof AuthedWishlistRoute
   '/anggota/$id': typeof AuthedAnggotaIdRoute
   '/anggota/cetak-kta': typeof AuthedAnggotaCetakKtaRoute
   '/anggota/new': typeof AuthedAnggotaNewRoute
@@ -359,6 +367,7 @@ export interface FileRoutesById {
   '/_authed/kunjungan': typeof AuthedKunjunganRoute
   '/_authed/laporan': typeof AuthedLaporanRouteWithChildren
   '/_authed/settings': typeof AuthedSettingsRouteWithChildren
+  '/_authed/wishlist': typeof AuthedWishlistRoute
   '/_authed/anggota/$id': typeof AuthedAnggotaIdRoute
   '/_authed/anggota/cetak-kta': typeof AuthedAnggotaCetakKtaRoute
   '/_authed/anggota/new': typeof AuthedAnggotaNewRoute
@@ -404,6 +413,7 @@ export interface FileRouteTypes {
     | '/kunjungan'
     | '/laporan'
     | '/settings'
+    | '/wishlist'
     | '/anggota/$id'
     | '/anggota/cetak-kta'
     | '/anggota/new'
@@ -445,6 +455,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/dashboard'
     | '/kunjungan'
+    | '/wishlist'
     | '/anggota/$id'
     | '/anggota/cetak-kta'
     | '/anggota/new'
@@ -489,6 +500,7 @@ export interface FileRouteTypes {
     | '/_authed/kunjungan'
     | '/_authed/laporan'
     | '/_authed/settings'
+    | '/_authed/wishlist'
     | '/_authed/anggota/$id'
     | '/_authed/anggota/cetak-kta'
     | '/_authed/anggota/new'
@@ -554,6 +566,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_authed/wishlist': {
+      id: '/_authed/wishlist'
+      path: '/wishlist'
+      fullPath: '/wishlist'
+      preLoaderRoute: typeof AuthedWishlistRouteImport
+      parentRoute: typeof AuthedRoute
     }
     '/_authed/settings': {
       id: '/_authed/settings'
@@ -898,6 +917,7 @@ interface AuthedRouteChildren {
   AuthedKunjunganRoute: typeof AuthedKunjunganRoute
   AuthedLaporanRoute: typeof AuthedLaporanRouteWithChildren
   AuthedSettingsRoute: typeof AuthedSettingsRouteWithChildren
+  AuthedWishlistRoute: typeof AuthedWishlistRoute
   AuthedAnggotaIdRoute: typeof AuthedAnggotaIdRoute
   AuthedAnggotaCetakKtaRoute: typeof AuthedAnggotaCetakKtaRoute
   AuthedAnggotaNewRoute: typeof AuthedAnggotaNewRoute
@@ -919,6 +939,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedKunjunganRoute: AuthedKunjunganRoute,
   AuthedLaporanRoute: AuthedLaporanRouteWithChildren,
   AuthedSettingsRoute: AuthedSettingsRouteWithChildren,
+  AuthedWishlistRoute: AuthedWishlistRoute,
   AuthedAnggotaIdRoute: AuthedAnggotaIdRoute,
   AuthedAnggotaCetakKtaRoute: AuthedAnggotaCetakKtaRoute,
   AuthedAnggotaNewRoute: AuthedAnggotaNewRoute,

--- a/apps/desktop/src/routes/_authed/anggota/$id.tsx
+++ b/apps/desktop/src/routes/_authed/anggota/$id.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { createFileRoute, Link, useNavigate, useParams } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, History, Pencil } from 'lucide-react';
+import { ArrowLeft, FileText, History, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { AnggotaForm } from '@/features/anggota/AnggotaForm';
 import { AnggotaRiwayatPanel } from '@/features/anggota/AnggotaRiwayatPanel';
+import { SuratBebasPustakaDialog } from '@/features/surat/SuratBebasPustakaDialog';
 import { anggotaApi, type Anggota } from '@/lib/anggota';
 import { toAnggotaInput } from '@/features/anggota/schema';
 import { useToast } from '@/components/ui/toast-manager';
@@ -31,6 +32,7 @@ function EditAnggotaRoute() {
   const [jurusan, setJurusan] = useState<string[]>([]);
   const [agama, setAgama] = useState<string[]>([]);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [suratOpen, setSuratOpen] = useState(false);
   const [tab, setTab] = useState<AnggotaDetailTab>('edit');
 
   useEffect(() => {
@@ -70,6 +72,17 @@ function EditAnggotaRoute() {
             {t('common:actions.back')}
           </Link>
         </Button>
+        {item && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSuratOpen(true)}
+            data-testid="anggota-surat-button"
+          >
+            <FileText className="mr-2 h-4 w-4" />
+            {t('surat:button.cetak', { defaultValue: 'Cetak Surat Bebas Pustaka' })}
+          </Button>
+        )}
       </div>
 
       <div className="mb-4">
@@ -129,6 +142,14 @@ function EditAnggotaRoute() {
       ) : item ? (
         <AnggotaRiwayatPanel anggotaId={item.id} />
       ) : null}
+
+      {item && (
+        <SuratBebasPustakaDialog
+          open={suratOpen}
+          onOpenChange={setSuratOpen}
+          anggotaId={item.id}
+        />
+      )}
 
       <ConfirmDialog
         open={confirmOpen}

--- a/apps/desktop/src/routes/_authed/wishlist.tsx
+++ b/apps/desktop/src/routes/_authed/wishlist.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { WishlistAdminPage } from '@/features/wishlist/WishlistAdminPage';
+
+export const Route = createFileRoute('/_authed/wishlist')({
+  component: WishlistAdminPage,
+});

--- a/apps/desktop/tests/unit/surat.test.ts
+++ b/apps/desktop/tests/unit/surat.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { fillSuratTemplate, previewNomor, suratApi } from '@/lib/surat';
+
+describe('previewNomor', () => {
+  it('substitutes tahun, bulan, and zero-padded nomor', () => {
+    expect(previewNomor('{tahun}/{bulan}/SBP-{nomor:04d}', 2026, 5, 12)).toBe(
+      '2026/05/SBP-0012',
+    );
+  });
+
+  it('supports unpadded {nomor} placeholder', () => {
+    expect(previewNomor('SBP-{nomor}', 2026, 5, 7)).toBe('SBP-7');
+  });
+
+  it('pads month to 2 digits', () => {
+    expect(previewNomor('{tahun}-{bulan}', 2026, 1, 1)).toBe('2026-01');
+  });
+});
+
+describe('fillSuratTemplate', () => {
+  it('replaces placeholders with values', () => {
+    const out = fillSuratTemplate(
+      'Nama: {nama}\nKelas: {kelas}\nTanggal: {tanggal}',
+      { nama: 'Adi', kelas: 'XII-A', tanggal: '2026-05-06' },
+    );
+    expect(out).toBe('Nama: Adi\nKelas: XII-A\nTanggal: 2026-05-06');
+  });
+
+  it('leaves unknown placeholders untouched', () => {
+    expect(fillSuratTemplate('Hello {missing}', {})).toBe('Hello {missing}');
+  });
+});
+
+describe('suratApi (browser mock)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('always reports eligible in the mock', async () => {
+    const elig = await suratApi.checkEligibility(42);
+    expect(elig.eligible).toBe(true);
+    expect(elig.anggotaId).toBe(42);
+    expect(elig.activeLoans).toBe(0);
+    expect(elig.outstandingDenda).toBe(0);
+  });
+
+  it('generates sequential nomor surat across calls', async () => {
+    const first = await suratApi.generate(1);
+    const second = await suratApi.generate(1);
+    expect(first.nomorSurat).toMatch(/SBP-0001$/);
+    expect(second.nomorSurat).toMatch(/SBP-0002$/);
+    expect(second.nomorTerakhir).toBe(2);
+  });
+
+  it('logList returns rows in reverse-chronological order and respects limit', async () => {
+    await suratApi.generate(1);
+    await suratApi.generate(2);
+    await suratApi.generate(3);
+    const all = await suratApi.logList();
+    expect(all.map((r) => r.anggotaId)).toEqual([3, 2, 1]);
+    const limited = await suratApi.logList({ limit: 2 });
+    expect(limited).toHaveLength(2);
+  });
+
+  it('logList filters by anggotaId', async () => {
+    await suratApi.generate(10);
+    await suratApi.generate(20);
+    await suratApi.generate(10);
+    const filtered = await suratApi.logList({ anggotaId: 10 });
+    expect(filtered).toHaveLength(2);
+    expect(filtered.every((r) => r.anggotaId === 10)).toBe(true);
+  });
+});

--- a/apps/desktop/tests/unit/wishlist.test.ts
+++ b/apps/desktop/tests/unit/wishlist.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  canTransition,
+  WISHLIST_STATUSES,
+  wishlistApi,
+  type WishlistStatus,
+} from '@/lib/wishlist';
+
+describe('wishlist canTransition', () => {
+  const allowed: Array<[WishlistStatus, WishlistStatus]> = [
+    ['pending', 'disetujui'],
+    ['pending', 'ditolak'],
+    ['pending', 'dibatalkan'],
+    ['disetujui', 'sudah_diadakan'],
+    ['disetujui', 'dibatalkan'],
+    ['ditolak', 'pending'],
+    ['dibatalkan', 'pending'],
+  ];
+
+  for (const [from, to] of allowed) {
+    it(`allows ${from} → ${to}`, () => {
+      expect(canTransition(from, to)).toBe(true);
+    });
+  }
+
+  const forbidden: Array<[WishlistStatus, WishlistStatus]> = [
+    ['pending', 'sudah_diadakan'],
+    ['ditolak', 'disetujui'],
+    ['ditolak', 'sudah_diadakan'],
+    ['sudah_diadakan', 'pending'],
+    ['sudah_diadakan', 'disetujui'],
+    ['sudah_diadakan', 'ditolak'],
+  ];
+
+  for (const [from, to] of forbidden) {
+    it(`forbids ${from} → ${to}`, () => {
+      expect(canTransition(from, to)).toBe(false);
+    });
+  }
+
+  it('treats every status as idempotent (self → self allowed)', () => {
+    for (const s of WISHLIST_STATUSES) {
+      expect(canTransition(s, s)).toBe(true);
+    }
+  });
+});
+
+describe('wishlistApi (browser mock)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('creates a row with status=pending and upvoteCount=1', async () => {
+    const row = await wishlistApi.create({
+      anggotaId: 7,
+      judul: 'Atomic Habits',
+      pengarang: 'James Clear',
+    });
+    expect(row.status).toBe('pending');
+    expect(row.upvoteCount).toBe(1);
+    expect(row.judul).toBe('Atomic Habits');
+    expect(row.pengarang).toBe('James Clear');
+    expect(row.anggotaId).toBe(7);
+  });
+
+  it('lists rows ordered by upvoteCount desc, id desc', async () => {
+    const a = await wishlistApi.create({ anggotaId: 1, judul: 'A' });
+    const b = await wishlistApi.create({ anggotaId: 1, judul: 'B' });
+    await wishlistApi.upvote(a.id);
+    await wishlistApi.upvote(a.id);
+    const list = await wishlistApi.list();
+    expect(list.map((r) => r.judul)).toEqual(['A', 'B']);
+    expect(list[0]?.upvoteCount).toBe(3);
+    expect(list[1]?.id).toBe(b.id);
+  });
+
+  it('filters list by status', async () => {
+    const a = await wishlistApi.create({ anggotaId: 1, judul: 'A' });
+    await wishlistApi.create({ anggotaId: 1, judul: 'B' });
+    await wishlistApi.updateStatus({ id: a.id, status: 'disetujui' });
+    const pending = await wishlistApi.list({ status: 'pending' });
+    expect(pending.map((r) => r.judul)).toEqual(['B']);
+    const approved = await wishlistApi.list({ status: 'disetujui' });
+    expect(approved.map((r) => r.judul)).toEqual(['A']);
+  });
+
+  it('rejects forbidden status transitions', async () => {
+    const row = await wishlistApi.create({ anggotaId: 1, judul: 'A' });
+    await expect(
+      wishlistApi.updateStatus({ id: row.id, status: 'sudah_diadakan' }),
+    ).rejects.toThrow(/transisi/);
+  });
+
+  it('upvote increments and delete removes the row', async () => {
+    const row = await wishlistApi.create({ anggotaId: 1, judul: 'A' });
+    const after = await wishlistApi.upvote(row.id);
+    expect(after.upvoteCount).toBe(2);
+    await wishlistApi.delete(row.id);
+    const list = await wishlistApi.list();
+    expect(list).toEqual([]);
+  });
+});


### PR DESCRIPTION
PR D dari batch v1.0.8 — implements **FEAT-21** (Surat Keterangan Bebas Pustaka) + **FEAT-22** (Wishlist anggota / request pengadaan).

## Done
- [x] Backend: `surat_log` table + nomor sequence (atomic) + eligibility check
- [x] Backend: `wishlist_buku` table + status state machine + upvote
- [x] Backend tests: 22 new (150 total cargo lib tests)
- [x] Backend: `cargo clippy --tests --all-targets -D warnings` clean
- [x] Frontend: `lib/surat.ts` + `lib/wishlist.ts` (RPC wrappers + browser mocks)
- [x] Frontend: `SuratBebasPustakaDialog` on AnggotaDetailPage (eligibility check, generate, download)
- [x] Frontend: `WishlistAdminPage` + `/wishlist` route + sidebar nav (Heart icon)
- [x] Frontend: i18n `surat`/`wishlist` namespaces (id+en parity)
- [x] Frontend: vitest tests (302 total, baseline 274 — +28 new)
- [x] All local gates clean: typecheck, eslint --max-warnings=0, i18n:lint, vitest, vite build

## Highlights

### FEAT-21 — Surat Bebas Pustaka
- Eligibility check = no active loans + no outstanding denda + status aktif. Validated server-side under same tx as nomor allocation, so concurrent calls can never produce duplicate nomor.
- 6 new settings keys (`surat.template_html`, `surat.nomor_terakhir`, `surat.format_nomor`, `surat.kepala_sekolah_nama`, `surat.kepala_sekolah_nip`, `surat.kepala_sekolah_ttd_path`).
- Default Indonesian template seeded on fresh + upgraded installs.
- nomor format: `{tahun}/{bulan}/SBP-{nomor:04d}` (configurable).
- audit_log entry per cetak with full nomor + anggota detail.
- PDF rendered in WebView via jsPDF (existing dep) — A4 portrait, plain Times-Roman, body filled in from template placeholders.

### FEAT-22 — Wishlist anggota
- 5-state machine: `pending → disetujui → sudah_diadakan` with `ditolak`/`dibatalkan`/`pending` (revive) escape hatches. Transition table tested both server- and client-side.
- `upvote_count` for admin prioritisation.
- Optional `buku_id` link when status flipped to `sudah_diadakan` (FK validated, ON DELETE SET NULL).
- audit_log on every status flip + upvote.
- Admin queue page: filter by status, inline status change via Select (forbidden edges disabled), upvote button, delete with confirm.

## Migrations
- Both migrations are additive (`CREATE TABLE IF NOT EXISTS`, `ALTER TABLE` with `ADD COLUMN IF NOT EXISTS`); no destructive changes. Safe to apply on existing v1.0.7 databases.

See `BUGS.md#FEAT-21` and `#FEAT-22` for full spec.