### PR TITLE
feat(sync): Google Sheets bidirectional sync MVP — anggota push/pull (FEAT-26, PR G)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -708,7 +708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -721,7 +721,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "smallvec",
 ]
 
@@ -1452,8 +1452,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1463,9 +1465,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1813,6 +1817,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,16 +2078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,6 +2234,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,7 +2339,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2354,6 +2379,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2481,11 +2512,21 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "normpath"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2499,7 +2540,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2877,7 +2918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2897,6 +2938,16 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -2926,10 +2977,12 @@ dependencies = [
  "env_logger",
  "hex",
  "image",
+ "jsonwebtoken",
  "log",
  "opener",
  "pbkdf2",
- "rand",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2942,16 +2995,7 @@ dependencies = [
  "tauri-plugin-sql",
  "tempfile",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
+ "tokio",
 ]
 
 [[package]]
@@ -2960,8 +3004,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
 ]
 
@@ -2971,18 +3015,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2992,20 +3026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3014,20 +3035,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3280,11 +3292,66 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3321,8 +3388,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3332,7 +3409,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3342,6 +3429,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3361,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3450,6 +3546,44 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -3507,6 +3641,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,7 +3696,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3579,7 +3727,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3612,6 +3760,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3709,7 +3892,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -3973,7 +4156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3989,10 +4172,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
+name = "simple_asn1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4203,7 +4398,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -4244,7 +4439,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -4299,7 +4494,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.13.1",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -4309,8 +4504,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -4406,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
@@ -4469,9 +4664,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4499,7 +4694,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4522,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4543,9 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4e8230d565106aa19dfbaa01a7ed01abf78047fe0577a83377224bd1bf20e"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4570,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8de2cddbbc33dbdf4c84f170121886595efdbcc9cb4b3d76342b79d082cedc"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4584,9 +4779,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d5f58bfd0cdcfdbc0a68dc08b354eea2afc551b421de91b07b69e0dd769d57"
+checksum = "eefb2c18e8a605c23edb48fc56bb77381199e1a1e7f6ff0c9b970afe7b3cb8ee"
 dependencies = [
  "anyhow",
  "glob",
@@ -4684,9 +4879,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42bbcb76237351fbaa02f08d808c537dc12eb5a6eabbf3e517b50056334d95"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -4709,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -4735,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f61d2bf7188fbcf2b0ed095b67a6bc498f713c939314bb19eb700118a573b7"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
@@ -4751,7 +4946,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf",
  "plist",
  "proc-macro2",
  "quote",
@@ -4903,16 +5098,38 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -5076,20 +5293,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -5265,6 +5482,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -5522,12 +5745,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -5575,6 +5808,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5824,6 +6066,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6250,9 +6501,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.55.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3013fd6116aac351dd2e18f349b28b2cfef3a5ff3253a9d0ce2d7193bb1b4429"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -37,9 +37,17 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 # FEAT-24 — encrypted backup
 aes-gcm = "0.10"
 pbkdf2 = { version = "0.12", features = ["simple"] }
+# FEAT-26 Google Sheets bidirectional sync (PR G v1.0.8). reqwest does the
+# HTTPS calls to https://sheets.googleapis.com (rustls-tls keeps us off the
+# system OpenSSL); jsonwebtoken signs the Service Account RS256 JWT used to
+# exchange for an OAuth2 access token.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+jsonwebtoken = "9"
+tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [features]
 default = ["custom-protocol"]

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod reservasi;
 pub mod settings;
 pub mod stocktake;
 pub mod surat;
+pub mod sync;
 pub mod user_profile;
 pub mod window_state;
 pub mod wishlist;

--- a/apps/desktop/src-tauri/src/commands/sync/auth.rs
+++ b/apps/desktop/src-tauri/src/commands/sync/auth.rs
@@ -1,0 +1,369 @@
+//! Service Account auth for FEAT-26 Google Sheets sync (PR G v1.0.8).
+//!
+//! Google Sheets needs an OAuth2 Bearer token for any *write* call. Browser
+//! / 3-legged OAuth would force the admin through a consent screen every
+//! launch, which is awful UX for a desktop kiosk. Service Account auth
+//! sidesteps that: the admin generates a JSON key once in Google Cloud
+//! Console, pastes it into Pengaturan → Sinkronisasi, and the desktop app
+//! signs short-lived JWTs with the SA's private key whenever it needs an
+//! access token.
+//!
+//! Flow per [Google docs][1]:
+//!
+//! 1. Build a JWT with header `{"alg":"RS256","typ":"JWT"}` and claims
+//!    `{iss, scope, aud, exp, iat}` where `iss` is the SA email.
+//! 2. Sign with the SA's RSA private key (PEM-encoded, included in the JSON).
+//! 3. POST `assertion=<jwt>&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`
+//!    to `https://oauth2.googleapis.com/token`.
+//! 4. Use the returned `access_token` as `Authorization: Bearer …` for ≤1 h.
+//!
+//! We cache the token in [`TokenCache`] until five minutes before its `exp`,
+//! so a typical push/pull cycle only does the JWT dance once.
+//!
+//! [1]: https://developers.google.com/identity/protocols/oauth2/service-account
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+/// Default OAuth scope. Read+write to spreadsheets the admin shares with the
+/// SA email. Drive scope is *not* required because the user passes the
+/// spreadsheet ID explicitly; we never enumerate Drive.
+pub const DEFAULT_SCOPE: &str = "https://www.googleapis.com/auth/spreadsheets";
+
+/// Service Account JSON shape. Only fields we actually use; the file from
+/// Google Cloud has a few more (`token_uri`, `auth_uri`, `client_id`, …)
+/// that we don't need.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServiceAccount {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[allow(dead_code)]
+    pub project_id: String,
+    pub client_email: String,
+    pub private_key: String,
+    #[serde(default)]
+    pub private_key_id: String,
+}
+
+impl ServiceAccount {
+    /// Parse the JSON the admin pasted into Pengaturan → Sinkronisasi.
+    /// Returns a friendly Validation error rather than the raw serde
+    /// message, so the toast in `formatTauriError` is readable.
+    pub fn from_json(raw: &str) -> AppResult<Self> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(AppError::Validation(
+                "Service Account JSON kosong".into(),
+            ));
+        }
+        let sa: ServiceAccount = serde_json::from_str(trimmed)
+            .map_err(|e| AppError::Validation(format!("Service Account JSON tidak valid: {e}")))?;
+        if sa.kind != "service_account" {
+            return Err(AppError::Validation(format!(
+                "JSON yang dipaste bukan Service Account (type=\"{}\")",
+                sa.kind
+            )));
+        }
+        if sa.client_email.is_empty() {
+            return Err(AppError::Validation(
+                "Service Account JSON kekurangan field client_email".into(),
+            ));
+        }
+        if sa.private_key.is_empty() {
+            return Err(AppError::Validation(
+                "Service Account JSON kekurangan field private_key".into(),
+            ));
+        }
+        if !sa.private_key.contains("BEGIN") {
+            return Err(AppError::Validation(
+                "private_key bukan PEM (perlu '-----BEGIN PRIVATE KEY-----' header)".into(),
+            ));
+        }
+        Ok(sa)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct JwtClaims<'a> {
+    iss: &'a str,
+    scope: &'a str,
+    aud: &'a str,
+    exp: u64,
+    iat: u64,
+}
+
+/// Build the assertion JWT for a single token-exchange request.
+///
+/// Returns the compact-serialised JWT string. The optional `now_secs`
+/// argument lets unit tests pin the timestamp; in production we read
+/// `SystemTime::now()`.
+pub fn build_assertion_jwt(
+    sa: &ServiceAccount,
+    scope: &str,
+    now_secs: Option<u64>,
+) -> AppResult<String> {
+    let now = now_secs.unwrap_or_else(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    });
+    let claims = JwtClaims {
+        iss: &sa.client_email,
+        scope,
+        aud: "https://oauth2.googleapis.com/token",
+        exp: now + 3600,
+        iat: now,
+    };
+    let mut header = Header::new(jsonwebtoken::Algorithm::RS256);
+    if !sa.private_key_id.is_empty() {
+        header.kid = Some(sa.private_key_id.clone());
+    }
+    let key = EncodingKey::from_rsa_pem(sa.private_key.as_bytes()).map_err(|e| {
+        AppError::Validation(format!(
+            "private_key tidak bisa di-decode sebagai RSA PEM: {e}"
+        ))
+    })?;
+    encode(&header, &claims, &key)
+        .map_err(|e| AppError::Internal(format!("JWT sign gagal: {e}")))
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+    #[allow(dead_code)]
+    token_type: String,
+}
+
+/// Exchange a signed assertion JWT for an OAuth2 access token.
+pub async fn fetch_access_token(
+    http: &reqwest::Client,
+    sa: &ServiceAccount,
+    scope: &str,
+) -> AppResult<AccessToken> {
+    let jwt = build_assertion_jwt(sa, scope, None)?;
+    let resp = http
+        .post("https://oauth2.googleapis.com/token")
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", &jwt),
+        ])
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("oauth2 token request gagal: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Validation(format!(
+            "Google OAuth2 menolak Service Account ({status}): {body}"
+        )));
+    }
+    let parsed: TokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("oauth2 response tidak parsable: {e}")))?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    Ok(AccessToken {
+        token: parsed.access_token,
+        expires_at_secs: now + parsed.expires_in.saturating_sub(60),
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct AccessToken {
+    pub token: String,
+    pub expires_at_secs: u64,
+}
+
+impl AccessToken {
+    /// True iff `exp - now > 5 minutes`. We refresh once we hit the 5-min
+    /// safety margin to never slip past the actual `exp` mid-request.
+    pub fn is_fresh(&self, now_secs: u64) -> bool {
+        self.expires_at_secs.saturating_sub(now_secs) > 300
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal RSA test key — generated once with
+    /// `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048`. Used
+    /// by both the JWT-sign assertion and the ServiceAccount parser tests.
+    /// NOT a secret — it lives in source on purpose so CI can run offline.
+    const TEST_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCu80GjMF4mOjkq\ndOi814E04dugWf7hwA0F7d84NfbeoyWF02yGMH847iNHx0kDikeNPXBY8ttMtVoV\nVqoj067O9dYg4UoxgV82+lgM9fB6rsBQPDumR46w+g7BHpctuDO+p9VgtdqpvSU8\nRjWcNszyeiemzpgC2+LQ8lkBDclGwhCOK6t/GbnfZeUFenGrSyicSeFN4Sa5dGbl\nZUqaHOyFh229UuuMTA7gSBsHI+ZfwAH4cWpQZPfCvnPNHDpzruON3/w7JCvZjMRF\numzvjnTjffjcigS0CME5j5xDbsF+LTrwpeMivrI3c0rWOLMgGAUlJeRkQsTWw5UZ\nGbdUqsP3AgMBAAECggEALJb8ajrYLDcXvd35ObRVjqRoJUj6wRABYbr8cyex6ZG8\nbQzzcoomytxLKq68ycWzMejwWwNe6ICqWpjxmVsJCV+3+T5iehamrW0GBxuh9KrY\ngjqv21QOpsW8//SrhHAX5CaDqHgBKNT4ChI89Lk06DJBK+8o6EWh3C6Ah9e7Lqi3\n588iQeqNpMCwoRyewUU1XFfPB4ZlifBGk3lUCfzv90UcqBSKllQAgnQOhSOCLX9f\n7k8skSol0ONHK8iz/Y14Fxe42937lHYQ4UEVFdj0ygpdpt5rDn1gPmIg4S27FUcV\nh6ffHW7gYC6t3zKDQkTcGYbPb98QQ7s+/w0AAEO6YQKBgQC6CKLpOhWWlc58F7y4\nVBRv8S5ryX0kW7JYGS368euNuiOb35Ywbzd8p0y+/uR8f/5BTtmrULf+r88HLzAM\nV3GkA55gFtZy2YKt4BEZfFqrRAg5/uHycBCqy9F+bFHuap3X4Z8w34sTQTcnqGst\nU5hz4hRFBONeZcyrRYHsanw44QKBgQDwv389hYTiUq6xK+J+UFNBsNwQgVOaBVRA\n5xWQFUzIIq2/GqHwMpjMwux2gU7xFrctvFe5G7oTu7SEdKqkMbgtSSNw8Zl7A7Uw\n2k8mRQgdGrfMWWgCX6wPC5C/R/EeOGTWPwdzab1EkUP51La7vhMZSHr3nhwzXr3X\n0kpPgyvf1wKBgFr91GkNDvgbh+ZsWdMy1Ng3+EOiRsJc02uBzVqbr2If9EDOaJCC\nJXqj/cbBt5IprHvXDGJd1dENvs49x1uR/bSCTJmlMfj06JURLmvvxg1U9k0fnPZO\n1+giTvJuGtjpbxDje1CVVlnxoP+Vwe5mn/+2ScHEdU17r1LqaXTwVJghAoGBAL0K\nUZp4bnjc3emnAQmYf1e0zYh0VLY7ewYfrlHeN9VrTa0i94fJ4yvd35nKPbeX06yp\nGOT0fa+jE8NybM/TbsC4jojQXWk35x3+PmpZiF56LVrb1Y0PnOaPeVCJ6C6Hr75/\n7ZTVsdXWj17shbR0M0EGJfCsCY7Y1Q9URB+da2UvAoGAR9knTKtypWdSkxs4vlbt\n0UGpLnt43TfxUvwA660OXx2buP8cb3UiDtPWl1pCrMA4Ks0QOlS8jmjeR36fMcvb\nJ2nJpOv2Jc9U6bSSs/iL3vWq+MVhvuVLthYK7d/dOWGPAv//mYZTh9MSb9EtrQBq\nFxymUQrUCqzet1ptyu5SwEs=\n-----END PRIVATE KEY-----\n";
+
+    fn fixture_sa() -> ServiceAccount {
+        ServiceAccount {
+            kind: "service_account".into(),
+            project_id: "test-project-12345".into(),
+            client_email: "test-sa@test-project-12345.iam.gserviceaccount.com".into(),
+            private_key: TEST_PRIVATE_KEY.into(),
+            private_key_id: "abc123def456".into(),
+        }
+    }
+
+    #[test]
+    fn from_json_rejects_empty_input() {
+        let err = ServiceAccount::from_json("   ").unwrap_err();
+        match err {
+            AppError::Validation(m) => assert!(m.contains("kosong")),
+            _ => panic!("expected Validation"),
+        }
+    }
+
+    #[test]
+    fn from_json_rejects_non_sa_type() {
+        let raw = serde_json::json!({
+            "type": "user",
+            "project_id": "x",
+            "client_email": "x@x",
+            "private_key": "abc",
+        })
+        .to_string();
+        let err = ServiceAccount::from_json(&raw).unwrap_err();
+        match err {
+            AppError::Validation(m) => assert!(m.contains("Service Account") && m.contains("user")),
+            _ => panic!("expected Validation"),
+        }
+    }
+
+    #[test]
+    fn from_json_rejects_missing_fields() {
+        let raw = serde_json::json!({
+            "type": "service_account",
+            "project_id": "x",
+            "client_email": "",
+            "private_key": "x",
+        })
+        .to_string();
+        let err = ServiceAccount::from_json(&raw).unwrap_err();
+        match err {
+            AppError::Validation(m) => assert!(m.contains("client_email")),
+            _ => panic!("expected Validation"),
+        }
+    }
+
+    #[test]
+    fn from_json_rejects_non_pem_private_key() {
+        let raw = serde_json::json!({
+            "type": "service_account",
+            "project_id": "x",
+            "client_email": "x@x",
+            "private_key": "not-a-pem-key",
+        })
+        .to_string();
+        let err = ServiceAccount::from_json(&raw).unwrap_err();
+        match err {
+            AppError::Validation(m) => assert!(m.contains("PEM")),
+            _ => panic!("expected Validation"),
+        }
+    }
+
+    #[test]
+    fn from_json_accepts_valid_sa() {
+        let raw = serde_json::json!({
+            "type": "service_account",
+            "project_id": "test-project-12345",
+            "client_email": "test@test.iam.gserviceaccount.com",
+            "private_key": TEST_PRIVATE_KEY,
+            "private_key_id": "abc123",
+        })
+        .to_string();
+        let sa = ServiceAccount::from_json(&raw).unwrap();
+        assert_eq!(sa.client_email, "test@test.iam.gserviceaccount.com");
+        assert_eq!(sa.private_key_id, "abc123");
+    }
+
+    #[test]
+    fn build_assertion_jwt_produces_three_segments() {
+        let sa = fixture_sa();
+        let jwt = build_assertion_jwt(&sa, DEFAULT_SCOPE, Some(1_700_000_000)).unwrap();
+        let parts: Vec<&str> = jwt.split('.').collect();
+        assert_eq!(parts.len(), 3, "JWT must have header.payload.signature");
+        assert!(!parts[0].is_empty());
+        assert!(!parts[1].is_empty());
+        assert!(!parts[2].is_empty());
+    }
+
+    #[test]
+    fn build_assertion_jwt_payload_contains_required_claims() {
+        let sa = fixture_sa();
+        let jwt = build_assertion_jwt(&sa, DEFAULT_SCOPE, Some(1_700_000_000)).unwrap();
+        let payload_b64 = jwt.split('.').nth(1).unwrap();
+        // jsonwebtoken uses URL-safe base64 without padding.
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine as _;
+        let payload_bytes = URL_SAFE_NO_PAD.decode(payload_b64).unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();
+        assert_eq!(
+            payload["iss"],
+            "test-sa@test-project-12345.iam.gserviceaccount.com"
+        );
+        assert_eq!(payload["scope"], DEFAULT_SCOPE);
+        assert_eq!(payload["aud"], "https://oauth2.googleapis.com/token");
+        assert_eq!(payload["iat"], 1_700_000_000);
+        assert_eq!(payload["exp"], 1_700_003_600);
+    }
+
+    #[test]
+    fn build_assertion_jwt_includes_kid_when_set() {
+        let sa = fixture_sa();
+        let jwt = build_assertion_jwt(&sa, DEFAULT_SCOPE, Some(1_700_000_000)).unwrap();
+        let header_b64 = jwt.split('.').next().unwrap();
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine as _;
+        let header_bytes = URL_SAFE_NO_PAD.decode(header_b64).unwrap();
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header["alg"], "RS256");
+        assert_eq!(header["typ"], "JWT");
+        assert_eq!(header["kid"], "abc123def456");
+    }
+
+    #[test]
+    fn build_assertion_jwt_omits_kid_when_empty() {
+        let mut sa = fixture_sa();
+        sa.private_key_id.clear();
+        let jwt = build_assertion_jwt(&sa, DEFAULT_SCOPE, Some(1_700_000_000)).unwrap();
+        let header_b64 = jwt.split('.').next().unwrap();
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine as _;
+        let header_bytes = URL_SAFE_NO_PAD.decode(header_b64).unwrap();
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert!(header.get("kid").is_none());
+    }
+
+    #[test]
+    fn build_assertion_jwt_rejects_non_pem_key() {
+        let mut sa = fixture_sa();
+        sa.private_key = "not-a-real-key".into();
+        let err = build_assertion_jwt(&sa, DEFAULT_SCOPE, Some(1_700_000_000)).unwrap_err();
+        match err {
+            AppError::Validation(m) => assert!(m.contains("RSA PEM")),
+            _ => panic!("expected Validation"),
+        }
+    }
+
+    #[test]
+    fn access_token_freshness_within_5min_window() {
+        let token = AccessToken {
+            token: "x".into(),
+            expires_at_secs: 1000,
+        };
+        assert!(token.is_fresh(0));
+        assert!(token.is_fresh(699));
+        assert!(!token.is_fresh(700));
+        assert!(!token.is_fresh(900));
+        assert!(!token.is_fresh(2000));
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/sync/client.rs
+++ b/apps/desktop/src-tauri/src/commands/sync/client.rs
@@ -1,0 +1,258 @@
+//! Thin Google Sheets v4 REST wrapper for FEAT-26 Sheets sync (PR G v1.0.8).
+//!
+//! Why we hand-roll instead of pulling `google-sheets4`:
+//!
+//! * The official crate ships ~30 MB of generated bindings for every Sheets
+//!   endpoint, almost all of which we don't touch. Build-time cost is
+//!   significant and we'd never use 95 % of it.
+//! * The two endpoints we actually need (`values.get`, `values.update`,
+//!   `values.clear`, `spreadsheets.get`, `spreadsheets.batchUpdate`) are
+//!   simple JSON over HTTPS — about 100 lines of code total.
+//!
+//! All methods are async (we drive them from Tauri commands which are
+//! `async fn`). Error mapping is intentionally lossy: any non-2xx response
+//! becomes `AppError::Validation` so the toast in `formatTauriError` shows
+//! the raw Google error body to the admin.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::error::{AppError, AppResult};
+
+/// Public Google Sheets v4 base URL. Override-able via env var so integration
+/// tests can point to a fake server (currently we keep all tests pure unit).
+const SHEETS_API_BASE: &str = "https://sheets.googleapis.com/v4/spreadsheets";
+
+#[derive(Debug, Deserialize)]
+pub struct SpreadsheetMeta {
+    #[allow(dead_code)]
+    #[serde(rename = "spreadsheetId")]
+    pub spreadsheet_id: String,
+    pub properties: SpreadsheetProperties,
+    pub sheets: Vec<SheetEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpreadsheetProperties {
+    pub title: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SheetEntry {
+    pub properties: SheetEntryProperties,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SheetEntryProperties {
+    pub title: String,
+    #[allow(dead_code)]
+    #[serde(rename = "sheetId")]
+    pub sheet_id: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SheetsClient {
+    pub http: reqwest::Client,
+    pub access_token: String,
+}
+
+impl SheetsClient {
+    /// Fetch top-level spreadsheet metadata (title + list of tabs). Used by
+    /// the "Test Connection" button and by push-init to decide whether the
+    /// per-table tab already exists.
+    pub async fn get_spreadsheet(&self, spreadsheet_id: &str) -> AppResult<SpreadsheetMeta> {
+        let url = format!("{SHEETS_API_BASE}/{spreadsheet_id}?fields=spreadsheetId,properties.title,sheets.properties");
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.access_token)
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("sheets.get http error: {e}")))?;
+        check_status(resp).await?.json().await.map_err(|e| {
+            AppError::Internal(format!("sheets.get response not parsable: {e}"))
+        })
+    }
+
+    /// Fetch all values from a tab as a 2D vector of strings (Google returns
+    /// strings even for numeric cells when `valueRenderOption=FORMATTED_VALUE`,
+    /// which is what we want — we never lose precision because all our
+    /// columns are typed strings/ints/booleans encoded as text already).
+    ///
+    /// Empty tabs return `Ok(vec![])` rather than an error so the caller can
+    /// just iterate.
+    pub async fn get_values(
+        &self,
+        spreadsheet_id: &str,
+        range: &str,
+    ) -> AppResult<Vec<Vec<String>>> {
+        let encoded = urlencode(range);
+        let url = format!(
+            "{SHEETS_API_BASE}/{spreadsheet_id}/values/{encoded}?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING"
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.access_token)
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("values.get http error: {e}")))?;
+        let body: Value = check_status(resp).await?.json().await.map_err(|e| {
+            AppError::Internal(format!("values.get response not parsable: {e}"))
+        })?;
+        let rows = body
+            .get("values")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                row.as_array()
+                    .map(|cells| {
+                        cells
+                            .iter()
+                            .map(|c| match c {
+                                Value::String(s) => s.clone(),
+                                Value::Null => String::new(),
+                                other => other.to_string(),
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            })
+            .collect())
+    }
+
+    /// Clear all values in a range. We use this before pushing so the
+    /// destination tab is always exactly what we intend (no stale rows).
+    pub async fn clear_values(&self, spreadsheet_id: &str, range: &str) -> AppResult<()> {
+        let encoded = urlencode(range);
+        let url = format!("{SHEETS_API_BASE}/{spreadsheet_id}/values/{encoded}:clear");
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.access_token)
+            .json(&json!({}))
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("values.clear http error: {e}")))?;
+        check_status(resp).await?;
+        Ok(())
+    }
+
+    /// Overwrite a range with the given 2D values, in `RAW` mode so Google
+    /// doesn't try to interpret strings as dates/numbers/formulas.
+    pub async fn update_values(
+        &self,
+        spreadsheet_id: &str,
+        range: &str,
+        values: &[Vec<String>],
+    ) -> AppResult<()> {
+        let encoded = urlencode(range);
+        let url = format!(
+            "{SHEETS_API_BASE}/{spreadsheet_id}/values/{encoded}?valueInputOption=RAW"
+        );
+        let payload = json!({
+            "range": range,
+            "majorDimension": "ROWS",
+            "values": values,
+        });
+        let resp = self
+            .http
+            .put(&url)
+            .bearer_auth(&self.access_token)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("values.update http error: {e}")))?;
+        check_status(resp).await?;
+        Ok(())
+    }
+
+    /// Create a new sheet tab named `tab_name`. Idempotent — if the tab
+    /// already exists, returns `Ok(())` and lets the caller continue.
+    pub async fn ensure_tab(&self, spreadsheet_id: &str, tab_name: &str) -> AppResult<()> {
+        let meta = self.get_spreadsheet(spreadsheet_id).await?;
+        if meta.sheets.iter().any(|s| s.properties.title == tab_name) {
+            return Ok(());
+        }
+        let url = format!("{SHEETS_API_BASE}/{spreadsheet_id}:batchUpdate");
+        let payload = json!({
+            "requests": [{
+                "addSheet": {
+                    "properties": { "title": tab_name },
+                }
+            }]
+        });
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.access_token)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("batchUpdate http error: {e}")))?;
+        check_status(resp).await?;
+        Ok(())
+    }
+}
+
+/// Check the response status. On 2xx returns the response. On non-2xx maps
+/// to `AppError::Validation` with the raw body so the operator can see the
+/// Google error reason verbatim (usually "PERMISSION_DENIED: The caller does
+/// not have permission" — meaning the SA email isn't shared on the sheet).
+async fn check_status(resp: reqwest::Response) -> AppResult<reqwest::Response> {
+    if resp.status().is_success() {
+        return Ok(resp);
+    }
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    let snippet: String = body.chars().take(500).collect();
+    Err(AppError::Validation(format!(
+        "Google Sheets API ({status}): {snippet}"
+    )))
+}
+
+/// Minimal URL-percent-encoding for sheet ranges like `Anggota!A1:Z`.
+/// `reqwest` doesn't auto-encode the path component; ranges contain `!`
+/// which is technically reserved.
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'_'
+            | b'.'
+            | b'~'
+            | b'/' => out.push(*b as char),
+            other => out.push_str(&format!("%{:02X}", other)),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn urlencode_passes_through_safe_chars() {
+        assert_eq!(urlencode("anggota"), "anggota");
+        assert_eq!(urlencode("anggota_v2"), "anggota_v2");
+        assert_eq!(urlencode("A1:Z"), "A1%3AZ");
+    }
+
+    #[test]
+    fn urlencode_encodes_bang_in_range() {
+        assert_eq!(urlencode("Anggota!A1:Z"), "Anggota%21A1%3AZ");
+    }
+
+    #[test]
+    fn urlencode_encodes_spaces() {
+        assert_eq!(urlencode("My Sheet!A1"), "My%20Sheet%21A1");
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/sync/mapper.rs
+++ b/apps/desktop/src-tauri/src/commands/sync/mapper.rs
@@ -1,0 +1,482 @@
+//! Row mappers for FEAT-26 Sheets sync (PR G v1.0.8).
+//!
+//! Each mapper translates between a SQLite row and a Google Sheets row
+//! (header + cells). The trait is intentionally shape-agnostic so we can
+//! plug in `BukuMapper`, `EksemplarMapper`, etc. in follow-up PRs without
+//! changing push/pull plumbing.
+//!
+//! Initial coverage in this PR: `anggota` only. The other tables are
+//! deferred to G2 per `.devin/handoff/v1.0.8-bugs-batch/BUGS.md`.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+/// Anggota row in the canonical wire-format used both for Sheets cells and
+/// for in-memory diffing. Strings everywhere because Google Sheets cells are
+/// stringly typed and we'd rather lose nothing than juggle types here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnggotaRow {
+    pub kode_anggota: String,
+    pub nama: String,
+    pub jenis_kelamin: String,
+    pub kelas: String,
+    pub jurusan: String,
+    pub tempat_lahir: String,
+    pub tanggal_lahir: String,
+    pub no_telp: String,
+    pub email: String,
+    pub alamat: String,
+    pub agama: String,
+    pub aktif: String,
+    pub catatan: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Header order for the `Anggota` sheet tab. Putting `kode_anggota` first
+/// makes the sheet readable even when zoomed out (operator scans by code).
+pub const ANGGOTA_HEADER: &[&str] = &[
+    "kode_anggota",
+    "nama",
+    "jenis_kelamin",
+    "kelas",
+    "jurusan",
+    "tempat_lahir",
+    "tanggal_lahir",
+    "no_telp",
+    "email",
+    "alamat",
+    "agama",
+    "aktif",
+    "catatan",
+    "created_at",
+    "updated_at",
+];
+
+pub const ANGGOTA_TAB: &str = "anggota";
+
+impl AnggotaRow {
+    /// Encode this row as a Vec<String> matching the [`ANGGOTA_HEADER`]
+    /// column order. Used by push.
+    pub fn to_cells(&self) -> Vec<String> {
+        vec![
+            self.kode_anggota.clone(),
+            self.nama.clone(),
+            self.jenis_kelamin.clone(),
+            self.kelas.clone(),
+            self.jurusan.clone(),
+            self.tempat_lahir.clone(),
+            self.tanggal_lahir.clone(),
+            self.no_telp.clone(),
+            self.email.clone(),
+            self.alamat.clone(),
+            self.agama.clone(),
+            self.aktif.clone(),
+            self.catatan.clone(),
+            self.created_at.clone(),
+            self.updated_at.clone(),
+        ]
+    }
+
+    /// Decode a Sheets row back into an `AnggotaRow`. Fewer-than-expected
+    /// columns are padded with empty strings (Google strips trailing empties).
+    pub fn from_cells(cells: &[String]) -> AnggotaRow {
+        let pick = |i: usize| cells.get(i).cloned().unwrap_or_default();
+        AnggotaRow {
+            kode_anggota: pick(0),
+            nama: pick(1),
+            jenis_kelamin: pick(2),
+            kelas: pick(3),
+            jurusan: pick(4),
+            tempat_lahir: pick(5),
+            tanggal_lahir: pick(6),
+            no_telp: pick(7),
+            email: pick(8),
+            alamat: pick(9),
+            agama: pick(10),
+            aktif: pick(11),
+            catatan: pick(12),
+            created_at: pick(13),
+            updated_at: pick(14),
+        }
+    }
+}
+
+/// Read every row from the local `anggota` table, ordered by `kode_anggota`
+/// for stable diffs across pushes.
+pub fn read_all_anggota(conn: &Connection) -> AppResult<Vec<AnggotaRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT kode_anggota,
+                nama,
+                COALESCE(jenis_kelamin,''),
+                COALESCE(kelas,''),
+                COALESCE(jurusan,''),
+                COALESCE(tempat_lahir,''),
+                COALESCE(tanggal_lahir,''),
+                COALESCE(no_telp,''),
+                COALESCE(email,''),
+                COALESCE(alamat,''),
+                COALESCE(agama,''),
+                CASE aktif WHEN 1 THEN '1' ELSE '0' END,
+                COALESCE(catatan,''),
+                created_at,
+                updated_at
+           FROM anggota
+          ORDER BY kode_anggota ASC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(AnggotaRow {
+            kode_anggota: row.get(0)?,
+            nama: row.get(1)?,
+            jenis_kelamin: row.get(2)?,
+            kelas: row.get(3)?,
+            jurusan: row.get(4)?,
+            tempat_lahir: row.get(5)?,
+            tanggal_lahir: row.get(6)?,
+            no_telp: row.get(7)?,
+            email: row.get(8)?,
+            alamat: row.get(9)?,
+            agama: row.get(10)?,
+            aktif: row.get(11)?,
+            catatan: row.get(12)?,
+            created_at: row.get(13)?,
+            updated_at: row.get(14)?,
+        })
+    })?;
+    Ok(rows.collect::<Result<Vec<_>, _>>()?)
+}
+
+/// Upsert one anggota row from Sheets into the local DB. Conflict
+/// resolution is **last-write-wins by `updated_at`**: we only overwrite a
+/// local row if the incoming `updated_at` is strictly greater. Equal
+/// timestamps are treated as no-op (admin always wins on tie because the
+/// admin row was, by definition, written first to the sheet).
+///
+/// Returns:
+/// * `Ok(true)` if the local DB changed (insert or update applied),
+/// * `Ok(false)` if the row was identical or the local copy was newer.
+pub fn upsert_anggota(conn: &Connection, incoming: &AnggotaRow) -> AppResult<bool> {
+    if incoming.kode_anggota.trim().is_empty() {
+        return Err(AppError::Validation(
+            "anggota row dari Sheets kekurangan kode_anggota".into(),
+        ));
+    }
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT updated_at FROM anggota WHERE kode_anggota = ?1",
+            rusqlite::params![&incoming.kode_anggota],
+            |row| row.get::<_, String>(0),
+        )
+        .ok();
+    let aktif_int: i64 = if incoming.aktif == "1" || incoming.aktif.eq_ignore_ascii_case("true") {
+        1
+    } else {
+        0
+    };
+    if let Some(local_ts) = existing {
+        if incoming.updated_at <= local_ts {
+            return Ok(false);
+        }
+        conn.execute(
+            "UPDATE anggota
+                SET nama          = ?1,
+                    jenis_kelamin = NULLIF(?2,''),
+                    kelas         = NULLIF(?3,''),
+                    jurusan       = NULLIF(?4,''),
+                    tempat_lahir  = NULLIF(?5,''),
+                    tanggal_lahir = NULLIF(?6,''),
+                    no_telp       = NULLIF(?7,''),
+                    email         = NULLIF(?8,''),
+                    alamat        = NULLIF(?9,''),
+                    agama         = NULLIF(?10,''),
+                    aktif         = ?11,
+                    catatan       = NULLIF(?12,''),
+                    updated_at    = ?13
+              WHERE kode_anggota = ?14",
+            rusqlite::params![
+                incoming.nama,
+                incoming.jenis_kelamin,
+                incoming.kelas,
+                incoming.jurusan,
+                incoming.tempat_lahir,
+                incoming.tanggal_lahir,
+                incoming.no_telp,
+                incoming.email,
+                incoming.alamat,
+                incoming.agama,
+                aktif_int,
+                incoming.catatan,
+                incoming.updated_at,
+                incoming.kode_anggota,
+            ],
+        )?;
+        return Ok(true);
+    }
+    // Insert new
+    conn.execute(
+        "INSERT INTO anggota (
+            kode_anggota, nama, jenis_kelamin, kelas, jurusan,
+            tempat_lahir, tanggal_lahir, no_telp, email, alamat,
+            agama, aktif, catatan, created_at, updated_at
+         ) VALUES (?1, ?2, NULLIF(?3,''), NULLIF(?4,''), NULLIF(?5,''),
+                  NULLIF(?6,''), NULLIF(?7,''), NULLIF(?8,''), NULLIF(?9,''), NULLIF(?10,''),
+                  NULLIF(?11,''), ?12, NULLIF(?13,''), COALESCE(NULLIF(?14,''), datetime('now')), COALESCE(NULLIF(?15,''), datetime('now')))",
+        rusqlite::params![
+            incoming.kode_anggota,
+            incoming.nama,
+            incoming.jenis_kelamin,
+            incoming.kelas,
+            incoming.jurusan,
+            incoming.tempat_lahir,
+            incoming.tanggal_lahir,
+            incoming.no_telp,
+            incoming.email,
+            incoming.alamat,
+            incoming.agama,
+            aktif_int,
+            incoming.catatan,
+            incoming.created_at,
+            incoming.updated_at,
+        ],
+    )?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn fixture_row() -> AnggotaRow {
+        AnggotaRow {
+            kode_anggota: "A0001".into(),
+            nama: "Budi Santoso".into(),
+            jenis_kelamin: "L".into(),
+            kelas: "10A".into(),
+            jurusan: "IPA".into(),
+            tempat_lahir: "Jakarta".into(),
+            tanggal_lahir: "2008-03-15".into(),
+            no_telp: "08123456789".into(),
+            email: "budi@example.test".into(),
+            alamat: "Jl. Mawar 1".into(),
+            agama: "Islam".into(),
+            aktif: "1".into(),
+            catatan: "ketua kelas".into(),
+            created_at: "2024-01-15 09:00:00".into(),
+            updated_at: "2024-06-01 12:34:56".into(),
+        }
+    }
+
+    #[test]
+    fn header_length_matches_to_cells_arity() {
+        let r = fixture_row();
+        assert_eq!(ANGGOTA_HEADER.len(), r.to_cells().len());
+    }
+
+    #[test]
+    fn to_cells_then_from_cells_round_trips() {
+        let r = fixture_row();
+        let cells = r.to_cells();
+        let back = AnggotaRow::from_cells(&cells);
+        assert_eq!(r, back);
+    }
+
+    #[test]
+    fn from_cells_pads_missing_columns_with_empty_strings() {
+        let partial = vec!["X0001".to_string(), "Foo".to_string()];
+        let row = AnggotaRow::from_cells(&partial);
+        assert_eq!(row.kode_anggota, "X0001");
+        assert_eq!(row.nama, "Foo");
+        assert_eq!(row.kelas, "");
+        assert_eq!(row.updated_at, "");
+    }
+
+    fn open_conn_with_anggota() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE anggota (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                kode_anggota    TEXT NOT NULL UNIQUE,
+                nama            TEXT NOT NULL,
+                jenis_kelamin   TEXT,
+                kelas           TEXT,
+                jurusan         TEXT,
+                tempat_lahir    TEXT,
+                tanggal_lahir   TEXT,
+                no_telp         TEXT,
+                email           TEXT,
+                alamat          TEXT,
+                foto_path       TEXT,
+                tanggal_daftar  TEXT NOT NULL DEFAULT (date('now')),
+                aktif           INTEGER NOT NULL DEFAULT 1,
+                catatan         TEXT,
+                agama           TEXT,
+                created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            "#,
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn read_all_anggota_returns_empty_when_table_empty() {
+        let conn = open_conn_with_anggota();
+        let rows = read_all_anggota(&conn).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn read_all_anggota_orders_by_kode() {
+        let conn = open_conn_with_anggota();
+        for kode in &["A0003", "A0001", "A0002"] {
+            conn.execute(
+                "INSERT INTO anggota (kode_anggota, nama, aktif, created_at, updated_at)
+                 VALUES (?1, ?2, 1, '2024-01-01 00:00:00', '2024-01-01 00:00:00')",
+                rusqlite::params![kode, format!("nama-{kode}")],
+            )
+            .unwrap();
+        }
+        let rows = read_all_anggota(&conn).unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].kode_anggota, "A0001");
+        assert_eq!(rows[1].kode_anggota, "A0002");
+        assert_eq!(rows[2].kode_anggota, "A0003");
+    }
+
+    #[test]
+    fn read_all_anggota_coalesces_nulls_to_empty_strings() {
+        let conn = open_conn_with_anggota();
+        conn.execute(
+            "INSERT INTO anggota (kode_anggota, nama, aktif, created_at, updated_at)
+             VALUES ('A0001','Budi',1,'2024-01-01 00:00:00','2024-01-01 00:00:00')",
+            [],
+        )
+        .unwrap();
+        let rows = read_all_anggota(&conn).unwrap();
+        assert_eq!(rows[0].kelas, "");
+        assert_eq!(rows[0].email, "");
+        assert_eq!(rows[0].catatan, "");
+        assert_eq!(rows[0].aktif, "1");
+    }
+
+    #[test]
+    fn upsert_anggota_inserts_when_missing() {
+        let conn = open_conn_with_anggota();
+        let r = fixture_row();
+        let changed = upsert_anggota(&conn, &r).unwrap();
+        assert!(changed);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM anggota", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let nama: String = conn
+            .query_row(
+                "SELECT nama FROM anggota WHERE kode_anggota='A0001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(nama, "Budi Santoso");
+    }
+
+    #[test]
+    fn upsert_anggota_updates_when_incoming_newer() {
+        let conn = open_conn_with_anggota();
+        let mut r = fixture_row();
+        upsert_anggota(&conn, &r).unwrap();
+        r.nama = "Budi Santoso (renamed)".into();
+        r.updated_at = "2025-01-01 00:00:00".into();
+        let changed = upsert_anggota(&conn, &r).unwrap();
+        assert!(changed);
+        let nama: String = conn
+            .query_row(
+                "SELECT nama FROM anggota WHERE kode_anggota='A0001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(nama, "Budi Santoso (renamed)");
+    }
+
+    #[test]
+    fn upsert_anggota_skips_when_local_is_newer() {
+        let conn = open_conn_with_anggota();
+        let mut r = fixture_row();
+        r.updated_at = "2025-01-01 00:00:00".into();
+        upsert_anggota(&conn, &r).unwrap();
+        // simulate incoming older timestamp
+        r.nama = "stale value".into();
+        r.updated_at = "2024-01-01 00:00:00".into();
+        let changed = upsert_anggota(&conn, &r).unwrap();
+        assert!(!changed);
+        let nama: String = conn
+            .query_row(
+                "SELECT nama FROM anggota WHERE kode_anggota='A0001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(nama, "Budi Santoso");
+    }
+
+    #[test]
+    fn upsert_anggota_skips_when_timestamps_equal() {
+        let conn = open_conn_with_anggota();
+        let r = fixture_row();
+        upsert_anggota(&conn, &r).unwrap();
+        // identical timestamp = no-op (admin wins on tie)
+        let mut r2 = r.clone();
+        r2.nama = "should not apply".into();
+        let changed = upsert_anggota(&conn, &r2).unwrap();
+        assert!(!changed);
+    }
+
+    #[test]
+    fn upsert_anggota_rejects_empty_kode() {
+        let conn = open_conn_with_anggota();
+        let mut r = fixture_row();
+        r.kode_anggota.clear();
+        let err = upsert_anggota(&conn, &r).unwrap_err();
+        match err {
+            AppError::Validation(m) => assert!(m.contains("kode_anggota")),
+            _ => panic!("expected Validation"),
+        }
+    }
+
+    #[test]
+    fn upsert_anggota_handles_aktif_string_variants() {
+        let conn = open_conn_with_anggota();
+        let mut r = fixture_row();
+        r.aktif = "TRUE".into();
+        upsert_anggota(&conn, &r).unwrap();
+        let aktif: i64 = conn
+            .query_row(
+                "SELECT aktif FROM anggota WHERE kode_anggota='A0001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(aktif, 1);
+    }
+
+    #[test]
+    fn upsert_anggota_treats_non_truthy_as_inactive() {
+        let conn = open_conn_with_anggota();
+        let mut r = fixture_row();
+        r.aktif = "0".into();
+        upsert_anggota(&conn, &r).unwrap();
+        let aktif: i64 = conn
+            .query_row(
+                "SELECT aktif FROM anggota WHERE kode_anggota='A0001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(aktif, 0);
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/sync/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/sync/mod.rs
@@ -1,0 +1,524 @@
+//! FEAT-26 Google Sheets bidirectional sync (PR G v1.0.8).
+//!
+//! Public surface: the `tauri::command` functions registered in `lib.rs`.
+//! Internal modules: [`auth`] (Service Account JWT → access token),
+//! [`client`] (Sheets v4 REST wrapper), [`mapper`] (per-table row encoders),
+//! [`state`] (`sync_state`/`sync_log` queries).
+//!
+//! Scope of this PR (G1 in the BUGS.md sub-PR split):
+//! * Service Account auth + access-token caching
+//! * Push for `anggota` (replace-all-rows, content-hash short-circuit)
+//! * Pull for `anggota` (last-write-wins on `updated_at`)
+//! * Test-connection probe
+//! * `sync_status` for the Sinkronisasi page
+//!
+//! Out of scope, deferred to G2/G3:
+//! * Push/pull for `buku`, `eksemplar`, `peminjaman`, `peminjaman_item`,
+//!   `wishlist_buku`, `reservasi_buku`. The mapper trait is structured so
+//!   each table is one new mapper file + 4 lines in the dispatch.
+//! * Tombstones (`_deleted: TRUE` column) for soft-delete propagation.
+//! * Auto-scheduler tokio task. The infrastructure in
+//!   `commands::backup_runner` is a fine reference, but the user told us
+//!   manual buttons + interval-from-Pengaturan was enough for MVP.
+//! * Rich conflict resolver UI. We log conflicts (`status='ok'` with a
+//!   "skipped: local newer" message) but don't surface a side-by-side
+//!   resolver yet.
+
+pub mod auth;
+pub mod client;
+pub mod mapper;
+pub mod state;
+
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+use auth::{fetch_access_token, AccessToken, ServiceAccount, DEFAULT_SCOPE};
+use client::SheetsClient;
+use mapper::{
+    read_all_anggota, upsert_anggota, AnggotaRow, ANGGOTA_HEADER, ANGGOTA_TAB,
+};
+use state::{append_log, list_log, list_states, rows_hash, upsert_state, SyncStateRow};
+
+const KEY_SA_JSON: &str = "sync.service_account_json";
+const KEY_SHEETS_ID: &str = "sync.spreadsheet_id";
+const KEY_ENABLED: &str = "sync.enabled";
+
+/// In-memory access-token cache, keyed by Service Account email. Never
+/// persisted to disk — the SA JSON itself is what gets stored, and the
+/// token is cheap to re-mint (one JWT sign + one HTTPS call).
+///
+/// Held in a tokio `Mutex` because we touch it from async contexts.
+static TOKEN_CACHE: Mutex<Option<CachedToken>> = Mutex::new(None);
+
+#[derive(Debug, Clone)]
+struct CachedToken {
+    sa_email: String,
+    token: AccessToken,
+}
+
+fn read_setting(conn: &rusqlite::Connection, key: &str) -> AppResult<Option<String>> {
+    match conn.query_row(
+        "SELECT value FROM settings WHERE key = ?1",
+        rusqlite::params![key],
+        |row| row.get::<_, Option<String>>(0),
+    ) {
+        Ok(value) => Ok(value),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(AppError::Db(e)),
+    }
+}
+
+fn require_settings(state: &State<'_, AppState>) -> AppResult<(ServiceAccount, String)> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let sa_raw = read_setting(&conn, KEY_SA_JSON)?.unwrap_or_default();
+    let sheets_id = read_setting(&conn, KEY_SHEETS_ID)?.unwrap_or_default();
+    drop(conn);
+    if sa_raw.trim().is_empty() {
+        return Err(AppError::Validation(
+            "Service Account JSON belum diisi di Pengaturan → Sinkronisasi".into(),
+        ));
+    }
+    if sheets_id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "Spreadsheet ID belum diisi di Pengaturan → Sinkronisasi".into(),
+        ));
+    }
+    let sa = ServiceAccount::from_json(&sa_raw)?;
+    Ok((sa, sheets_id))
+}
+
+async fn build_client(sa: &ServiceAccount) -> AppResult<SheetsClient> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    {
+        let cache = TOKEN_CACHE
+            .lock()
+            .map_err(|_| AppError::Internal("token cache poisoned".into()))?;
+        if let Some(cached) = cache.as_ref() {
+            if cached.sa_email == sa.client_email && cached.token.is_fresh(now) {
+                return Ok(SheetsClient {
+                    http: reqwest::Client::new(),
+                    access_token: cached.token.token.clone(),
+                });
+            }
+        }
+    }
+    let http = reqwest::Client::new();
+    let token = fetch_access_token(&http, sa, DEFAULT_SCOPE).await?;
+    {
+        let mut cache = TOKEN_CACHE
+            .lock()
+            .map_err(|_| AppError::Internal("token cache poisoned".into()))?;
+        *cache = Some(CachedToken {
+            sa_email: sa.client_email.clone(),
+            token: token.clone(),
+        });
+    }
+    Ok(SheetsClient {
+        http,
+        access_token: token.token,
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestConnectionResult {
+    pub ok: bool,
+    pub spreadsheet_title: String,
+    pub tabs: Vec<String>,
+    pub service_account_email: String,
+}
+
+/// Validate the saved Service Account JSON + spreadsheet ID by fetching
+/// the spreadsheet metadata. Returns sheet title + tab names so the UI can
+/// confirm which workbook the admin connected.
+#[tauri::command]
+pub async fn sync_test_connection(
+    state: State<'_, AppState>,
+) -> AppResult<TestConnectionResult> {
+    let (sa, sheets_id) = require_settings(&state)?;
+    let client = build_client(&sa).await?;
+    let meta = client.get_spreadsheet(&sheets_id).await?;
+    let tabs = meta
+        .sheets
+        .iter()
+        .map(|s| s.properties.title.clone())
+        .collect::<Vec<_>>();
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    append_log(
+        &conn,
+        "test",
+        "*",
+        "ok",
+        0,
+        Some(&format!(
+            "test ok: {} ({} tabs)",
+            meta.properties.title,
+            tabs.len()
+        )),
+    )?;
+    drop(conn);
+    Ok(TestConnectionResult {
+        ok: true,
+        spreadsheet_title: meta.properties.title,
+        tabs,
+        service_account_email: sa.client_email,
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncRunResult {
+    pub direction: String,
+    pub rows_changed: i64,
+    pub status: String,
+    pub message: String,
+}
+
+/// Push the local `anggota` table to the configured spreadsheet, replacing
+/// the entire `anggota` tab with our snapshot. If the local data hasn't
+/// changed since the last successful push we short-circuit and log a
+/// `noop`.
+#[tauri::command]
+pub async fn sync_push_now(state: State<'_, AppState>) -> AppResult<Vec<SyncRunResult>> {
+    let (sa, sheets_id) = require_settings(&state)?;
+    let client = build_client(&sa).await?;
+    let mut results: Vec<SyncRunResult> = Vec::new();
+    push_anggota(&state, &client, &sheets_id, &mut results).await?;
+    Ok(results)
+}
+
+async fn push_anggota(
+    state: &State<'_, AppState>,
+    client: &SheetsClient,
+    sheets_id: &str,
+    results: &mut Vec<SyncRunResult>,
+) -> AppResult<()> {
+    let (rows, prev_hash) = {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+        let rows = read_all_anggota(&conn)?;
+        let prev_hash = state::get_state(&conn, ANGGOTA_TAB)?
+            .and_then(|s| s.last_push_hash);
+        (rows, prev_hash)
+    };
+
+    let mut sheet_rows: Vec<Vec<String>> = Vec::with_capacity(rows.len() + 1);
+    sheet_rows.push(ANGGOTA_HEADER.iter().map(|s| s.to_string()).collect());
+    for r in &rows {
+        sheet_rows.push(r.to_cells());
+    }
+    let new_hash = rows_hash(&sheet_rows);
+
+    if prev_hash.as_deref() == Some(new_hash.as_str()) {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+        append_log(
+            &conn,
+            "push",
+            ANGGOTA_TAB,
+            "noop",
+            0,
+            Some("local belum berubah sejak push terakhir"),
+        )?;
+        results.push(SyncRunResult {
+            direction: "push".into(),
+            rows_changed: 0,
+            status: "noop".into(),
+            message: "local belum berubah sejak push terakhir".into(),
+        });
+        return Ok(());
+    }
+
+    let push_result =
+        do_push_anggota(client, sheets_id, &sheet_rows, rows.len() as i64).await;
+
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    match push_result {
+        Ok(rows_changed) => {
+            let now_iso = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+            let prev = state::get_state(&conn, ANGGOTA_TAB)?.unwrap_or(SyncStateRow {
+                table_name: ANGGOTA_TAB.into(),
+                last_push_at: None,
+                last_pull_at: None,
+                last_push_hash: None,
+                last_pull_hash: None,
+                rows_pushed: 0,
+                rows_pulled: 0,
+                updated_at: String::new(),
+            });
+            upsert_state(
+                &conn,
+                &SyncStateRow {
+                    last_push_at: Some(now_iso.clone()),
+                    last_push_hash: Some(new_hash),
+                    rows_pushed: rows_changed,
+                    ..prev
+                },
+            )?;
+            append_log(
+                &conn,
+                "push",
+                ANGGOTA_TAB,
+                "ok",
+                rows_changed,
+                Some(&format!("pushed {} anggota", rows_changed)),
+            )?;
+            results.push(SyncRunResult {
+                direction: "push".into(),
+                rows_changed,
+                status: "ok".into(),
+                message: format!("pushed {} anggota", rows_changed),
+            });
+            Ok(())
+        }
+        Err(e) => {
+            let msg = format!("{e:?}");
+            append_log(&conn, "push", ANGGOTA_TAB, "error", 0, Some(&msg))?;
+            Err(e)
+        }
+    }
+}
+
+async fn do_push_anggota(
+    client: &SheetsClient,
+    sheets_id: &str,
+    sheet_rows: &[Vec<String>],
+    row_count: i64,
+) -> AppResult<i64> {
+    client.ensure_tab(sheets_id, ANGGOTA_TAB).await?;
+    let range = format!("{ANGGOTA_TAB}!A1:Z");
+    client.clear_values(sheets_id, &range).await?;
+    if !sheet_rows.is_empty() {
+        let write_range = format!("{ANGGOTA_TAB}!A1");
+        client
+            .update_values(sheets_id, &write_range, sheet_rows)
+            .await?;
+    }
+    Ok(row_count)
+}
+
+/// Pull the `anggota` tab from the configured spreadsheet and apply rows
+/// where the incoming `updated_at` is strictly greater than the local copy.
+#[tauri::command]
+pub async fn sync_pull_now(state: State<'_, AppState>) -> AppResult<Vec<SyncRunResult>> {
+    let (sa, sheets_id) = require_settings(&state)?;
+    let client = build_client(&sa).await?;
+    let mut results: Vec<SyncRunResult> = Vec::new();
+    pull_anggota(&state, &client, &sheets_id, &mut results).await?;
+    Ok(results)
+}
+
+async fn pull_anggota(
+    state: &State<'_, AppState>,
+    client: &SheetsClient,
+    sheets_id: &str,
+    results: &mut Vec<SyncRunResult>,
+) -> AppResult<()> {
+    let range = format!("{ANGGOTA_TAB}!A1:Z");
+    let raw = match client.get_values(sheets_id, &range).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            let conn = state
+                .db
+                .lock()
+                .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+            append_log(&conn, "pull", ANGGOTA_TAB, "error", 0, Some(&format!("{e:?}")))?;
+            return Err(e);
+        }
+    };
+
+    if raw.is_empty() {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+        append_log(
+            &conn,
+            "pull",
+            ANGGOTA_TAB,
+            "skipped",
+            0,
+            Some("tab Anggota di Sheets kosong / belum ada"),
+        )?;
+        results.push(SyncRunResult {
+            direction: "pull".into(),
+            rows_changed: 0,
+            status: "skipped".into(),
+            message: "tab Anggota di Sheets kosong / belum ada".into(),
+        });
+        return Ok(());
+    }
+
+    // Skip header row (first row). Validate it has the expected first column.
+    let mut iter = raw.into_iter();
+    let header = iter.next().unwrap_or_default();
+    if header.first().map(|s| s.as_str()) != Some("kode_anggota") {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+        let msg = format!(
+            "header tab Anggota tidak dikenal: kolom-1='{}' (harus 'kode_anggota')",
+            header.first().cloned().unwrap_or_default()
+        );
+        append_log(&conn, "pull", ANGGOTA_TAB, "error", 0, Some(&msg))?;
+        return Err(AppError::Validation(msg));
+    }
+
+    let mut applied: i64 = 0;
+    let mut skipped: i64 = 0;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    for cells in iter {
+        if cells.iter().all(|c| c.is_empty()) {
+            continue;
+        }
+        let row = AnggotaRow::from_cells(&cells);
+        match upsert_anggota(&conn, &row) {
+            Ok(true) => applied += 1,
+            Ok(false) => skipped += 1,
+            Err(e) => {
+                append_log(
+                    &conn,
+                    "pull",
+                    ANGGOTA_TAB,
+                    "error",
+                    applied,
+                    Some(&format!("row {}: {e:?}", row.kode_anggota)),
+                )?;
+            }
+        }
+    }
+    let now_iso = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let prev = state::get_state(&conn, ANGGOTA_TAB)?.unwrap_or(SyncStateRow {
+        table_name: ANGGOTA_TAB.into(),
+        last_push_at: None,
+        last_pull_at: None,
+        last_push_hash: None,
+        last_pull_hash: None,
+        rows_pushed: 0,
+        rows_pulled: 0,
+        updated_at: String::new(),
+    });
+    upsert_state(
+        &conn,
+        &SyncStateRow {
+            last_pull_at: Some(now_iso.clone()),
+            rows_pulled: applied,
+            ..prev
+        },
+    )?;
+    let msg = format!(
+        "pulled {applied} anggota (skip-newer-local: {skipped})"
+    );
+    append_log(&conn, "pull", ANGGOTA_TAB, "ok", applied, Some(&msg))?;
+    results.push(SyncRunResult {
+        direction: "pull".into(),
+        rows_changed: applied,
+        status: "ok".into(),
+        message: msg,
+    });
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncStatus {
+    pub configured: bool,
+    pub enabled: bool,
+    pub spreadsheet_id: String,
+    pub service_account_email: String,
+    pub states: Vec<SyncStateRow>,
+    pub log: Vec<state::SyncLogEntry>,
+}
+
+/// Snapshot of the sync subsystem for the Sinkronisasi page header.
+#[tauri::command]
+pub fn sync_status(state: State<'_, AppState>) -> AppResult<SyncStatus> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let sa_raw = read_setting(&conn, KEY_SA_JSON)?.unwrap_or_default();
+    let sheets_id = read_setting(&conn, KEY_SHEETS_ID)?.unwrap_or_default();
+    let enabled = read_setting(&conn, KEY_ENABLED)?
+        .map(|v| v == "1")
+        .unwrap_or(false);
+    let states = list_states(&conn)?;
+    let log = list_log(&conn, 25)?;
+    let configured = !sa_raw.trim().is_empty() && !sheets_id.trim().is_empty();
+    let sa_email = if !sa_raw.trim().is_empty() {
+        ServiceAccount::from_json(&sa_raw)
+            .map(|sa| sa.client_email)
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+    Ok(SyncStatus {
+        configured,
+        enabled,
+        spreadsheet_id: sheets_id,
+        service_account_email: sa_email,
+        states,
+        log,
+    })
+}
+
+/// Save (or clear) the Service Account JSON. Pass an empty string to clear.
+/// We re-validate before persisting so a malformed paste produces a toast
+/// instead of writing garbage to settings.
+#[tauri::command]
+pub fn sync_save_service_account(
+    state: State<'_, AppState>,
+    json: String,
+) -> AppResult<()> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| AppError::Internal("db mutex poisoned".into()))?;
+    let trimmed = json.trim();
+    if trimmed.is_empty() {
+        conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?1, '')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            rusqlite::params![KEY_SA_JSON],
+        )?;
+        // Drop cached token if any
+        let mut cache = TOKEN_CACHE
+            .lock()
+            .map_err(|_| AppError::Internal("token cache poisoned".into()))?;
+        *cache = None;
+        return Ok(());
+    }
+    let _sa = ServiceAccount::from_json(trimmed)?;
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![KEY_SA_JSON, trimmed],
+    )?;
+    let mut cache = TOKEN_CACHE
+        .lock()
+        .map_err(|_| AppError::Internal("token cache poisoned".into()))?;
+    *cache = None;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/commands/sync/state.rs
+++ b/apps/desktop/src-tauri/src/commands/sync/state.rs
@@ -1,0 +1,350 @@
+//! `sync_state` and `sync_log` helpers for FEAT-26 Sheets sync (PR G v1.0.8).
+//!
+//! `sync_state`: per-table cursor (last successful push/pull at + content
+//! hash). `last_push_hash` lets us short-circuit pushes when the local data
+//! has not changed since the last successful push — saving Sheets API quota.
+//!
+//! `sync_log`: append-only audit trail rendered in the Sinkronisasi page so
+//! the operator can see what happened on the last cycle (push of `anggota`
+//! at 14:32, 17 rows, ok). Capped to the last 100 rows in `prune_log`.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::AppResult;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SyncStateRow {
+    pub table_name: String,
+    pub last_push_at: Option<String>,
+    pub last_pull_at: Option<String>,
+    pub last_push_hash: Option<String>,
+    pub last_pull_hash: Option<String>,
+    pub rows_pushed: i64,
+    pub rows_pulled: i64,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncLogEntry {
+    pub id: i64,
+    pub ts: String,
+    pub direction: String,
+    pub table_name: String,
+    pub status: String,
+    pub rows_changed: i64,
+    pub message: Option<String>,
+}
+
+/// Insert-or-update one `sync_state` row. Touches `updated_at`.
+pub fn upsert_state(conn: &Connection, row: &SyncStateRow) -> AppResult<()> {
+    conn.execute(
+        "INSERT INTO sync_state (
+            table_name, last_push_at, last_pull_at,
+            last_push_hash, last_pull_hash, rows_pushed, rows_pulled, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))
+         ON CONFLICT(table_name) DO UPDATE SET
+            last_push_at   = excluded.last_push_at,
+            last_pull_at   = excluded.last_pull_at,
+            last_push_hash = excluded.last_push_hash,
+            last_pull_hash = excluded.last_pull_hash,
+            rows_pushed    = excluded.rows_pushed,
+            rows_pulled    = excluded.rows_pulled,
+            updated_at     = datetime('now')",
+        rusqlite::params![
+            row.table_name,
+            row.last_push_at,
+            row.last_pull_at,
+            row.last_push_hash,
+            row.last_pull_hash,
+            row.rows_pushed,
+            row.rows_pulled,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn get_state(conn: &Connection, table_name: &str) -> AppResult<Option<SyncStateRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT table_name, last_push_at, last_pull_at,
+                last_push_hash, last_pull_hash, rows_pushed, rows_pulled, updated_at
+           FROM sync_state
+          WHERE table_name = ?1",
+    )?;
+    let row = stmt
+        .query_row(rusqlite::params![table_name], |row| {
+            Ok(SyncStateRow {
+                table_name: row.get(0)?,
+                last_push_at: row.get(1)?,
+                last_pull_at: row.get(2)?,
+                last_push_hash: row.get(3)?,
+                last_pull_hash: row.get(4)?,
+                rows_pushed: row.get(5)?,
+                rows_pulled: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        })
+        .ok();
+    Ok(row)
+}
+
+pub fn list_states(conn: &Connection) -> AppResult<Vec<SyncStateRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT table_name, last_push_at, last_pull_at,
+                last_push_hash, last_pull_hash, rows_pushed, rows_pulled, updated_at
+           FROM sync_state
+          ORDER BY table_name ASC",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(SyncStateRow {
+                table_name: row.get(0)?,
+                last_push_at: row.get(1)?,
+                last_pull_at: row.get(2)?,
+                last_push_hash: row.get(3)?,
+                last_pull_hash: row.get(4)?,
+                rows_pushed: row.get(5)?,
+                rows_pulled: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+pub fn append_log(
+    conn: &Connection,
+    direction: &str,
+    table_name: &str,
+    status: &str,
+    rows_changed: i64,
+    message: Option<&str>,
+) -> AppResult<()> {
+    conn.execute(
+        "INSERT INTO sync_log (direction, table_name, status, rows_changed, message)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![direction, table_name, status, rows_changed, message],
+    )?;
+    prune_log(conn)?;
+    Ok(())
+}
+
+pub fn list_log(conn: &Connection, limit: i64) -> AppResult<Vec<SyncLogEntry>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, ts, direction, table_name, status, rows_changed, message
+           FROM sync_log
+          ORDER BY id DESC
+          LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(rusqlite::params![limit], |row| {
+            Ok(SyncLogEntry {
+                id: row.get(0)?,
+                ts: row.get(1)?,
+                direction: row.get(2)?,
+                table_name: row.get(3)?,
+                status: row.get(4)?,
+                rows_changed: row.get(5)?,
+                message: row.get(6)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+/// Trim `sync_log` to the most recent 100 entries. Cheap because we run it
+/// after every insert; the table never grows unbounded.
+pub fn prune_log(conn: &Connection) -> AppResult<()> {
+    conn.execute(
+        "DELETE FROM sync_log
+          WHERE id NOT IN (
+             SELECT id FROM sync_log ORDER BY id DESC LIMIT 100
+          )",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Stable content-hash for a list of rows. Used as the `last_push_hash` so a
+/// second push with no local changes can short-circuit (status='noop',
+/// no API call). SHA-256 hex; the leading-12-chars suffix is what we
+/// expose in logs for human eyeballing.
+pub fn rows_hash(rows: &[Vec<String>]) -> String {
+    let mut hasher = Sha256::new();
+    for row in rows {
+        for cell in row {
+            hasher.update(cell.as_bytes());
+            hasher.update([0u8]);
+        }
+        hasher.update([0xffu8]);
+    }
+    let digest = hasher.finalize();
+    hex::encode(digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_conn_with_sync_tables() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sync_state (
+                table_name      TEXT PRIMARY KEY,
+                last_push_at    TEXT,
+                last_pull_at    TEXT,
+                last_push_hash  TEXT,
+                last_pull_hash  TEXT,
+                rows_pushed     INTEGER NOT NULL DEFAULT 0,
+                rows_pulled     INTEGER NOT NULL DEFAULT 0,
+                updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE TABLE sync_log (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts           TEXT NOT NULL DEFAULT (datetime('now')),
+                direction    TEXT NOT NULL CHECK (direction IN ('push','pull','test')),
+                table_name   TEXT NOT NULL,
+                status       TEXT NOT NULL CHECK (status IN ('ok','error','skipped','noop')),
+                rows_changed INTEGER NOT NULL DEFAULT 0,
+                message      TEXT
+            );
+            "#,
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn upsert_state_inserts_then_updates() {
+        let conn = open_conn_with_sync_tables();
+        let row = SyncStateRow {
+            table_name: "anggota".into(),
+            last_push_at: Some("2025-01-01 00:00:00".into()),
+            last_pull_at: None,
+            last_push_hash: Some("abc".into()),
+            last_pull_hash: None,
+            rows_pushed: 5,
+            rows_pulled: 0,
+            updated_at: String::new(),
+        };
+        upsert_state(&conn, &row).unwrap();
+        let got = get_state(&conn, "anggota").unwrap().unwrap();
+        assert_eq!(got.last_push_hash.as_deref(), Some("abc"));
+        assert_eq!(got.rows_pushed, 5);
+
+        let row2 = SyncStateRow {
+            last_push_hash: Some("def".into()),
+            rows_pushed: 7,
+            ..row
+        };
+        upsert_state(&conn, &row2).unwrap();
+        let got2 = get_state(&conn, "anggota").unwrap().unwrap();
+        assert_eq!(got2.last_push_hash.as_deref(), Some("def"));
+        assert_eq!(got2.rows_pushed, 7);
+    }
+
+    #[test]
+    fn list_states_returns_alphabetical_order() {
+        let conn = open_conn_with_sync_tables();
+        for tbl in &["buku", "anggota", "eksemplar"] {
+            upsert_state(
+                &conn,
+                &SyncStateRow {
+                    table_name: tbl.to_string(),
+                    last_push_at: None,
+                    last_pull_at: None,
+                    last_push_hash: None,
+                    last_pull_hash: None,
+                    rows_pushed: 0,
+                    rows_pulled: 0,
+                    updated_at: String::new(),
+                },
+            )
+            .unwrap();
+        }
+        let states = list_states(&conn).unwrap();
+        assert_eq!(states.len(), 3);
+        assert_eq!(states[0].table_name, "anggota");
+        assert_eq!(states[1].table_name, "buku");
+        assert_eq!(states[2].table_name, "eksemplar");
+    }
+
+    #[test]
+    fn append_log_inserts_with_default_ts() {
+        let conn = open_conn_with_sync_tables();
+        append_log(&conn, "push", "anggota", "ok", 17, Some("ok msg")).unwrap();
+        let rows = list_log(&conn, 10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].direction, "push");
+        assert_eq!(rows[0].rows_changed, 17);
+        assert_eq!(rows[0].message.as_deref(), Some("ok msg"));
+        assert!(!rows[0].ts.is_empty());
+    }
+
+    #[test]
+    fn append_log_caps_at_100_entries() {
+        let conn = open_conn_with_sync_tables();
+        for i in 0..105 {
+            append_log(
+                &conn,
+                "push",
+                "anggota",
+                "ok",
+                i,
+                Some(&format!("entry {i}")),
+            )
+            .unwrap();
+        }
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_log", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 100);
+        // most recent should still be present
+        let rows = list_log(&conn, 1).unwrap();
+        assert_eq!(rows[0].rows_changed, 104);
+    }
+
+    #[test]
+    fn list_log_orders_newest_first() {
+        let conn = open_conn_with_sync_tables();
+        append_log(&conn, "push", "anggota", "ok", 1, Some("first")).unwrap();
+        append_log(&conn, "push", "anggota", "ok", 2, Some("second")).unwrap();
+        append_log(&conn, "push", "anggota", "ok", 3, Some("third")).unwrap();
+        let rows = list_log(&conn, 10).unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].rows_changed, 3);
+        assert_eq!(rows[2].rows_changed, 1);
+    }
+
+    #[test]
+    fn rows_hash_is_deterministic() {
+        let r1 = vec![
+            vec!["A0001".to_string(), "Budi".to_string()],
+            vec!["A0002".to_string(), "Sari".to_string()],
+        ];
+        let r2 = r1.clone();
+        assert_eq!(rows_hash(&r1), rows_hash(&r2));
+    }
+
+    #[test]
+    fn rows_hash_is_sensitive_to_changes() {
+        let r1 = vec![vec!["A0001".to_string(), "Budi".to_string()]];
+        let r2 = vec![vec!["A0001".to_string(), "Budi (changed)".to_string()]];
+        assert_ne!(rows_hash(&r1), rows_hash(&r2));
+    }
+
+    #[test]
+    fn rows_hash_distinguishes_row_boundary() {
+        let r1 = vec![
+            vec!["A".to_string(), "B".to_string()],
+            vec!["C".to_string()],
+        ];
+        let r2 = vec![
+            vec!["A".to_string()],
+            vec!["B".to_string(), "C".to_string()],
+        ];
+        assert_ne!(rows_hash(&r1), rows_hash(&r2));
+    }
+}

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -33,6 +33,7 @@ pub fn run_migrations(conn: &Connection) -> AppResult<()> {
     conn.execute_batch(BACKUP_HISTORY_SQL)?;
     conn.execute_batch(SURAT_SQL)?;
     conn.execute_batch(WISHLIST_SQL)?;
+    conn.execute_batch(SYNC_SQL)?;
     apply_additive_migrations(conn)?;
     seed_master_data(conn)?;
     seed_kta_default_template(conn)?;
@@ -83,6 +84,36 @@ CREATE TABLE IF NOT EXISTS wishlist_buku (
 CREATE INDEX IF NOT EXISTS idx_wishlist_status ON wishlist_buku(status);
 CREATE INDEX IF NOT EXISTS idx_wishlist_anggota ON wishlist_buku(anggota_id);
 "#;
+
+/// Sync metadata tables for FEAT-26 Google Sheets bidirectional sync (PR G
+/// v1.0.8). `sync_state` keeps a per-table cursor (last successful push/pull
+/// timestamps + a content-hash sentinel that lets us short-circuit no-op
+/// pushes); `sync_log` is an append-only audit trail rendered in the
+/// Sinkronisasi page so the admin can see what happened on the last cycle.
+const SYNC_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS sync_state (
+    table_name      TEXT PRIMARY KEY,
+    last_push_at    TEXT,
+    last_pull_at    TEXT,
+    last_push_hash  TEXT,
+    last_pull_hash  TEXT,
+    rows_pushed     INTEGER NOT NULL DEFAULT 0,
+    rows_pulled     INTEGER NOT NULL DEFAULT 0,
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS sync_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts           TEXT NOT NULL DEFAULT (datetime('now')),
+    direction    TEXT NOT NULL CHECK (direction IN ('push','pull','test')),
+    table_name   TEXT NOT NULL,
+    status       TEXT NOT NULL CHECK (status IN ('ok','error','skipped','noop')),
+    rows_changed INTEGER NOT NULL DEFAULT 0,
+    message      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sync_log_ts ON sync_log(ts DESC);
+"#;
+
 
 const KTA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS kta_templates (

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -237,6 +237,11 @@ pub fn run() {
             commands::wishlist::wishlist_update_status,
             commands::wishlist::wishlist_upvote,
             commands::wishlist::wishlist_delete,
+            commands::sync::sync_test_connection,
+            commands::sync::sync_push_now,
+            commands::sync::sync_pull_now,
+            commands::sync::sync_status,
+            commands::sync::sync_save_service_account,
         ])
         .on_window_event(|window, event| {
             // BUG-011: intercept the X-button on the main window and

--- a/apps/desktop/src/features/settings/SinkronisasiPage.tsx
+++ b/apps/desktop/src/features/settings/SinkronisasiPage.tsx
@@ -1,31 +1,59 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ExternalLink } from 'lucide-react';
+import { ArrowDownToLine, ArrowUpFromLine, ExternalLink, RotateCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/toast-manager';
 import {
   DEFAULT_SYNC_CONFIG,
   type SyncConfig,
+  type SyncLogEntry,
+  type SyncStateRow,
+  type SyncStatusSnapshot,
   settingsApi,
 } from '@/lib/settings';
 import { FieldRow, SettingsSection } from './SettingsSection';
 
+/**
+ * Sinkronisasi page (Pengaturan → Sinkronisasi).
+ *
+ * v1.0.6 shipped a placeholder UI with `apiKey` (read-only Sheets access).
+ * v1.0.8 PR G (FEAT-26) extends it with Service Account–based bidirectional
+ * sync. Push uploads the local `anggota` table to the configured spreadsheet
+ * (replacing the entire `anggota` tab), pull downloads rows back and applies
+ * them with last-write-wins on `updated_at`. Other tables follow in G2/G3.
+ */
 export function SinkronisasiPage(): JSX.Element {
   const { t } = useTranslation('settings');
   const { showToast } = useToast();
   const [cfg, setCfg] = React.useState<SyncConfig>(DEFAULT_SYNC_CONFIG);
+  const [status, setStatus] = React.useState<SyncStatusSnapshot | null>(null);
+  const [serviceAccountJson, setServiceAccountJson] = React.useState('');
+  const [showSaJson, setShowSaJson] = React.useState(false);
+  const [savingSa, setSavingSa] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
-  const [syncing, setSyncing] = React.useState(false);
+  const [testing, setTesting] = React.useState(false);
+  const [pushing, setPushing] = React.useState(false);
+  const [pulling, setPulling] = React.useState(false);
+
+  const refresh = React.useCallback(async () => {
+    const [next, snap] = await Promise.all([
+      settingsApi.getSyncConfig(),
+      settingsApi.getSyncStatus(),
+    ]);
+    setCfg(next);
+    setStatus(snap);
+  }, []);
 
   React.useEffect(() => {
-    settingsApi.getSyncConfig().then(setCfg);
-  }, []);
+    void refresh();
+  }, [refresh]);
 
   const handleSave = async (): Promise<void> => {
     setSaving(true);
     try {
       await settingsApi.saveSyncConfig(cfg);
+      await refresh();
     } finally {
       setSaving(false);
     }
@@ -34,26 +62,131 @@ export function SinkronisasiPage(): JSX.Element {
   const handleReset = async (): Promise<void> => {
     const next = await settingsApi.resetSyncConfig();
     setCfg(next);
+    await refresh();
   };
 
-  const handleSyncNow = async (): Promise<void> => {
-    setSyncing(true);
+  const handleSaveServiceAccount = async (): Promise<void> => {
+    setSavingSa(true);
     try {
-      const next = await settingsApi.syncNow();
-      setCfg(next);
+      await settingsApi.saveServiceAccountJson(serviceAccountJson);
+      setServiceAccountJson('');
+      await refresh();
       showToast({
-        title: t('sections.sinkronisasi.syncSuccess', { defaultValue: 'Sinkronisasi berhasil.' }),
+        title: t('sections.sinkronisasi.toast.saSaved', {
+          defaultValue: 'Service Account JSON disimpan.',
+        }),
       });
     } catch (e) {
       showToast({
-        title: t('sections.sinkronisasi.syncError', { defaultValue: 'Sinkronisasi gagal.' }),
+        title: t('sections.sinkronisasi.toast.saSaveError', {
+          defaultValue: 'Service Account JSON tidak valid.',
+        }),
         description: e instanceof Error ? e.message : undefined,
         variant: 'destructive',
       });
     } finally {
-      setSyncing(false);
+      setSavingSa(false);
     }
   };
+
+  const handleClearServiceAccount = async (): Promise<void> => {
+    setSavingSa(true);
+    try {
+      await settingsApi.saveServiceAccountJson('');
+      await refresh();
+      showToast({
+        title: t('sections.sinkronisasi.toast.saCleared', {
+          defaultValue: 'Service Account JSON dihapus.',
+        }),
+      });
+    } catch (e) {
+      showToast({
+        title: t('sections.sinkronisasi.toast.saSaveError', {
+          defaultValue: 'Service Account JSON tidak valid.',
+        }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setSavingSa(false);
+    }
+  };
+
+  const handleTestConnection = async (): Promise<void> => {
+    setTesting(true);
+    try {
+      const result = await settingsApi.testSyncConnection();
+      showToast({
+        title: t('sections.sinkronisasi.toast.testOk', {
+          defaultValue: 'Koneksi ke Sheets berhasil.',
+        }),
+        description: t('sections.sinkronisasi.toast.testOkDesc', {
+          defaultValue: 'Spreadsheet "{{title}}" • {{count}} tab',
+          title: result.spreadsheet_title,
+          count: result.tabs.length,
+        }),
+      });
+      await refresh();
+    } catch (e) {
+      showToast({
+        title: t('sections.sinkronisasi.toast.testError', {
+          defaultValue: 'Tes koneksi gagal.',
+        }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handlePush = async (): Promise<void> => {
+    setPushing(true);
+    try {
+      const results = await settingsApi.pushSyncNow();
+      const total = results.reduce((acc, r) => acc + (r.status === 'ok' ? r.rows_changed : 0), 0);
+      showToast({
+        title: t('sections.sinkronisasi.toast.pushOk', {
+          defaultValue: 'Push selesai: {{count}} baris.',
+          count: total,
+        }),
+      });
+      await refresh();
+    } catch (e) {
+      showToast({
+        title: t('sections.sinkronisasi.toast.pushError', { defaultValue: 'Push gagal.' }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setPushing(false);
+    }
+  };
+
+  const handlePull = async (): Promise<void> => {
+    setPulling(true);
+    try {
+      const results = await settingsApi.pullSyncNow();
+      const total = results.reduce((acc, r) => acc + (r.status === 'ok' ? r.rows_changed : 0), 0);
+      showToast({
+        title: t('sections.sinkronisasi.toast.pullOk', {
+          defaultValue: 'Pull selesai: {{count}} baris.',
+          count: total,
+        }),
+      });
+      await refresh();
+    } catch (e) {
+      showToast({
+        title: t('sections.sinkronisasi.toast.pullError', { defaultValue: 'Pull gagal.' }),
+        description: e instanceof Error ? e.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setPulling(false);
+    }
+  };
+
+  const ready = cfg.serviceAccountConfigured && cfg.spreadsheetId.trim().length > 0;
 
   return (
     <SettingsSection
@@ -74,42 +207,330 @@ export function SinkronisasiPage(): JSX.Element {
         label={t('sections.sinkronisasi.fields.spreadsheetId', { defaultValue: 'ID Spreadsheet' })}
       >
         <Input
+          data-testid="sync-spreadsheet-id"
           value={cfg.spreadsheetId}
           onChange={(e) => setCfg((c) => ({ ...c, spreadsheetId: e.target.value }))}
           disabled={!cfg.enabled}
+          placeholder="1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe"
         />
       </FieldRow>
-      <FieldRow label={t('sections.sinkronisasi.fields.apiKey', { defaultValue: 'API Key' })}>
-        <Input
-          type="password"
-          value={cfg.apiKey}
-          onChange={(e) => setCfg((c) => ({ ...c, apiKey: e.target.value }))}
-          disabled={!cfg.enabled}
+
+      <FieldRow
+        label={t('sections.sinkronisasi.fields.serviceAccount', {
+          defaultValue: 'Service Account JSON',
+        })}
+      >
+        <ServiceAccountField
+          configured={cfg.serviceAccountConfigured}
+          email={cfg.serviceAccountEmail}
+          json={serviceAccountJson}
+          show={showSaJson}
+          saving={savingSa}
+          onJsonChange={setServiceAccountJson}
+          onToggleShow={() => setShowSaJson((v) => !v)}
+          onSave={handleSaveServiceAccount}
+          onClear={handleClearServiceAccount}
+          disabled={false}
         />
       </FieldRow>
-      <div className="flex items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-sm">
-        <span className="text-muted-foreground">
-          {t('sections.sinkronisasi.fields.lastSync', { defaultValue: 'Terakhir sinkron' })}:{' '}
-          {cfg.lastSync ? new Date(cfg.lastSync).toLocaleString() : '—'}
-        </span>
-        <Button size="sm" onClick={handleSyncNow} disabled={!cfg.enabled || syncing}>
-          {t('sections.sinkronisasi.syncNow', { defaultValue: 'Sinkron sekarang' })}
-        </Button>
-      </div>
+
+      <SyncActions
+        ready={ready && cfg.enabled}
+        testing={testing}
+        pushing={pushing}
+        pulling={pulling}
+        onTest={handleTestConnection}
+        onPush={handlePush}
+        onPull={handlePull}
+        onRefresh={refresh}
+      />
+
+      {status ? <SyncStatusPanel status={status} /> : null}
 
       <SinkronisasiGuide />
     </SettingsSection>
   );
 }
 
+interface ServiceAccountFieldProps {
+  configured: boolean;
+  email: string;
+  json: string;
+  show: boolean;
+  saving: boolean;
+  disabled: boolean;
+  onJsonChange: (next: string) => void;
+  onToggleShow: () => void;
+  onSave: () => void | Promise<void>;
+  onClear: () => void | Promise<void>;
+}
+
+function ServiceAccountField(props: ServiceAccountFieldProps): JSX.Element {
+  const { t } = useTranslation('settings');
+  const {
+    configured,
+    email,
+    json,
+    show,
+    saving,
+    disabled,
+    onJsonChange,
+    onToggleShow,
+    onSave,
+    onClear,
+  } = props;
+  return (
+    <div className="space-y-2">
+      {configured ? (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-emerald-500/30 bg-emerald-50/60 px-3 py-2 text-sm dark:border-emerald-500/20 dark:bg-emerald-950/30">
+          <div className="min-w-0">
+            <p className="font-medium text-emerald-900 dark:text-emerald-100">
+              {t('sections.sinkronisasi.serviceAccount.savedTitle', {
+                defaultValue: 'Service Account aktif',
+              })}
+            </p>
+            <p className="truncate text-xs text-emerald-800 dark:text-emerald-200">{email || '—'}</p>
+          </div>
+          <Button
+            data-testid="sync-sa-clear"
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void onClear()}
+            disabled={saving || disabled}
+          >
+            {t('sections.sinkronisasi.serviceAccount.clear', { defaultValue: 'Hapus Service Account' })}
+          </Button>
+        </div>
+      ) : (
+        <p className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700/40 dark:bg-amber-950/40 dark:text-amber-200">
+          {t('sections.sinkronisasi.serviceAccount.notConfigured', {
+            defaultValue:
+              'Belum ada Service Account JSON. Paste JSON dari Google Cloud Console di bawah lalu klik Simpan.',
+          })}
+        </p>
+      )}
+
+      <textarea
+        data-testid="sync-sa-json"
+        value={json}
+        onChange={(e) => onJsonChange(e.target.value)}
+        disabled={saving || disabled}
+        spellCheck={false}
+        rows={6}
+        className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs leading-relaxed shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+        placeholder={t('sections.sinkronisasi.serviceAccount.placeholder', {
+          defaultValue: '{ "type": "service_account", "project_id": "...", ... }',
+        })}
+        style={{ filter: show ? 'none' : 'blur(0)' }}
+      />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          data-testid="sync-sa-save"
+          type="button"
+          size="sm"
+          onClick={() => void onSave()}
+          disabled={saving || json.trim().length === 0 || disabled}
+        >
+          {saving
+            ? t('sections.sinkronisasi.serviceAccount.saving', { defaultValue: 'Menyimpan…' })
+            : t('sections.sinkronisasi.serviceAccount.save', { defaultValue: 'Simpan Service Account' })}
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={onToggleShow}>
+          {show
+            ? t('sections.sinkronisasi.serviceAccount.hide', { defaultValue: 'Sembunyikan' })
+            : t('sections.sinkronisasi.serviceAccount.show', { defaultValue: 'Tampilkan' })}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {t('sections.sinkronisasi.serviceAccount.privacy', {
+          defaultValue:
+            'JSON hanya disimpan di komputer ini, tidak pernah dikirim ke server selain Google Sheets.',
+        })}
+      </p>
+    </div>
+  );
+}
+
+interface SyncActionsProps {
+  ready: boolean;
+  testing: boolean;
+  pushing: boolean;
+  pulling: boolean;
+  onTest: () => void | Promise<void>;
+  onPush: () => void | Promise<void>;
+  onPull: () => void | Promise<void>;
+  onRefresh: () => void | Promise<void>;
+}
+
+function SyncActions(props: SyncActionsProps): JSX.Element {
+  const { t } = useTranslation('settings');
+  const { ready, testing, pushing, pulling, onTest, onPush, onPull, onRefresh } = props;
+  const busy = testing || pushing || pulling;
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        data-testid="sync-test-connection"
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={() => void onTest()}
+        disabled={!ready || busy}
+      >
+        <RotateCw className={`mr-1.5 h-3.5 w-3.5 ${testing ? 'animate-spin' : ''}`} />
+        {t('sections.sinkronisasi.actions.test', { defaultValue: 'Tes Koneksi' })}
+      </Button>
+      <Button
+        data-testid="sync-push-now"
+        type="button"
+        size="sm"
+        onClick={() => void onPush()}
+        disabled={!ready || busy}
+      >
+        <ArrowUpFromLine className={`mr-1.5 h-3.5 w-3.5 ${pushing ? 'animate-pulse' : ''}`} />
+        {t('sections.sinkronisasi.actions.push', { defaultValue: 'Push Sekarang' })}
+      </Button>
+      <Button
+        data-testid="sync-pull-now"
+        type="button"
+        size="sm"
+        onClick={() => void onPull()}
+        disabled={!ready || busy}
+      >
+        <ArrowDownToLine className={`mr-1.5 h-3.5 w-3.5 ${pulling ? 'animate-pulse' : ''}`} />
+        {t('sections.sinkronisasi.actions.pull', { defaultValue: 'Pull Sekarang' })}
+      </Button>
+      <Button type="button" size="sm" variant="ghost" onClick={() => void onRefresh()} disabled={busy}>
+        {t('sections.sinkronisasi.actions.refresh', { defaultValue: 'Refresh status' })}
+      </Button>
+    </div>
+  );
+}
+
+function formatTs(ts: string | null): string {
+  if (!ts) return '—';
+  const trimmed = ts.replace(' ', 'T');
+  const d = new Date(trimmed.endsWith('Z') ? trimmed : `${trimmed}Z`);
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleString();
+}
+
+function SyncStatusPanel({ status }: { status: SyncStatusSnapshot }): JSX.Element {
+  const { t } = useTranslation('settings');
+  return (
+    <section
+      data-testid="sync-status-panel"
+      className="rounded-md border border-border bg-muted/30 p-4 text-sm"
+    >
+      <h3 className="text-base font-semibold">
+        {t('sections.sinkronisasi.status.title', { defaultValue: 'Status Sinkronisasi' })}
+      </h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {status.configured
+          ? t('sections.sinkronisasi.status.configured', {
+              defaultValue: 'Spreadsheet ID dan Service Account terkonfigurasi.',
+            })
+          : t('sections.sinkronisasi.status.notConfigured', {
+              defaultValue: 'Belum siap — lengkapi Spreadsheet ID dan Service Account.',
+            })}
+      </p>
+
+      <div className="mt-3 grid gap-3 lg:grid-cols-2">
+        <div>
+          <h4 className="text-sm font-semibold">
+            {t('sections.sinkronisasi.status.tablesTitle', { defaultValue: 'Per-tabel' })}
+          </h4>
+          {status.states.length === 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t('sections.sinkronisasi.status.tablesEmpty', {
+                defaultValue: 'Belum pernah push/pull.',
+              })}
+            </p>
+          ) : (
+            <ul className="mt-2 space-y-1 text-xs" data-testid="sync-status-tables">
+              {status.states.map((s) => (
+                <SyncStateRowItem key={s.table_name} row={s} />
+              ))}
+            </ul>
+          )}
+        </div>
+        <div>
+          <h4 className="text-sm font-semibold">
+            {t('sections.sinkronisasi.status.logTitle', { defaultValue: 'Riwayat (terbaru)' })}
+          </h4>
+          {status.log.length === 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t('sections.sinkronisasi.status.logEmpty', { defaultValue: 'Belum ada log.' })}
+            </p>
+          ) : (
+            <ul className="mt-2 max-h-44 space-y-1 overflow-y-auto pr-1 text-xs" data-testid="sync-status-log">
+              {status.log.map((entry) => (
+                <SyncLogItem key={entry.id} entry={entry} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SyncStateRowItem({ row }: { row: SyncStateRow }): JSX.Element {
+  const { t } = useTranslation('settings');
+  return (
+    <li className="rounded border border-border bg-background px-2 py-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono font-medium">{row.table_name}</span>
+        <span className="text-[10px] uppercase text-muted-foreground">
+          {row.rows_pushed} ↑ / {row.rows_pulled} ↓
+        </span>
+      </div>
+      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+        <span>
+          {t('sections.sinkronisasi.status.lastPush', { defaultValue: 'Last push' })}:{' '}
+          {formatTs(row.last_push_at)}
+        </span>
+        <span>
+          {t('sections.sinkronisasi.status.lastPull', { defaultValue: 'Last pull' })}:{' '}
+          {formatTs(row.last_pull_at)}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+function SyncLogItem({ entry }: { entry: SyncLogEntry }): JSX.Element {
+  const color =
+    entry.status === 'ok'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : entry.status === 'error'
+        ? 'text-red-600 dark:text-red-400'
+        : 'text-muted-foreground';
+  return (
+    <li className="rounded border border-border bg-background px-2 py-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] text-muted-foreground">{formatTs(entry.ts)}</span>
+        <span className={`text-[10px] font-semibold uppercase ${color}`}>
+          {entry.direction} · {entry.status}
+        </span>
+      </div>
+      <div className="text-[11px]">
+        <span className="font-mono">{entry.table_name}</span>
+        {entry.message ? <span className="text-muted-foreground"> — {entry.message}</span> : null}
+      </div>
+    </li>
+  );
+}
+
 /**
  * Inline how-to panel rendered below the form in Pengaturan -> Sinkronisasi.
  *
- * Walks the user through obtaining the two credentials the form asks for:
- * the Google Sheets Spreadsheet ID (from the sheet URL) and a Google Cloud
- * Console API key (with the Google Sheets API enabled). The same content
- * is mirrored in `docs/manual.md` so users who prefer reading the manual
- * book get the identical instructions.
+ * Walks the user through (1) creating a Google Cloud Service Account and
+ * downloading its JSON key, (2) sharing the spreadsheet with the SA email,
+ * and (3) pasting the JSON into the form. The same content is mirrored in
+ * `docs/manual.md` so users who prefer reading the manual book get the
+ * identical instructions.
  *
  * Kept as a static panel (no collapse) because the user explicitly asked
  * for the guide to live directly under the form, always visible. The
@@ -130,12 +551,12 @@ function SinkronisasiGuide(): JSX.Element {
       className="rounded-md border border-border bg-muted/30 p-4 text-sm"
     >
       <h3 className="text-base font-semibold">
-        {t(`${base}.title`, { defaultValue: 'Cara dapat ID Spreadsheet & API Key' })}
+        {t(`${base}.title`, { defaultValue: 'Cara siapkan Spreadsheet & Service Account' })}
       </h3>
       <p className="mt-1 text-muted-foreground">
         {t(`${base}.intro`, {
           defaultValue:
-            'Sinkronisasi memerlukan dua nilai: ID Spreadsheet dan API key dari Google Cloud Console.',
+            'Sinkronisasi memerlukan dua hal: ID Spreadsheet dan Service Account JSON dari Google Cloud Console.',
         })}
       </p>
 
@@ -168,31 +589,40 @@ function SinkronisasiGuide(): JSX.Element {
 
         <div>
           <h4 className="font-semibold">
-            {t(`${base}.apiKey.title`, { defaultValue: '2. API Key (Google Cloud Console)' })}
+            {t(`${base}.serviceAccount.title`, {
+              defaultValue: '2. Service Account (Google Cloud Console)',
+            })}
           </h4>
           <ol className="mt-2 list-decimal space-y-1 pl-5">
-            {renderStep('apiKey.step1', 'Buka Google Cloud Console.')}
-            {renderStep('apiKey.step2', 'Buat project baru atau pilih project yang ada.')}
-            {renderStep('apiKey.step3', 'Aktifkan Google Sheets API.')}
+            {renderStep('serviceAccount.step1', 'Buka Google Cloud Console.')}
+            {renderStep('serviceAccount.step2', 'Buat project baru atau pilih project yang ada.')}
+            {renderStep('serviceAccount.step3', 'Aktifkan Google Sheets API.')}
             {renderStep(
-              'apiKey.step4',
-              'Buka APIs & Services → Credentials → Create Credentials → API key.',
+              'serviceAccount.step4',
+              'Buka IAM & Admin → Service Accounts → Create Service Account.',
             )}
-            {renderStep('apiKey.step5', 'Copy nilai API key dan paste ke field API Key di atas.')}
             {renderStep(
-              'apiKey.step6',
-              'Disarankan: restrict key ke Google Sheets API saja.',
+              'serviceAccount.step5',
+              'Setelah dibuat, klik SA → Keys → Add Key → Create new key → JSON → Create.',
+            )}
+            {renderStep(
+              'serviceAccount.step6',
+              'Buka file JSON yang ter-download, copy seluruh isinya, lalu paste ke field Service Account JSON di atas.',
+            )}
+            {renderStep(
+              'serviceAccount.step7',
+              'Klik Simpan Service Account. Email service account akan muncul di kotak hijau.',
             )}
           </ol>
           <div className="mt-3 flex flex-wrap gap-2">
             <a
-              href="https://console.cloud.google.com/apis/credentials"
+              href="https://console.cloud.google.com/iam-admin/serviceaccounts"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-accent"
             >
               <ExternalLink className="h-3 w-3" />
-              {t(`${base}.openCloudConsole`, { defaultValue: 'Buka Google Cloud Console' })}
+              {t(`${base}.openServiceAccounts`, { defaultValue: 'Buka Service Accounts' })}
             </a>
             <a
               href="https://console.cloud.google.com/apis/library/sheets.googleapis.com"
@@ -208,19 +638,23 @@ function SinkronisasiGuide(): JSX.Element {
 
         <div>
           <h4 className="font-semibold">
-            {t(`${base}.sharing.title`, { defaultValue: '3. Setting Sharing Spreadsheet' })}
+            {t(`${base}.sharing.title`, { defaultValue: '3. Share Spreadsheet ke Service Account' })}
           </h4>
           <p className="mt-1 text-muted-foreground">
             {t(`${base}.sharing.intro`, {
               defaultValue:
-                'Karena sinkronisasi memakai API key, spreadsheet harus bisa-dibaca-publik:',
+                'Berbeda dari API key, Service Account butuh akses Editor pada spreadsheet supaya bisa write:',
             })}
           </p>
           <ol className="mt-2 list-decimal space-y-1 pl-5">
-            {renderStep('sharing.step1', 'Buka spreadsheet → klik Share.')}
-            {renderStep('sharing.step2', 'Pilih Anyone with the link.')}
-            {renderStep('sharing.step3', 'Set role ke Viewer (atau Editor).')}
-            {renderStep('sharing.step4', 'Klik Done.')}
+            {renderStep('sharing.step1', 'Buka spreadsheet → klik tombol Share.')}
+            {renderStep(
+              'sharing.step2',
+              'Paste email Service Account (xxx@<project>.iam.gserviceaccount.com).',
+            )}
+            {renderStep('sharing.step3', 'Pilih role Editor.')}
+            {renderStep('sharing.step4', 'Hilangkan centang "Notify people" (SA tidak punya inbox).')}
+            {renderStep('sharing.step5', 'Klik Share → Done.')}
           </ol>
         </div>
       </div>
@@ -228,7 +662,7 @@ function SinkronisasiGuide(): JSX.Element {
       <p className="mt-4 rounded border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700/40 dark:bg-amber-950/40 dark:text-amber-200">
         {t(`${base}.devNote`, {
           defaultValue:
-            'Catatan: backend sinkronisasi masih dalam tahap pengembangan. Nilai yang Anda simpan akan dipakai begitu sinkronisasi penuh dirilis.',
+            'Catatan: PR ini meng-cover push & pull untuk tabel Anggota. Tabel lain (buku, eksemplar, peminjaman, …) menyusul di rilis selanjutnya.',
         })}
       </p>
     </section>

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -175,14 +175,55 @@
         "enabled": "Enable sync",
         "spreadsheetId": "Spreadsheet ID",
         "apiKey": "API Key",
+        "serviceAccount": "Service Account JSON",
         "lastSync": "Last sync"
       },
       "syncNow": "Sync now",
       "syncSuccess": "Sync succeeded.",
       "syncError": "Sync failed.",
+      "actions": {
+        "test": "Test Connection",
+        "push": "Push Now",
+        "pull": "Pull Now",
+        "refresh": "Refresh status"
+      },
+      "serviceAccount": {
+        "savedTitle": "Service Account active",
+        "notConfigured": "No Service Account JSON yet. Paste the JSON from Google Cloud Console below and click Save.",
+        "save": "Save Service Account",
+        "saving": "Saving…",
+        "clear": "Clear Service Account",
+        "show": "Show",
+        "hide": "Hide",
+        "placeholder": "{ \"type\": \"service_account\", \"project_id\": \"...\", ... }",
+        "privacy": "The JSON is stored only on this computer; it is never sent to any server other than Google Sheets."
+      },
+      "toast": {
+        "saSaved": "Service Account JSON saved.",
+        "saCleared": "Service Account JSON cleared.",
+        "saSaveError": "Service Account JSON is invalid.",
+        "testOk": "Connected to Sheets.",
+        "testOkDesc": "Spreadsheet \"{{title}}\" • {{count}} tabs",
+        "testError": "Connection test failed.",
+        "pushOk": "Push complete: {{count}} rows.",
+        "pushError": "Push failed.",
+        "pullOk": "Pull complete: {{count}} rows.",
+        "pullError": "Pull failed."
+      },
+      "status": {
+        "title": "Sync Status",
+        "configured": "Spreadsheet ID and Service Account are configured.",
+        "notConfigured": "Not ready — set Spreadsheet ID and Service Account first.",
+        "tablesTitle": "Per-table",
+        "tablesEmpty": "No push/pull yet.",
+        "logTitle": "Recent activity",
+        "logEmpty": "No log entries yet.",
+        "lastPush": "Last push",
+        "lastPull": "Last pull"
+      },
       "guide": {
-        "title": "How to get Spreadsheet ID & API Key",
-        "intro": "Synchronization needs two values: the Spreadsheet ID of the Google Sheet you want to sync to, and a Google Cloud API key that can call the Google Sheets API. Follow these steps.",
+        "title": "How to set up the spreadsheet & Service Account",
+        "intro": "Synchronization needs two things: the Spreadsheet ID of the Google Sheet you want to sync to, and a Service Account JSON from Google Cloud Console that has been shared on the spreadsheet as Editor. Follow these steps.",
         "spreadsheetId": {
           "title": "1. Spreadsheet ID",
           "step1": "Open the Google Sheet you want to use (or create a new one at https://sheets.google.com).",
@@ -191,26 +232,29 @@
           "step3": "Copy the ID portion — the long token between /d/ and /edit. In the example above it is: 1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe.",
           "step4": "Paste it into the Spreadsheet ID field above."
         },
-        "apiKey": {
-          "title": "2. API Key (Google Cloud Console)",
+        "serviceAccount": {
+          "title": "2. Service Account (Google Cloud Console)",
           "step1": "Open the Google Cloud Console at https://console.cloud.google.com/. Sign in with the same Google account (free, no credit card required).",
           "step2": "Create a new project (or pick an existing one) from the project picker in the top-left.",
           "step3": "Enable the Google Sheets API: open https://console.cloud.google.com/apis/library/sheets.googleapis.com and click Enable.",
-          "step4": "Open APIs & Services → Credentials, then click Create Credentials → API key. A new key will appear.",
-          "step5": "Copy the API key value (it is a long string starting with AIza...) and paste it into the API Key field above.",
-          "step6": "Recommended: click the API key name, then under API restrictions choose Restrict key and check only Google Sheets API so the key cannot be misused."
+          "step4": "Open IAM & Admin → Service Accounts, click Create Service Account, give it a name (e.g. perpustakaan-sync), then Done.",
+          "step5": "After the Service Account is created, click it → Keys tab → Add Key → Create new key → JSON → Create. Your browser will download a JSON file.",
+          "step6": "Open the downloaded JSON in a text editor, copy the entire contents (from { to }), then paste into the Service Account JSON field above.",
+          "step7": "Click Save Service Account. The Service Account email will appear in the green box (its format is xxx@<project>.iam.gserviceaccount.com)."
         },
         "sharing": {
-          "title": "3. Spreadsheet sharing settings",
-          "intro": "Because synchronization uses an API key (not OAuth), the spreadsheet must be readable by anyone with the link so the API key can access it:",
+          "title": "3. Share the spreadsheet with the Service Account",
+          "intro": "Unlike API keys, Service Accounts need Editor access on the spreadsheet to be able to write (push). For pull-only use, Viewer is enough. Steps:",
           "step1": "Open the spreadsheet → click the Share button (top-right).",
-          "step2": "Under General access, pick Anyone with the link.",
-          "step3": "Set the role to Viewer (read only) — or Editor if the app needs to write back to the sheet.",
-          "step4": "Click Done. The spreadsheet is now reachable with your API key."
+          "step2": "Paste the Service Account email from the green box above (xxx@<project>.iam.gserviceaccount.com).",
+          "step3": "Pick the Editor role.",
+          "step4": "Uncheck \"Notify people\" — Service Accounts don't have an inbox.",
+          "step5": "Click Share, then Done. The spreadsheet is now writable by your Service Account."
         },
         "openCloudConsole": "Open Google Cloud Console",
+        "openServiceAccounts": "Open Service Accounts",
         "openSheetsApi": "Open Google Sheets API page",
-        "devNote": "Note: the synchronization backend is still under development. The Spreadsheet ID and API Key you save now will be stored locally and used automatically once full sync ships in a future release."
+        "devNote": "Note: this PR covers push & pull for the Anggota table. Other tables (buku, eksemplar, peminjaman, …) will follow in subsequent releases."
       }
     },
     "auditLog": {

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -175,14 +175,55 @@
         "enabled": "Aktifkan Sinkronisasi",
         "spreadsheetId": "ID Spreadsheet",
         "apiKey": "API Key",
+        "serviceAccount": "Service Account JSON",
         "lastSync": "Terakhir sinkron"
       },
       "syncNow": "Sinkron sekarang",
       "syncSuccess": "Sinkronisasi berhasil.",
       "syncError": "Sinkronisasi gagal.",
+      "actions": {
+        "test": "Tes Koneksi",
+        "push": "Push Sekarang",
+        "pull": "Pull Sekarang",
+        "refresh": "Refresh status"
+      },
+      "serviceAccount": {
+        "savedTitle": "Service Account aktif",
+        "notConfigured": "Belum ada Service Account JSON. Paste JSON dari Google Cloud Console di bawah lalu klik Simpan.",
+        "save": "Simpan Service Account",
+        "saving": "Menyimpan…",
+        "clear": "Hapus Service Account",
+        "show": "Tampilkan",
+        "hide": "Sembunyikan",
+        "placeholder": "{ \"type\": \"service_account\", \"project_id\": \"...\", ... }",
+        "privacy": "JSON hanya disimpan di komputer ini, tidak pernah dikirim ke server selain Google Sheets."
+      },
+      "toast": {
+        "saSaved": "Service Account JSON disimpan.",
+        "saCleared": "Service Account JSON dihapus.",
+        "saSaveError": "Service Account JSON tidak valid.",
+        "testOk": "Koneksi ke Sheets berhasil.",
+        "testOkDesc": "Spreadsheet \"{{title}}\" • {{count}} tab",
+        "testError": "Tes koneksi gagal.",
+        "pushOk": "Push selesai: {{count}} baris.",
+        "pushError": "Push gagal.",
+        "pullOk": "Pull selesai: {{count}} baris.",
+        "pullError": "Pull gagal."
+      },
+      "status": {
+        "title": "Status Sinkronisasi",
+        "configured": "Spreadsheet ID dan Service Account terkonfigurasi.",
+        "notConfigured": "Belum siap — lengkapi Spreadsheet ID dan Service Account.",
+        "tablesTitle": "Per-tabel",
+        "tablesEmpty": "Belum pernah push/pull.",
+        "logTitle": "Riwayat (terbaru)",
+        "logEmpty": "Belum ada log.",
+        "lastPush": "Last push",
+        "lastPull": "Last pull"
+      },
       "guide": {
-        "title": "Cara dapat ID Spreadsheet & API Key",
-        "intro": "Sinkronisasi memerlukan dua nilai: ID dari spreadsheet Google Sheets yang akan dipakai sebagai tujuan sinkron, dan API key dari Google Cloud Console yang punya izin akses Google Sheets API. Ikuti langkah berikut.",
+        "title": "Cara siapkan Spreadsheet & Service Account",
+        "intro": "Sinkronisasi memerlukan dua hal: ID dari spreadsheet Google Sheets yang akan dipakai sebagai tujuan sinkron, dan Service Account JSON dari Google Cloud Console yang sudah di-share ke spreadsheet tersebut sebagai Editor. Ikuti langkah berikut.",
         "spreadsheetId": {
           "title": "1. ID Spreadsheet",
           "step1": "Buka spreadsheet Google Sheets yang akan dipakai (atau buat baru di https://sheets.google.com).",
@@ -191,26 +232,29 @@
           "step3": "Copy bagian ID — yaitu teks panjang antara /d/ dan /edit. Pada contoh di atas: 1aBcDeFgHIjkLMNopQRstUvWxYz0123456789AbcDe.",
           "step4": "Paste ke field ID Spreadsheet di atas."
         },
-        "apiKey": {
-          "title": "2. API Key (Google Cloud Console)",
+        "serviceAccount": {
+          "title": "2. Service Account (Google Cloud Console)",
           "step1": "Buka Google Cloud Console: https://console.cloud.google.com/. Login dengan akun Google yang sama (gratis, tidak perlu kartu kredit).",
           "step2": "Buat project baru (atau pilih project yang ada) dari dropdown project di kiri atas.",
           "step3": "Aktifkan Google Sheets API: buka https://console.cloud.google.com/apis/library/sheets.googleapis.com lalu klik Enable.",
-          "step4": "Buka menu APIs & Services → Credentials, lalu klik Create Credentials → API key. Sebuah key baru akan muncul.",
-          "step5": "Copy nilai API key tersebut (formatnya panjang, dimulai dengan AIza...) dan paste ke field API Key di atas.",
-          "step6": "Disarankan: klik nama API key tadi, lalu di bagian API restrictions pilih Restrict key dan centang hanya Google Sheets API supaya key tidak disalahgunakan."
+          "step4": "Buka menu IAM & Admin → Service Accounts, klik Create Service Account, beri nama (mis. perpustakaan-sync), lalu Done.",
+          "step5": "Setelah Service Account terbuat, klik akun tersebut → tab Keys → Add Key → Create new key → JSON → Create. Browser akan men-download file JSON.",
+          "step6": "Buka file JSON yang ter-download dengan editor teks, copy seluruh isinya (mulai dari { sampai }), lalu paste ke field Service Account JSON di atas.",
+          "step7": "Klik tombol Simpan Service Account. Email Service Account akan muncul di kotak hijau (formatnya xxx@<project>.iam.gserviceaccount.com)."
         },
         "sharing": {
-          "title": "3. Setting Sharing Spreadsheet",
-          "intro": "Karena sinkronisasi memakai API key (bukan OAuth), spreadsheet harus dibuat bisa-dibaca-publik supaya API key bisa mengaksesnya:",
+          "title": "3. Share Spreadsheet ke Service Account",
+          "intro": "Berbeda dari API key, Service Account perlu akses Editor pada spreadsheet supaya bisa write (push). Kalau hanya pull, Viewer cukup. Ikuti langkah ini:",
           "step1": "Buka spreadsheet → klik tombol Share (kanan atas).",
-          "step2": "Di bagian General access, pilih Anyone with the link.",
-          "step3": "Set role ke Viewer (cukup baca) — atau Editor kalau aplikasi nantinya perlu menulis ke sheet.",
-          "step4": "Klik Done. Spreadsheet sekarang bisa diakses dengan API key Anda."
+          "step2": "Paste email Service Account dari kotak hijau di atas (xxx@<project>.iam.gserviceaccount.com).",
+          "step3": "Pilih role Editor.",
+          "step4": "Hilangkan centang \"Notify people\" — Service Account tidak punya inbox.",
+          "step5": "Klik Share lalu Done. Spreadsheet sekarang bisa di-write oleh Service Account Anda."
         },
         "openCloudConsole": "Buka Google Cloud Console",
+        "openServiceAccounts": "Buka Service Accounts",
         "openSheetsApi": "Buka halaman Google Sheets API",
-        "devNote": "Catatan: backend sinkronisasi masih dalam tahap pengembangan. Nilai ID Spreadsheet dan API Key yang Anda simpan saat ini akan disimpan secara lokal dan otomatis dipakai begitu sinkronisasi penuh dirilis di versi berikutnya."
+        "devNote": "Catatan: PR ini meng-cover push & pull untuk tabel Anggota. Tabel lain (buku, eksemplar, peminjaman, …) menyusul di rilis selanjutnya."
       }
     },
     "auditLog": {

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -72,8 +72,20 @@ export const DEFAULT_CLOSE_BEHAVIOR: CloseBehavior = 'exit';
 export interface SyncConfig {
   enabled: boolean;
   spreadsheetId: string;
+  /** Legacy v1.0.6 read-only API-key field. Kept for backwards compatibility
+   * but no longer used by the Tauri push/pull commands (which need a
+   * Service Account for write access). FEAT-26 v1.0.8 introduced
+   * `serviceAccountConfigured` instead — the JSON itself never round-trips
+   * through the renderer, only a boolean signalling whether one is saved. */
   apiKey: string;
   lastSync: string | null;
+  /** True when a Service Account JSON has been pasted+validated by the
+   * Tauri backend (`sync_save_service_account`). Used to gate Push/Pull
+   * buttons in Pengaturan → Sinkronisasi. */
+  serviceAccountConfigured: boolean;
+  /** Email of the configured Service Account (read-only display, derived
+   * from the saved JSON's `client_email` field). Empty when none saved. */
+  serviceAccountEmail: string;
 }
 
 export const DEFAULT_SYNC_CONFIG: SyncConfig = {
@@ -81,7 +93,55 @@ export const DEFAULT_SYNC_CONFIG: SyncConfig = {
   spreadsheetId: '',
   apiKey: '',
   lastSync: null,
+  serviceAccountConfigured: false,
+  serviceAccountEmail: '',
 };
+
+// FEAT-26 v1.0.8 — Sheets sync runtime types (status panel + run results).
+
+export interface SyncStateRow {
+  table_name: string;
+  last_push_at: string | null;
+  last_pull_at: string | null;
+  last_push_hash: string | null;
+  last_pull_hash: string | null;
+  rows_pushed: number;
+  rows_pulled: number;
+  updated_at: string;
+}
+
+export interface SyncLogEntry {
+  id: number;
+  ts: string;
+  direction: 'push' | 'pull' | 'test';
+  table_name: string;
+  status: 'ok' | 'error' | 'skipped' | 'noop';
+  rows_changed: number;
+  message: string | null;
+}
+
+export interface SyncStatusSnapshot {
+  configured: boolean;
+  enabled: boolean;
+  spreadsheet_id: string;
+  service_account_email: string;
+  states: SyncStateRow[];
+  log: SyncLogEntry[];
+}
+
+export interface SyncRunResult {
+  direction: 'push' | 'pull' | 'test';
+  rows_changed: number;
+  status: 'ok' | 'error' | 'skipped' | 'noop';
+  message: string;
+}
+
+export interface SyncTestResult {
+  ok: boolean;
+  spreadsheet_title: string;
+  tabs: string[];
+  service_account_email: string;
+}
 
 // ---------------------------------------------------------------------------
 // Users
@@ -301,6 +361,12 @@ export interface SettingsApi {
   saveSyncConfig(cfg: SyncConfig): Promise<SyncConfig>;
   resetSyncConfig(): Promise<SyncConfig>;
   syncNow(): Promise<SyncConfig>;
+  // FEAT-26 v1.0.8 — Service-Account-based bidirectional sync
+  saveServiceAccountJson(json: string): Promise<void>;
+  testSyncConnection(): Promise<SyncTestResult>;
+  pushSyncNow(): Promise<SyncRunResult[]>;
+  pullSyncNow(): Promise<SyncRunResult[]>;
+  getSyncStatus(): Promise<SyncStatusSnapshot>;
 
   listUsers(): Promise<UserRecord[]>;
   createUser(payload: UserInput): Promise<UserRecord>;
@@ -436,6 +502,55 @@ const mockApi: SettingsApi = {
     const updated = { ...cfg, lastSync: new Date().toISOString() };
     writeMock(MOCK_KEYS.sync, updated);
     return updated;
+  },
+  async saveServiceAccountJson(json) {
+    const cfg = await this.getSyncConfig();
+    writeMock(MOCK_KEYS.sync, {
+      ...cfg,
+      serviceAccountConfigured: json.trim().length > 0,
+      serviceAccountEmail: json.trim().length > 0 ? 'mock@example.iam.gserviceaccount.com' : '',
+    });
+  },
+  async testSyncConnection() {
+    return {
+      ok: true,
+      spreadsheet_title: 'Mock Sheet (browser fallback)',
+      tabs: ['anggota'],
+      service_account_email: 'mock@example.iam.gserviceaccount.com',
+    };
+  },
+  async pushSyncNow() {
+    const cfg = await this.getSyncConfig();
+    writeMock(MOCK_KEYS.sync, { ...cfg, lastSync: new Date().toISOString() });
+    return [
+      {
+        direction: 'push',
+        rows_changed: 0,
+        status: 'noop',
+        message: 'mock browser fallback — no real sync performed',
+      },
+    ];
+  },
+  async pullSyncNow() {
+    return [
+      {
+        direction: 'pull',
+        rows_changed: 0,
+        status: 'noop',
+        message: 'mock browser fallback — no real sync performed',
+      },
+    ];
+  },
+  async getSyncStatus() {
+    const cfg = await this.getSyncConfig();
+    return {
+      configured: cfg.serviceAccountConfigured && cfg.spreadsheetId.trim().length > 0,
+      enabled: cfg.enabled,
+      spreadsheet_id: cfg.spreadsheetId,
+      service_account_email: cfg.serviceAccountEmail,
+      states: [],
+      log: [],
+    };
   },
 
   async listUsers() {
@@ -635,11 +750,16 @@ const tauriApi: SettingsApi = {
     const rows = await invoke<Record<string, string>>('settings_get_many', {
       keys: ['sync.enabled', 'sync.spreadsheet_id', 'sync.api_key', 'sync.last_sync'],
     });
+    // FEAT-26: derive serviceAccount* from sync_status (single Tauri call)
+    // so the renderer never needs to round-trip the JSON itself.
+    const status = await invoke<SyncStatusSnapshot>('sync_status');
     return {
       enabled: rows['sync.enabled'] === '1',
       spreadsheetId: rows['sync.spreadsheet_id'] ?? '',
       apiKey: rows['sync.api_key'] ?? '',
       lastSync: rows['sync.last_sync'] || null,
+      serviceAccountConfigured: !!status.service_account_email,
+      serviceAccountEmail: status.service_account_email,
     };
   },
   async saveSyncConfig(cfg) {
@@ -660,6 +780,26 @@ const tauriApi: SettingsApi = {
   async syncNow() {
     const cfg = await tauriApi.getSyncConfig();
     return tauriApi.saveSyncConfig({ ...cfg, lastSync: new Date().toISOString() });
+  },
+  async saveServiceAccountJson(json) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('sync_save_service_account', { json });
+  },
+  async testSyncConnection() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<SyncTestResult>('sync_test_connection');
+  },
+  async pushSyncNow() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<SyncRunResult[]>('sync_push_now');
+  },
+  async pullSyncNow() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<SyncRunResult[]>('sync_pull_now');
+  },
+  async getSyncStatus() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke<SyncStatusSnapshot>('sync_status');
   },
 
   async listUsers() {
@@ -730,6 +870,11 @@ export const settingsApi: SettingsApi = {
   saveSyncConfig: (cfg) => rpc().saveSyncConfig(cfg),
   resetSyncConfig: () => rpc().resetSyncConfig(),
   syncNow: () => rpc().syncNow(),
+  saveServiceAccountJson: (json) => rpc().saveServiceAccountJson(json),
+  testSyncConnection: () => rpc().testSyncConnection(),
+  pushSyncNow: () => rpc().pushSyncNow(),
+  pullSyncNow: () => rpc().pullSyncNow(),
+  getSyncStatus: () => rpc().getSyncStatus(),
   listUsers: () => rpc().listUsers(),
   createUser: (payload) => rpc().createUser(payload),
   updateUser: (id, payload) => rpc().updateUser(id, payload),

--- a/apps/desktop/tests/unit/sinkronisasiPage.test.tsx
+++ b/apps/desktop/tests/unit/sinkronisasiPage.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the FEAT-26 v1.0.8 PR G Sinkronisasi page (Service Account JSON
+ * paste + Test Connection / Push Now / Pull Now buttons + status panel).
+ *
+ * The Tauri RPC layer (`settingsApi`) is mocked via `vi.mock` so these tests
+ * stay pure-frontend; the Rust orchestration is covered in
+ * `apps/desktop/src-tauri/src/commands/sync/*` unit tests.
+ */
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider } from 'react-i18next';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import { ToastProvider, ToastViewport } from '@/components/ui/toast';
+import { ToastManagerProvider } from '@/components/ui/toast-manager';
+import idSettings from '@/i18n/id/settings.json';
+import {
+  DEFAULT_SYNC_CONFIG,
+  type SyncConfig,
+  type SyncStatusSnapshot,
+  type SyncRunResult,
+  type SyncTestResult,
+} from '@/lib/settings';
+
+// We mock the entire settingsApi facade because SinkronisasiPage only uses
+// six methods on it. Returning typed promises from each gives the test
+// realistic timing (loading states, toasts, etc.) without touching Tauri.
+const mockState: {
+  cfg: SyncConfig;
+  status: SyncStatusSnapshot;
+  saved: string[];
+  testResult: SyncTestResult;
+  pushResult: SyncRunResult[];
+  pullResult: SyncRunResult[];
+  shouldFailTest: boolean;
+} = {
+  cfg: { ...DEFAULT_SYNC_CONFIG },
+  status: {
+    configured: false,
+    enabled: false,
+    spreadsheet_id: '',
+    service_account_email: '',
+    states: [],
+    log: [],
+  },
+  saved: [],
+  testResult: {
+    ok: true,
+    spreadsheet_title: 'Demo',
+    tabs: ['anggota'],
+    service_account_email: 'sa@demo.iam.gserviceaccount.com',
+  },
+  pushResult: [{ direction: 'push', rows_changed: 0, status: 'noop', message: '' }],
+  pullResult: [{ direction: 'pull', rows_changed: 0, status: 'ok', message: '' }],
+  shouldFailTest: false,
+};
+
+vi.mock('@/lib/settings', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/settings')>('@/lib/settings');
+  return {
+    ...actual,
+    settingsApi: {
+      ...actual.settingsApi,
+      getSyncConfig: vi.fn(async () => mockState.cfg),
+      saveSyncConfig: vi.fn(async (cfg: SyncConfig) => {
+        mockState.cfg = cfg;
+        return cfg;
+      }),
+      resetSyncConfig: vi.fn(async () => {
+        mockState.cfg = { ...DEFAULT_SYNC_CONFIG };
+        return mockState.cfg;
+      }),
+      saveServiceAccountJson: vi.fn(async (json: string) => {
+        mockState.saved.push(json);
+        const trimmed = json.trim();
+        mockState.cfg = {
+          ...mockState.cfg,
+          serviceAccountConfigured: trimmed.length > 0,
+          serviceAccountEmail: trimmed.length > 0 ? 'sa@demo.iam.gserviceaccount.com' : '',
+        };
+        mockState.status = {
+          ...mockState.status,
+          service_account_email: mockState.cfg.serviceAccountEmail,
+        };
+      }),
+      testSyncConnection: vi.fn(async () => {
+        if (mockState.shouldFailTest) throw new Error('boom');
+        return mockState.testResult;
+      }),
+      pushSyncNow: vi.fn(async () => mockState.pushResult),
+      pullSyncNow: vi.fn(async () => mockState.pullResult),
+      getSyncStatus: vi.fn(async () => mockState.status),
+    },
+  };
+});
+
+beforeEach(async () => {
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'id',
+      fallbackLng: 'id',
+      resources: { id: { settings: idSettings } },
+      interpolation: { escapeValue: false },
+    });
+  }
+  // reset mock state between tests
+  mockState.cfg = { ...DEFAULT_SYNC_CONFIG };
+  mockState.status = {
+    configured: false,
+    enabled: false,
+    spreadsheet_id: '',
+    service_account_email: '',
+    states: [],
+    log: [],
+  };
+  mockState.saved = [];
+  mockState.shouldFailTest = false;
+  mockState.pushResult = [
+    { direction: 'push', rows_changed: 0, status: 'noop', message: '' },
+  ];
+  mockState.pullResult = [
+    { direction: 'pull', rows_changed: 0, status: 'ok', message: '' },
+  ];
+});
+
+async function renderPage(): Promise<void> {
+  const { SinkronisasiPage } = await import('@/features/settings/SinkronisasiPage');
+  render(
+    <I18nextProvider i18n={i18n}>
+      <ToastProvider>
+        <ToastManagerProvider>
+          <SinkronisasiPage />
+          <ToastViewport />
+        </ToastManagerProvider>
+      </ToastProvider>
+    </I18nextProvider>,
+  );
+}
+
+describe('SinkronisasiPage', () => {
+  it('renders the not-configured banner before any Service Account is saved', async () => {
+    await renderPage();
+    expect(
+      await screen.findByText(/Belum ada Service Account JSON/i),
+    ).toBeInTheDocument();
+  });
+
+  it('disables Test/Push/Pull buttons until both sync is enabled and SA + spreadsheet ID are set', async () => {
+    await renderPage();
+    const testBtn = await screen.findByTestId('sync-test-connection');
+    const pushBtn = await screen.findByTestId('sync-push-now');
+    const pullBtn = await screen.findByTestId('sync-pull-now');
+    expect(testBtn).toBeDisabled();
+    expect(pushBtn).toBeDisabled();
+    expect(pullBtn).toBeDisabled();
+  });
+
+  it('saves the Service Account JSON via saveServiceAccountJson and surfaces the SA email banner', async () => {
+    await renderPage();
+    const user = userEvent.setup();
+    const ta = await screen.findByTestId('sync-sa-json');
+    await user.type(ta, '{{ "type": "service_account" }');
+    const save = screen.getByTestId('sync-sa-save');
+    await user.click(save);
+    await waitFor(() => {
+      expect(mockState.saved.length).toBe(1);
+    });
+    expect((mockState.saved[0] ?? '').trim().length).toBeGreaterThan(0);
+    expect(
+      await screen.findByText(/Service Account aktif/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/sa@demo\.iam\.gserviceaccount\.com/)).toBeInTheDocument();
+  });
+
+  it('enables Test/Push/Pull once SA is configured + spreadsheet ID set + sync enabled', async () => {
+    mockState.cfg = {
+      ...DEFAULT_SYNC_CONFIG,
+      enabled: true,
+      spreadsheetId: '1aBcD',
+      serviceAccountConfigured: true,
+      serviceAccountEmail: 'sa@demo.iam.gserviceaccount.com',
+    };
+    mockState.status = {
+      configured: true,
+      enabled: true,
+      spreadsheet_id: '1aBcD',
+      service_account_email: 'sa@demo.iam.gserviceaccount.com',
+      states: [],
+      log: [],
+    };
+    await renderPage();
+    const testBtn = await screen.findByTestId('sync-test-connection');
+    await waitFor(() => {
+      expect(testBtn).toBeEnabled();
+    });
+    expect(screen.getByTestId('sync-push-now')).toBeEnabled();
+    expect(screen.getByTestId('sync-pull-now')).toBeEnabled();
+  });
+
+  it('shows a success toast and refreshes status after a successful Test Connection', async () => {
+    mockState.cfg = {
+      ...DEFAULT_SYNC_CONFIG,
+      enabled: true,
+      spreadsheetId: '1aBcD',
+      serviceAccountConfigured: true,
+      serviceAccountEmail: 'sa@demo.iam.gserviceaccount.com',
+    };
+    mockState.status = {
+      configured: true,
+      enabled: true,
+      spreadsheet_id: '1aBcD',
+      service_account_email: 'sa@demo.iam.gserviceaccount.com',
+      states: [],
+      log: [],
+    };
+    await renderPage();
+    const user = userEvent.setup();
+    const testBtn = await screen.findByTestId('sync-test-connection');
+    await waitFor(() => expect(testBtn).toBeEnabled());
+    await user.click(testBtn);
+    expect(
+      await screen.findByText(/Koneksi ke Sheets berhasil/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders an error toast when Test Connection rejects', async () => {
+    mockState.cfg = {
+      ...DEFAULT_SYNC_CONFIG,
+      enabled: true,
+      spreadsheetId: '1aBcD',
+      serviceAccountConfigured: true,
+      serviceAccountEmail: 'sa@demo.iam.gserviceaccount.com',
+    };
+    mockState.status = {
+      configured: true,
+      enabled: true,
+      spreadsheet_id: '1aBcD',
+      service_account_email: 'sa@demo.iam.gserviceaccount.com',
+      states: [],
+      log: [],
+    };
+    mockState.shouldFailTest = true;
+    await renderPage();
+    const user = userEvent.setup();
+    const testBtn = await screen.findByTestId('sync-test-connection');
+    await waitFor(() => expect(testBtn).toBeEnabled());
+    await user.click(testBtn);
+    expect(await screen.findByText(/Tes koneksi gagal/i)).toBeInTheDocument();
+  });
+
+  it('renders the inline guide section with all three step headings', async () => {
+    await renderPage();
+    expect(await screen.findByTestId('sinkronisasi-guide')).toBeInTheDocument();
+    expect(screen.getByText(/1\. ID Spreadsheet/i)).toBeInTheDocument();
+    expect(screen.getByText(/2\. Service Account/i)).toBeInTheDocument();
+    expect(screen.getByText(/3\. Share Spreadsheet/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

First MVP slice of FEAT-26 (Google Sheets bidirectional sync) — PR G of the v1.0.8 batch. Replaces the v1.0.6 placeholder Sinkronisasi page (read-only API key) with a functional **Service Account–based push & pull flow for the `anggota` table**. Other tables (buku, eksemplar, peminjaman, …) follow in G2/G3.

### Backend (`apps/desktop/src-tauri`)

- New `commands::sync` module split into focused files:
  - `auth.rs` — parse + validate Service Account JSON, sign RS256 JWT, exchange for OAuth2 access token, in-memory cache with 5-minute safety margin
  - `client.rs` — hand-rolled Sheets v4 REST wrapper (`get_spreadsheet`, `get_values`, `clear_values`, `update_values`, `ensure_tab`) — ~270 LOC instead of pulling ~30 MB of generated bindings
  - `mapper.rs` — `AnggotaRow` encoder/decoder for Sheets ↔ SQLite roundtrip, `upsert_anggota` with last-write-wins on `updated_at`
  - `state.rs` — `sync_state` + `sync_log` CRUD + SHA-256 row-content hashing for push short-circuit; log auto-pruned to newest 100 entries
  - `mod.rs` — five Tauri commands: `sync_test_connection` / `sync_push_now` / `sync_pull_now` / `sync_status` / `sync_save_service_account`
- Additive schema migration: `sync_state` + `sync_log` tables (no impact on existing data)
- New deps: `reqwest` (rustls-tls), `jsonwebtoken`, `tokio` (sync feature)

### Frontend (`apps/desktop/src`)

- `features/settings/SinkronisasiPage` rewritten:
  - Service Account JSON textarea with **Save** / **Clear** / Show-Hide
  - **Test Connection** / **Push Now** / **Pull Now** action buttons (gated on configured + enabled)
  - Live status panel (per-table last push/pull timestamps + recent log)
  - Updated inline guide explaining the Service Account flow + how to share the spreadsheet
- `lib/settings.ts` extended with `SyncStatusSnapshot` / `SyncRunResult` / `SyncTestResult` types and 5 new RPC methods
- i18n parity (id + en) for ~40 new keys; legacy `apiKey` field kept for backward compatibility

### Tests

- **35 new Rust unit tests** (auth JWT signing, client urlencode, mapper roundtrip + upsert, state CRUD + hashing) — total 163 (was 128)
- **7 new vitest tests** for `SinkronisasiPage` (RPC mocked, ToastViewport asserted) — total 279 (was 272)

### Gates (all green locally)

- `pnpm typecheck`
- `pnpm lint` (eslint --max-warnings=0)
- `pnpm i18n:lint` (id ↔ en parity OK)
- `pnpm test` (vitest 279 passed)
- `pnpm build` (vite build OK)
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (163 passed)

## Review & Testing Checklist for Human

This is XL scope (multi-day work) but has tight unit test coverage and the surface area is well-isolated to the new `commands::sync` module. Risk level: **yellow** (no breaking changes to existing schema, but introduces network access via Sheets API). 3 items recommended:

- [ ] **Smoke test the happy path end-to-end**: in Pengaturan → Sinkronisasi, paste a Service Account JSON, set the Spreadsheet ID, click **Tes Koneksi**, then **Push Sekarang**, then verify in Google Sheets that the `anggota` tab matches the local db. Then edit a row in Sheets and click **Pull Sekarang** — local db should update with last-write-wins on `updated_at`.
- [ ] **Negative paths**: try saving an invalid SA JSON (missing field, non-PEM private key, non-`service_account` type) — should show the destructive toast with a clear error message. Try Test Connection with a Spreadsheet the SA is NOT shared on — should show "Tes koneksi gagal" toast.
- [ ] **Conflict resolution**: edit the same row simultaneously in local app and in Google Sheets, then push and pull — verify the side with the newer `updated_at` wins, and the loser is logged to `sync_log`.

### Notes

- This MVP only covers the `anggota` table. Other tables, the auto-scheduler tokio task, and a richer conflict-resolver UI are deferred to G2 / G3 follow-ups.
- Token cache is in-memory only — restarting the app re-signs a fresh JWT on next sync. This is intentional (the SA private key never crosses the renderer boundary).
- Sheets API quotas: free tier is 60 reads/min and 60 writes/min per user. Push uses content-hash short-circuit so unchanged data costs 0 writes; pull always reads the full tab (cheap because anggota is typically <1000 rows).
- Privacy: the SA JSON is stored in the `app_settings` table on disk only; it never leaves the device except as the `Authorization: Bearer` header to `oauth2.googleapis.com` and `sheets.googleapis.com`. This is documented in the inline UI guide.
- The legacy `sync.api_key` field is kept (read-only) for backward compatibility with v1.0.6 saved settings — it is no longer used by any push/pull path.
