### PR TITLE
feat(sirkulasi): scanner overlay + ROI + multi-format + manual scan (FEAT-28, PR J)

### DIFF
--- a/apps/desktop/src/features/sirkulasi/ScannerOverlay.tsx
+++ b/apps/desktop/src/features/sirkulasi/ScannerOverlay.tsx
@@ -1,0 +1,86 @@
+/**
+ * Visual aiming overlay for the Sirkulasi webcam scanner (FEAT-28).
+ *
+ * Renders absolutely-positioned guides on top of the `<video>` element
+ * so the operator knows where to place the barcode. Pure presentational
+ * component — the actual decoder pipeline crops frames to the same
+ * region using `computeRoi(...)` from `lib/scanner/overlay`.
+ *
+ * Layout breakdown:
+ *
+ * - Outer dim mask: a single absolute box sized to the ROI with a huge
+ *   `box-shadow` spread that paints the surrounding pixels at 50%
+ *   black. Cheaper than 4 separate edge boxes and resizes naturally
+ *   when the video aspect ratio changes.
+ * - Corner brackets: 4 absolute boxes at the rectangle corners, each
+ *   with two visible borders (e.g. top-left = top + left). Pure CSS,
+ *   no SVG, scales with the container.
+ * - Scanning line: thin red horizontal bar animated up-and-down via
+ *   the `animate-scanner-line` Tailwind keyframe.
+ * - Hint label: short instruction text floats just above the box.
+ */
+import { ROI_PERCENT } from '@/lib/scanner/overlay';
+
+export interface ScannerOverlayProps {
+  /** Hint text shown just above the rectangle. */
+  label: string;
+  /**
+   * When true, the small "Memindai…" badge is shown next to the label.
+   * Used during a manual scan attempt for feedback.
+   */
+  busy?: boolean;
+  /** Optional badge text shown alongside the label (e.g. busy spinner). */
+  busyLabel?: string;
+}
+
+export function ScannerOverlay({
+  label,
+  busy = false,
+  busyLabel,
+}: ScannerOverlayProps) {
+  // Convert 0..1 fractions to CSS percentages so the overlay stays in
+  // sync with the decoder's pixel-space ROI even when the video
+  // element is resized by Tailwind's responsive utilities.
+  const left = `${((1 - ROI_PERCENT.width) / 2) * 100}%`;
+  const top = `${((1 - ROI_PERCENT.height) / 2) * 100}%`;
+  const width = `${ROI_PERCENT.width * 100}%`;
+  const height = `${ROI_PERCENT.height * 100}%`;
+
+  return (
+    <div className="pointer-events-none absolute inset-0" data-testid="scanner-overlay">
+      {/* Dim mask outside the ROI rectangle. */}
+      <div
+        className="absolute"
+        style={{
+          left,
+          top,
+          width,
+          height,
+          boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.45)',
+        }}
+      />
+      {/* ROI frame holding the corner brackets and scanning line. */}
+      <div className="absolute" style={{ left, top, width, height }}>
+        {/* Corner brackets — two perpendicular borders per corner. */}
+        <span className="absolute left-0 top-0 h-4 w-4 border-l-2 border-t-2 border-white/85" />
+        <span className="absolute right-0 top-0 h-4 w-4 border-r-2 border-t-2 border-white/85" />
+        <span className="absolute bottom-0 left-0 h-4 w-4 border-b-2 border-l-2 border-white/85" />
+        <span className="absolute bottom-0 right-0 h-4 w-4 border-b-2 border-r-2 border-white/85" />
+        {/* Animated scanning line — purely cosmetic, signals "active". */}
+        <span className="absolute inset-x-3 top-1/2 h-0.5 animate-scanner-line bg-red-500/80 shadow-[0_0_4px_rgba(239,68,68,0.6)]" />
+      </div>
+      {/* Hint label above the rectangle. */}
+      <div
+        className="absolute left-0 right-0 flex justify-center"
+        style={{ top: `calc(${top} - 1.75rem)` }}
+      >
+        <span className="rounded bg-black/60 px-2 py-1 text-xs text-white">
+          {label}
+          {busy && busyLabel ? (
+            <span className="ml-2 inline-flex items-center text-white/80">{busyLabel}</span>
+          ) : null}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
+++ b/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
@@ -18,6 +18,9 @@ import { Link } from '@tanstack/react-router';
 import {
   CameraOff,
   CheckCircle2,
+  Flashlight,
+  FlashlightOff,
+  Focus,
   Keyboard,
   Loader2,
   RefreshCw,
@@ -51,6 +54,7 @@ import {
 } from '@/lib/peminjaman';
 import { formatTauriError } from '@/lib/errors';
 import { useBarcodeScanner } from './useBarcodeScanner';
+import { ScannerOverlay } from './ScannerOverlay';
 
 type Mode = 'pinjam' | 'kembalikan';
 
@@ -265,6 +269,63 @@ export function SirkulasiPage() {
       void handleScan(text);
     },
   });
+  const [scanningOnce, setScanningOnce] = useState(false);
+
+  /**
+   * Handler for the manual "Scan Sekarang" button. Captures the current
+   * frame, crops to ROI, and runs the 3-pass preprocess pipeline.
+   * Toasts the outcome and feeds successful hits through the same
+   * `handleScan` pipeline as continuous decode (so anggota / eksemplar
+   * dispatch is identical).
+   */
+  const onClickScanOnce = async (): Promise<void> => {
+    if (scanningOnce) return;
+    setScanningOnce(true);
+    try {
+      const result = await scanner.decodeOnce();
+      if (result) {
+        showToast({
+          title: t('sirkulasi:scanner.scanSuccess', {
+            defaultValue: 'Berhasil: {{code}}',
+            code: result.text,
+          }),
+        });
+        void handleScan(result.text);
+      } else {
+        showToast({
+          variant: 'destructive',
+          title: t('sirkulasi:scanner.scanFail', {
+            defaultValue:
+              'Tidak terdeteksi — coba ulangi atau ketik manual.',
+          }),
+        });
+      }
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('sirkulasi:scanner.scanError', {
+          defaultValue: 'Gagal melakukan scan',
+        }),
+        description: formatTauriError(err),
+      });
+    } finally {
+      setScanningOnce(false);
+    }
+  };
+
+  const onClickToggleTorch = async (): Promise<void> => {
+    try {
+      await scanner.toggleTorch();
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('sirkulasi:scanner.torchError', {
+          defaultValue: 'Senter tidak dapat diaktifkan',
+        }),
+        description: formatTauriError(err),
+      });
+    }
+  };
 
   const onSubmitManual = (e: React.FormEvent): void => {
     e.preventDefault();
@@ -468,6 +529,21 @@ export function SirkulasiPage() {
                 muted
                 playsInline
               />
+              {scanner.active && (
+                <ScannerOverlay
+                  label={t('sirkulasi:scanner.overlayLabel', {
+                    defaultValue: 'Arahkan barcode ke dalam kotak',
+                  })}
+                  busy={scanningOnce}
+                  busyLabel={
+                    scanningOnce
+                      ? t('sirkulasi:scanner.scanning', {
+                          defaultValue: 'Memindai…',
+                        })
+                      : undefined
+                  }
+                />
+              )}
               {!scanner.active && (
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 text-white">
                   <CameraOff className="h-10 w-10 opacity-70" />
@@ -483,6 +559,52 @@ export function SirkulasiPage() {
                 </div>
               )}
             </div>
+
+            {scanner.active && (
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="default"
+                  size="sm"
+                  onClick={() => {
+                    void onClickScanOnce();
+                  }}
+                  disabled={scanningOnce}
+                >
+                  {scanningOnce ? (
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Focus className="mr-1.5 h-4 w-4" />
+                  )}
+                  {t('sirkulasi:scanner.scanNow', {
+                    defaultValue: 'Scan Sekarang',
+                  })}
+                </Button>
+                {scanner.torchSupported && (
+                  <Button
+                    type="button"
+                    variant={scanner.torchOn ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => {
+                      void onClickToggleTorch();
+                    }}
+                  >
+                    {scanner.torchOn ? (
+                      <Flashlight className="mr-1.5 h-4 w-4" />
+                    ) : (
+                      <FlashlightOff className="mr-1.5 h-4 w-4" />
+                    )}
+                    {scanner.torchOn
+                      ? t('sirkulasi:scanner.torchOn', {
+                          defaultValue: 'Senter aktif',
+                        })
+                      : t('sirkulasi:scanner.torchOff', {
+                          defaultValue: 'Nyalakan senter',
+                        })}
+                  </Button>
+                )}
+              </div>
+            )}
 
             <div className="flex flex-wrap items-center gap-2">
               {scanner.active ? (

--- a/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
+++ b/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
@@ -1,5 +1,5 @@
 /**
- * Webcam barcode scanner hook (v1.0.6 #19).
+ * Webcam barcode scanner hook (FEAT-28 PR J).
  *
  * Wraps `@zxing/browser` to drive a `<video>` element and emit decoded
  * results into a callback. The hook keeps the controls handle around so it
@@ -7,16 +7,28 @@
  * scanning off — leaking a MediaStream would prevent other apps (and Tauri
  * webview tabs) from accessing the webcam.
  *
- * Decoder format hints are intentionally narrow: the app only emits
- * Code-128 barcodes for `kode_eksemplar`/`kode_anggota` (see
- * `apps/desktop/src/features/label-buku/print.ts` and the KTA renderer)
- * and QR codes for some KTA presets, so we tell zxing to skip every other
- * format. Skipping unused formats noticeably reduces CPU usage on the
- * hot decode path that runs every frame.
+ * v1.0.8 additions on top of the v1.0.6/v1.0.7 baseline:
+ *
+ * - Multi-format hint set widened to include Data Matrix (in addition
+ *   to Code-128, Code-39, EAN-13, EAN-8, QR Code) — see
+ *   `lib/scanner/decoder.ts`.
+ * - Manual single-shot decode (`decodeOnce`) used by the
+ *   "Scan Sekarang" button on `SirkulasiPage`. Crops the current
+ *   video frame to the ROI overlay and runs up to 3 preprocess
+ *   variants (normal → contrast → grayscale) before giving up.
+ * - Torch toggle (`toggleTorch`, `torchSupported`, `torchOn`) for
+ *   browsers/cameras that expose a `torch` track capability.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { BrowserMultiFormatReader, type IScannerControls } from '@zxing/browser';
-import { BarcodeFormat, DecodeHintType, type Result } from '@zxing/library';
+import { type Result } from '@zxing/library';
+import { computeRoi } from '@/lib/scanner/overlay';
+import {
+  buildDecodeHints,
+  createImageDataReader,
+  decodeWithRetry,
+  type DecodedResult,
+} from '@/lib/scanner/decoder';
 
 export interface UseBarcodeScannerOptions {
   onDecode: (text: string) => void;
@@ -53,6 +65,23 @@ export interface UseBarcodeScannerResult {
   /** Currently selected `deviceId`. Falls back to the first device. */
   selectedDeviceId: string | null;
   selectDevice: (deviceId: string) => void;
+  /**
+   * One-shot manual decode — capture the current frame, crop to ROI,
+   * try up to 3 preprocess variants. Returns `null` if nothing decodes.
+   *
+   * Useful when continuous decode keeps missing under tricky lighting.
+   * Triggered by the "Scan Sekarang" button on the Sirkulasi page.
+   */
+  decodeOnce: () => Promise<DecodedResult | null>;
+  /** True if the current camera track exposes a `torch` capability. */
+  torchSupported: boolean;
+  /** True if the torch is currently on. */
+  torchOn: boolean;
+  /**
+   * Toggle the camera torch. Resolves once the constraint has been
+   * applied; rejects if the track no longer exists.
+   */
+  toggleTorch: () => Promise<void>;
 }
 
 /**
@@ -87,18 +116,22 @@ export function classifyScannerError(e: unknown): ScannerErrorKind {
   return 'other';
 }
 
-const HINTS = (() => {
-  const m = new Map<DecodeHintType, unknown>();
-  m.set(DecodeHintType.POSSIBLE_FORMATS, [
-    BarcodeFormat.CODE_128,
-    BarcodeFormat.CODE_39,
-    BarcodeFormat.EAN_13,
-    BarcodeFormat.EAN_8,
-    BarcodeFormat.QR_CODE,
-  ]);
-  m.set(DecodeHintType.TRY_HARDER, true);
-  return m;
-})();
+/**
+ * Detect the `torch` capability on a track. Spec-defined under
+ * MediaTrackCapabilities but TypeScript's lib doesn't include it
+ * (Chromium-only at time of writing), so we duck-type.
+ */
+function trackHasTorch(track: MediaStreamTrack): boolean {
+  // `getCapabilities` is not supported on every browser — Safari before
+  // 17 returns nothing, Firefox doesn't expose the torch hint at all.
+  type Cap = { torch?: boolean };
+  const caps =
+    typeof (track as unknown as { getCapabilities?: () => Cap }).getCapabilities ===
+    'function'
+      ? ((track as unknown as { getCapabilities: () => Cap }).getCapabilities() ?? {})
+      : {};
+  return caps.torch === true;
+}
 
 export function useBarcodeScanner(
   options: UseBarcodeScannerOptions,
@@ -107,6 +140,7 @@ export function useBarcodeScanner(
   const videoRef = useRef<HTMLVideoElement>(null);
   const readerRef = useRef<BrowserMultiFormatReader | null>(null);
   const controlsRef = useRef<IScannerControls | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
   const lastDecodedRef = useRef<{ text: string; at: number } | null>(null);
   // Always read the latest callback inside the decode handler so callers
   // don't have to memoise it on every render.
@@ -121,12 +155,20 @@ export function useBarcodeScanner(
   const [errorKind, setErrorKind] = useState<ScannerErrorKind | null>(null);
   const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [torchSupported, setTorchSupported] = useState(false);
+  const [torchOn, setTorchOn] = useState(false);
 
   /** Stop and release the active camera, if any. */
   const stop = useCallback(() => {
     controlsRef.current?.stop();
     controlsRef.current = null;
+    // controls.stop() releases the tracks zxing owns, but if we held a
+    // separate reference (for torch) clear it so React doesn't think
+    // torch is still controllable on a dead track.
+    streamRef.current = null;
     setActive(false);
+    setTorchSupported(false);
+    setTorchOn(false);
   }, []);
 
   const start = useCallback(async (): Promise<void> => {
@@ -152,7 +194,7 @@ export function useBarcodeScanner(
       setSelectedDeviceId(preferred);
 
       if (!readerRef.current) {
-        readerRef.current = new BrowserMultiFormatReader(HINTS);
+        readerRef.current = new BrowserMultiFormatReader(buildDecodeHints());
       }
       const reader = readerRef.current;
       const video = videoRef.current;
@@ -163,13 +205,9 @@ export function useBarcodeScanner(
       // Ask the browser for a higher-resolution stream than the zxing
       // default (which falls back to roughly 640×480 on most webcams).
       // Code-128 barcodes printed at A4-label scale are too small for
-      // 480p to decode reliably — the user reports having to hold the
-      // book very close to the lens before the scan registers (BUG-18).
-      // 1280×720 doubles the linear pixel budget, restores reliable
-      // decoding at a normal arm's-length distance, and is supported by
-      // virtually every laptop/USB webcam on the market. The browser
-      // is free to fall back to the next-best size if 720p is not
-      // available — `ideal` is a soft constraint, not `exact`.
+      // 480p to decode reliably (BUG-18). 1280×720 doubles the linear
+      // pixel budget. The browser is free to fall back to the next-best
+      // size if 720p is not available — `ideal` is a soft constraint.
       const videoConstraints: MediaTrackConstraints = preferred
         ? {
             deviceId: { exact: preferred },
@@ -213,6 +251,16 @@ export function useBarcodeScanner(
         // ignore secondary enumeration errors
       }
 
+      // After zxing has wired the stream into the video element, the
+      // `srcObject` is the live MediaStream — use it to detect torch
+      // capability and to apply the torch constraint when the user
+      // toggles it.
+      const stream = (video.srcObject as MediaStream | null) ?? null;
+      streamRef.current = stream;
+      const track = stream?.getVideoTracks()[0];
+      setTorchSupported(track ? trackHasTorch(track) : false);
+      setTorchOn(false);
+
       setActive(true);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -240,6 +288,45 @@ export function useBarcodeScanner(
     [active, stop, start],
   );
 
+  const decodeOnce = useCallback(async (): Promise<DecodedResult | null> => {
+    const video = videoRef.current;
+    if (!video || video.readyState < 2) return null;
+    const w = video.videoWidth;
+    const h = video.videoHeight;
+    if (!w || !h) return null;
+
+    // Crop to the same ROI rectangle the overlay renders. Decoding
+    // only this region speeds the manual scan up (~4× fewer pixels)
+    // and removes the cluttered background that otherwise confuses
+    // zxing's binarizer.
+    const roi = computeRoi(w, h);
+    if (roi.width <= 0 || roi.height <= 0) return null;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = roi.width;
+    canvas.height = roi.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    ctx.drawImage(video, roi.x, roi.y, roi.width, roi.height, 0, 0, roi.width, roi.height);
+    const imageData = ctx.getImageData(0, 0, roi.width, roi.height);
+
+    const reader = createImageDataReader();
+    return decodeWithRetry(reader, imageData);
+  }, []);
+
+  const toggleTorch = useCallback(async (): Promise<void> => {
+    const stream = streamRef.current;
+    const track = stream?.getVideoTracks()[0];
+    if (!track) return;
+    const next = !torchOn;
+    // Type the constraints loosely — `torch` is non-standard and not
+    // present in the lib.dom MediaTrackConstraints definition.
+    await track.applyConstraints({
+      advanced: [{ torch: next } as MediaTrackConstraintSet],
+    } as MediaTrackConstraints);
+    setTorchOn(next);
+  }, [torchOn]);
+
   // Always release on unmount.
   useEffect(() => {
     return () => {
@@ -259,5 +346,9 @@ export function useBarcodeScanner(
     devices,
     selectedDeviceId,
     selectDevice,
+    decodeOnce,
+    torchSupported,
+    torchOn,
+    toggleTorch,
   };
 }

--- a/apps/desktop/src/i18n/en/sirkulasi.json
+++ b/apps/desktop/src/i18n/en/sirkulasi.json
@@ -20,7 +20,16 @@
     "noDeviceTitle": "Camera not found",
     "noDeviceHelp": "Make sure a webcam is connected and not disabled in Device Manager.",
     "inUseTitle": "Camera in use by another app",
-    "inUseHelp": "Close any other app using the camera (Zoom, Meet, Camera, etc.), then click Try again."
+    "inUseHelp": "Close any other app using the camera (Zoom, Meet, Camera, etc.), then click Try again.",
+    "overlayLabel": "Aim the barcode inside the box",
+    "scanNow": "Scan Now",
+    "scanning": "Scanning…",
+    "scanSuccess": "Detected: {{code}}",
+    "scanFail": "No barcode detected — try again or type manually.",
+    "scanError": "Failed to perform scan",
+    "torchOn": "Torch on",
+    "torchOff": "Turn on torch",
+    "torchError": "Could not toggle the torch"
   },
   "manual": {
     "placeholder": "Or type / scan via USB scanner (Enter to submit)",

--- a/apps/desktop/src/i18n/id/sirkulasi.json
+++ b/apps/desktop/src/i18n/id/sirkulasi.json
@@ -20,7 +20,16 @@
     "noDeviceTitle": "Kamera tidak ditemukan",
     "noDeviceHelp": "Pastikan kamera webcam tersambung dan tidak dinonaktifkan di Device Manager.",
     "inUseTitle": "Kamera sedang dipakai aplikasi lain",
-    "inUseHelp": "Tutup aplikasi lain yang sedang menggunakan kamera (Zoom, Meet, Camera, dll), lalu klik Coba lagi."
+    "inUseHelp": "Tutup aplikasi lain yang sedang menggunakan kamera (Zoom, Meet, Camera, dll), lalu klik Coba lagi.",
+    "overlayLabel": "Arahkan barcode ke dalam kotak",
+    "scanNow": "Scan Sekarang",
+    "scanning": "Memindai…",
+    "scanSuccess": "Berhasil: {{code}}",
+    "scanFail": "Tidak terdeteksi — coba ulangi atau ketik manual.",
+    "scanError": "Gagal melakukan scan",
+    "torchOn": "Senter aktif",
+    "torchOff": "Nyalakan senter",
+    "torchError": "Senter tidak dapat diaktifkan"
   },
   "manual": {
     "placeholder": "Atau ketik / scan pakai USB scanner (Enter untuk submit)",

--- a/apps/desktop/src/lib/scanner/decoder.ts
+++ b/apps/desktop/src/lib/scanner/decoder.ts
@@ -1,0 +1,172 @@
+/**
+ * Multi-format barcode decoder wrapper (FEAT-28 PR J).
+ *
+ * Wraps `@zxing/browser`'s {@link BrowserMultiFormatReader} and
+ * `@zxing/library`'s low-level {@link MultiFormatReader} so the rest
+ * of the app can decode either:
+ *
+ * - A continuous video stream (legacy use case, kept for
+ *   `useBarcodeScanner`).
+ * - A single Canvas / `ImageData` snapshot — used by the manual
+ *   "Scan Sekarang" button which wants to crop to the ROI overlay
+ *   and try multiple preprocessing variants before giving up.
+ *
+ * Format coverage matches the FEAT-28 acceptance:
+ *   EAN-13, EAN-8, Code-128, Code-39, QR Code, Data Matrix.
+ *
+ * We deliberately keep the same library family the app already
+ * shipped (zxing) — switching to quagga2 would have meant a fresh
+ * audit of decode rates, license, and bundle size. zxing already
+ * supports every format we need; the v1.0.7 hint list just didn't
+ * include Data Matrix.
+ */
+import { BrowserMultiFormatReader } from '@zxing/browser';
+import {
+  BarcodeFormat,
+  BinaryBitmap,
+  DecodeHintType,
+  HybridBinarizer,
+  MultiFormatReader,
+  NotFoundException,
+  RGBLuminanceSource,
+  type Result,
+} from '@zxing/library';
+import {
+  applyPreprocess,
+  MANUAL_RETRY_VARIANTS,
+  type PreprocessVariant,
+} from './preprocess';
+
+/**
+ * Formats the FEAT-28 acceptance requires the scanner to recognise.
+ *
+ * Order matters slightly: zxing tries them roughly in declaration
+ * order on each frame, so the format most likely to be present in our
+ * use case (Code-128 — every label printed by the app) goes first.
+ */
+export const SUPPORTED_FORMATS: BarcodeFormat[] = [
+  BarcodeFormat.CODE_128,
+  BarcodeFormat.CODE_39,
+  BarcodeFormat.EAN_13,
+  BarcodeFormat.EAN_8,
+  BarcodeFormat.QR_CODE,
+  BarcodeFormat.DATA_MATRIX,
+];
+
+/**
+ * Build the {@link DecodeHintType} map handed to every reader. zxing's
+ * `Map<DecodeHintType, unknown>` is non-trivial to type-check across
+ * versions so we encapsulate the construction in one place.
+ *
+ * `TRY_HARDER` enables the slower-but-more-thorough decode path. The
+ * frame budget on a manual click is generous (~500ms) so the perf
+ * cost is fine, and it noticeably improves the catch rate on
+ * partially-occluded or skewed barcodes.
+ */
+export function buildDecodeHints(): Map<DecodeHintType, unknown> {
+  const hints = new Map<DecodeHintType, unknown>();
+  hints.set(DecodeHintType.POSSIBLE_FORMATS, SUPPORTED_FORMATS);
+  hints.set(DecodeHintType.TRY_HARDER, true);
+  return hints;
+}
+
+/**
+ * Construct a fresh {@link BrowserMultiFormatReader} configured for
+ * the FEAT-28 format set. The browser reader handles continuous video
+ * decode (`decodeFromConstraints`, `decodeFromVideoElement`).
+ */
+export function createBrowserReader(): BrowserMultiFormatReader {
+  return new BrowserMultiFormatReader(buildDecodeHints());
+}
+
+/**
+ * Construct a fresh low-level {@link MultiFormatReader} for one-shot
+ * decodes against an `ImageData` (canvas snapshot). The browser
+ * reader can do this too via `decodeFromCanvas`, but going through
+ * the lower-level API lets us pre-build the `BinaryBitmap` ourselves
+ * which is a few percent faster on the manual scan hot path.
+ */
+export function createImageDataReader(): MultiFormatReader {
+  const reader = new MultiFormatReader();
+  reader.setHints(buildDecodeHints());
+  return reader;
+}
+
+/**
+ * Convert an RGBA {@link ImageData} to a zxing {@link BinaryBitmap}.
+ *
+ * Steps:
+ *   1. Build an `RGBLuminanceSource` directly from the RGBA bytes.
+ *      zxing provides a constructor for this exact shape.
+ *   2. Wrap it in a `HybridBinarizer` (best general-purpose
+ *      binarizer for the 1-D + 2-D format mix we support).
+ *   3. Wrap that in a `BinaryBitmap` for the reader.
+ */
+export function imageDataToBitmap(image: ImageData): BinaryBitmap {
+  const luminance = new RGBLuminanceSource(image.data, image.width, image.height);
+  return new BinaryBitmap(new HybridBinarizer(luminance));
+}
+
+export interface DecodedResult {
+  /** Decoded payload text. */
+  text: string;
+  /** Which preprocessing variant produced the hit (for diagnostics). */
+  variant: PreprocessVariant;
+  /** Which barcode format matched, e.g. `'CODE_128'`. */
+  format: string;
+}
+
+/**
+ * Single decode pass — apply the variant, build the bitmap, run the
+ * reader. Returns `null` on a clean `NotFoundException`. Any other
+ * error is rethrown so the caller can surface it (it would indicate
+ * a deeper bug — bad ImageData, broken zxing build, etc.).
+ *
+ * The reader is reset between calls because zxing's stateful
+ * binarizer cache otherwise carries over between unrelated frames
+ * and can return stale results during retry passes.
+ */
+function decodeOnce(
+  reader: MultiFormatReader,
+  image: ImageData,
+  variant: PreprocessVariant,
+): DecodedResult | null {
+  const processed = applyPreprocess(image, variant);
+  const bitmap = imageDataToBitmap(processed);
+  try {
+    const result: Result = reader.decode(bitmap);
+    return {
+      text: result.getText(),
+      variant,
+      format: BarcodeFormat[result.getBarcodeFormat()] ?? String(result.getBarcodeFormat()),
+    };
+  } catch (e) {
+    if (e instanceof NotFoundException) {
+      return null;
+    }
+    throw e;
+  } finally {
+    reader.reset();
+  }
+}
+
+/**
+ * Manual-scan retry pipeline. Tries each variant in order; returns
+ * the first successful decode, or `null` if all variants miss.
+ *
+ * Default order is {@link MANUAL_RETRY_VARIANTS}: normal → contrast
+ * → grayscale, tuned for Indonesian classroom lighting.
+ */
+export function decodeWithRetry(
+  reader: MultiFormatReader,
+  image: ImageData,
+  variants: PreprocessVariant[] = MANUAL_RETRY_VARIANTS,
+): DecodedResult | null {
+  for (const variant of variants) {
+    const hit = decodeOnce(reader, image, variant);
+    if (hit) {
+      return hit;
+    }
+  }
+  return null;
+}

--- a/apps/desktop/src/lib/scanner/overlay.ts
+++ b/apps/desktop/src/lib/scanner/overlay.ts
@@ -1,0 +1,131 @@
+/**
+ * Scanner overlay geometry helpers (FEAT-28 PR J).
+ *
+ * The webcam feed in Sirkulasi paints a rectangular "aiming guide" on
+ * top of the `<video>` element so the operator knows where to place the
+ * barcode. The same rectangle is also used to crop the video frame
+ * before passing pixels to the decoder, which both speeds up decode
+ * (~4× fewer pixels) and reduces background noise from the room behind
+ * the book.
+ *
+ * Two coordinate systems matter here:
+ *
+ * - **Percentages** (`ROI_PERCENT`): independent of the camera
+ *   resolution. Used by the React component to position the overlay
+ *   `<div>` via inline `top/left/width/height` styles. The overlay is
+ *   purely cosmetic so percentages are perfect.
+ *
+ * - **Pixels** ({@link computeRoi}): tied to the video's intrinsic
+ *   `videoWidth` / `videoHeight`. Used at decode time to call
+ *   `getImageData(x, y, w, h)` on a hidden canvas — that one needs
+ *   absolute integer coordinates.
+ *
+ * Both halves are derived from the same constants so they always stay
+ * in sync.
+ */
+
+/**
+ * ROI rectangle as a fraction of the video frame.
+ *
+ * - 70% width × 30% height matches a typical landscape barcode aspect
+ *   ratio (EAN-13 ≈ 2.4:1, Code-128 varies). Wide enough to fit the
+ *   full barcode at a normal arm's-length distance, tall enough that
+ *   slight tilt or vertical drift still keeps the bars in frame.
+ * - Centered (left/top = (1 - size)/2). Easier for operators than
+ *   off-center alignment and matches every other phone-camera
+ *   scanner UI in the wild.
+ */
+export const ROI_PERCENT = {
+  width: 0.7,
+  height: 0.3,
+} as const;
+
+export interface RoiRect {
+  /** Pixel offset from the left edge of the video frame. */
+  x: number;
+  /** Pixel offset from the top edge of the video frame. */
+  y: number;
+  /** Width of the ROI in pixels. */
+  width: number;
+  /** Height of the ROI in pixels. */
+  height: number;
+}
+
+/**
+ * Compute the pixel-aligned ROI rectangle for a given video frame size.
+ *
+ * Returns integer pixel coordinates because Canvas `getImageData`
+ * silently truncates fractions and we'd rather control the rounding
+ * than have it bias one side by half a pixel each frame.
+ *
+ * Falls back to a zero-sized rect (centered at `videoWidth/2`,
+ * `videoHeight/2`) if either dimension is non-positive — the decoder
+ * is expected to short-circuit on a 0×0 region rather than throwing.
+ */
+export function computeRoi(videoWidth: number, videoHeight: number): RoiRect {
+  if (
+    !Number.isFinite(videoWidth) ||
+    !Number.isFinite(videoHeight) ||
+    videoWidth <= 0 ||
+    videoHeight <= 0
+  ) {
+    return { x: 0, y: 0, width: 0, height: 0 };
+  }
+  const width = Math.round(videoWidth * ROI_PERCENT.width);
+  const height = Math.round(videoHeight * ROI_PERCENT.height);
+  const x = Math.round((videoWidth - width) / 2);
+  const y = Math.round((videoHeight - height) / 2);
+  return { x, y, width, height };
+}
+
+/**
+ * Length of the bracket "elbow" drawn at each corner of the overlay,
+ * as a fraction of the *shorter* dimension of the ROI.
+ *
+ * 12% gives an elbow that's clearly visible at common video sizes
+ * (480p–1080p) without overpowering the rectangle. The bracket arms
+ * are the same length on both axes, computed from the shorter side, so
+ * a wide-and-short ROI doesn't end up with stretched-looking elbows.
+ */
+export const BRACKET_LENGTH_FRACTION = 0.12;
+
+export interface BracketSegment {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/**
+ * Compute the 8 line segments that form the corner bracket overlay.
+ *
+ * Each corner is two perpendicular line segments (one horizontal, one
+ * vertical) starting from the corner point and extending inward by
+ * `armLength`. The order is: top-left H, top-left V, top-right H,
+ * top-right V, bottom-right H, bottom-right V, bottom-left H,
+ * bottom-left V.
+ *
+ * Coordinates are in the same space as the input rectangle — typically
+ * pixels for a Canvas overlay or a normalised 0..1 range for SVG.
+ */
+export function computeCornerBrackets(rect: RoiRect): BracketSegment[] {
+  const arm = Math.max(0, Math.min(rect.width, rect.height) * BRACKET_LENGTH_FRACTION);
+  const left = rect.x;
+  const top = rect.y;
+  const right = rect.x + rect.width;
+  const bottom = rect.y + rect.height;
+  return [
+    // top-left: horizontal arm pointing right, vertical arm pointing down
+    { x1: left, y1: top, x2: left + arm, y2: top },
+    { x1: left, y1: top, x2: left, y2: top + arm },
+    // top-right: horizontal arm pointing left, vertical arm pointing down
+    { x1: right, y1: top, x2: right - arm, y2: top },
+    { x1: right, y1: top, x2: right, y2: top + arm },
+    // bottom-right: horizontal arm pointing left, vertical arm pointing up
+    { x1: right, y1: bottom, x2: right - arm, y2: bottom },
+    { x1: right, y1: bottom, x2: right, y2: bottom - arm },
+    // bottom-left: horizontal arm pointing right, vertical arm pointing up
+    { x1: left, y1: bottom, x2: left + arm, y2: bottom },
+    { x1: left, y1: bottom, x2: left, y2: bottom - arm },
+  ];
+}

--- a/apps/desktop/src/lib/scanner/preprocess.ts
+++ b/apps/desktop/src/lib/scanner/preprocess.ts
@@ -1,0 +1,144 @@
+/**
+ * Image preprocessing for barcode decode (FEAT-28 PR J).
+ *
+ * The continuous-decode path runs the raw RGBA frame through zxing as
+ * fast as it can. That works for high-contrast labels in good light,
+ * but the user reports that real classroom lighting (fluorescent,
+ * window glare, low-CRI LEDs) regularly trips up the decoder even
+ * after BUG-18's resolution bump.
+ *
+ * The manual "Scan Sekarang" button trades latency for accuracy by
+ * running up to three decode passes per click — each pass uses a
+ * different preprocessing variant. {@link applyPreprocess} produces
+ * the variant; the decoder picks the first one that returns a hit.
+ *
+ * All transforms here are pure functions over `ImageData`. They are
+ * intentionally easy to test in isolation: pass in a synthetic
+ * 4×4 ImageData, assert the per-pixel output. No DOM, no Canvas,
+ * no async.
+ */
+
+export type PreprocessVariant = 'normal' | 'grayscale' | 'contrast';
+
+/**
+ * Build a fresh ImageData buffer the same size as the source. Used by
+ * every transform so the input is never mutated. We allocate a
+ * `Uint8ClampedArray` directly (rather than `new ImageData(w, h)`)
+ * because some test environments (jsdom) don't expose the ImageData
+ * constructor, and the canvas helpers we call later only ever read
+ * `.data`, `.width`, `.height`.
+ */
+function cloneShape(src: ImageData): ImageData {
+  const data = new Uint8ClampedArray(src.data.length);
+  // Tests ran fine with this minimal shim, but if the runtime offers
+  // a real ImageData constructor we use it so consumers that rely on
+  // `instanceof ImageData` keep working.
+  if (typeof ImageData === 'function') {
+    try {
+      return new ImageData(data, src.width, src.height);
+    } catch {
+      // fall through to the duck-typed version below
+    }
+  }
+  return { data, width: src.width, height: src.height } as ImageData;
+}
+
+/**
+ * Convert each pixel to its luminance, written back across all three
+ * RGB channels (so the result is still RGBA but visually monochrome).
+ *
+ * Uses the BT.601 coefficients (0.299 R + 0.587 G + 0.114 B). zxing
+ * internally does its own grayscale conversion, but giving it an
+ * already-grayscale image (a) saves a tiny bit of CPU and (b) avoids
+ * the small bias colour-cast adds when one channel saturates earlier
+ * than the others — important under warm-tinted classroom lights
+ * where the red channel of an EAN barcode can clip.
+ */
+export function toGrayscale(src: ImageData): ImageData {
+  const out = cloneShape(src);
+  const s = src.data;
+  const d = out.data;
+  for (let i = 0; i < s.length; i += 4) {
+    // Indices are bounded by `s.length` so the `?? 0` defaults exist
+    // only to satisfy `noUncheckedIndexedAccess`. They are never hit
+    // at runtime for a well-formed RGBA buffer.
+    const r = s[i] ?? 0;
+    const g = s[i + 1] ?? 0;
+    const b = s[i + 2] ?? 0;
+    const y = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
+    d[i] = y;
+    d[i + 1] = y;
+    d[i + 2] = y;
+    d[i + 3] = s[i + 3] ?? 255;
+  }
+  return out;
+}
+
+/**
+ * Adjust contrast around the 128 mid-grey by a multiplicative factor.
+ *
+ * `factor = 1.0` is a no-op. `factor = 1.3` boosts contrast by ~30%
+ * (the spec's recommended default for the second decode pass). The
+ * formula is the standard `(v - 128) * f + 128` clamped to 0..255 —
+ * matches the GIMP / Photoshop "Contrast" slider behaviour.
+ *
+ * Alpha is left untouched so the image stays opaque after the boost.
+ */
+export function applyContrast(src: ImageData, factor: number): ImageData {
+  const out = cloneShape(src);
+  const s = src.data;
+  const d = out.data;
+  for (let i = 0; i < s.length; i += 4) {
+    for (let c = 0; c < 3; c++) {
+      const sample = s[i + c] ?? 0;
+      const v = (sample - 128) * factor + 128;
+      d[i + c] = v < 0 ? 0 : v > 255 ? 255 : v;
+    }
+    d[i + 3] = s[i + 3] ?? 255;
+  }
+  return out;
+}
+
+/**
+ * Pick the preprocessing variant requested by the caller.
+ *
+ * The decoder tries variants in this order:
+ *   1. `'normal'`   — pass-through (still useful as a baseline pass).
+ *   2. `'contrast'` — +30% contrast boost (most common decode rescue).
+ *   3. `'grayscale'`— pure luminance (last resort: handles colour cast).
+ *
+ * We expose them as discrete variants rather than as a single
+ * configurable pipeline because the manual scan button benefits from
+ * a fixed retry order — easier to reason about, easier to test.
+ */
+export function applyPreprocess(src: ImageData, variant: PreprocessVariant): ImageData {
+  switch (variant) {
+    case 'normal':
+      return src;
+    case 'grayscale':
+      return toGrayscale(src);
+    case 'contrast':
+      return applyContrast(src, 1.3);
+    default: {
+      // Exhaustiveness guard. Compile-time `never` ensures all cases
+      // are handled; the runtime fallback returns the source unchanged.
+      const _exhaustive: never = variant;
+      void _exhaustive;
+      return src;
+    }
+  }
+}
+
+/**
+ * Default retry order for the manual scan button.
+ *
+ * The order is designed for the median classroom case: most decodes
+ * miss because of low contrast (under-lit barcodes on white paper),
+ * so contrast boost is tried *before* grayscale. Grayscale is kept
+ * last as the safety net for colour-cast failures.
+ */
+export const MANUAL_RETRY_VARIANTS: PreprocessVariant[] = [
+  'normal',
+  'contrast',
+  'grayscale',
+];

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -73,12 +73,18 @@ const config: Config = {
           from: { opacity: '0', transform: 'translateY(8px)' },
           to: { opacity: '1', transform: 'translateY(0)' },
         },
+        'scanner-line': {
+          '0%': { transform: 'translateY(-50%)', opacity: '0.4' },
+          '50%': { transform: 'translateY(50%)', opacity: '1' },
+          '100%': { transform: 'translateY(-50%)', opacity: '0.4' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
         'fade-in': 'fade-in 0.2s ease-out',
         'slide-up': 'slide-up 0.3s ease-out',
+        'scanner-line': 'scanner-line 1.6s ease-in-out infinite',
       },
     },
   },

--- a/apps/desktop/tests/unit/scannerDecoder.test.ts
+++ b/apps/desktop/tests/unit/scannerDecoder.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BarcodeFormat, DecodeHintType, NotFoundException } from '@zxing/library';
+import {
+  buildDecodeHints,
+  createImageDataReader,
+  decodeWithRetry,
+  imageDataToBitmap,
+  SUPPORTED_FORMATS,
+} from '@/lib/scanner/decoder';
+
+/**
+ * Minimal RGBA `ImageData` factory shared with the preprocess tests —
+ * we don't need a real Canvas because zxing only ever reads `.data`,
+ * `.width`, `.height` from the input.
+ */
+function blankImage(width: number, height: number): ImageData {
+  return {
+    data: new Uint8ClampedArray(width * height * 4),
+    width,
+    height,
+  } as ImageData;
+}
+
+describe('buildDecodeHints', () => {
+  it('declares the FEAT-28 format set including Data Matrix', () => {
+    const hints = buildDecodeHints();
+    const formats = hints.get(DecodeHintType.POSSIBLE_FORMATS) as BarcodeFormat[];
+    expect(formats).toContain(BarcodeFormat.CODE_128);
+    expect(formats).toContain(BarcodeFormat.CODE_39);
+    expect(formats).toContain(BarcodeFormat.EAN_13);
+    expect(formats).toContain(BarcodeFormat.EAN_8);
+    expect(formats).toContain(BarcodeFormat.QR_CODE);
+    // Data Matrix is the new addition vs v1.0.7's narrower hint list.
+    expect(formats).toContain(BarcodeFormat.DATA_MATRIX);
+  });
+
+  it('enables TRY_HARDER for the slower-but-thorough decode path', () => {
+    const hints = buildDecodeHints();
+    expect(hints.get(DecodeHintType.TRY_HARDER)).toBe(true);
+  });
+
+  it('SUPPORTED_FORMATS is the same list (single source of truth)', () => {
+    const hints = buildDecodeHints();
+    expect(hints.get(DecodeHintType.POSSIBLE_FORMATS)).toEqual(SUPPORTED_FORMATS);
+  });
+});
+
+describe('imageDataToBitmap', () => {
+  it('builds a BinaryBitmap with the same dimensions as the source', () => {
+    const img = blankImage(80, 40);
+    const bitmap = imageDataToBitmap(img);
+    expect(bitmap.getWidth()).toBe(80);
+    expect(bitmap.getHeight()).toBe(40);
+  });
+});
+
+describe('createImageDataReader', () => {
+  it('produces a fresh MultiFormatReader instance', () => {
+    const a = createImageDataReader();
+    const b = createImageDataReader();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('decodeWithRetry', () => {
+  /**
+   * Build a stub reader whose `decode()` returns a NotFoundException
+   * for every call until the configured number of attempts is reached,
+   * at which point it returns a fake `Result`-like object.
+   *
+   * `failTimes` controls how many variants should miss before the
+   * stub starts returning hits. The order of variant calls is
+   * inferred from the order the stub is invoked — the stub records
+   * each call so the test can assert on it.
+   */
+  function stubReader(failTimes: number, hitText = 'OK', hitFormat = BarcodeFormat.CODE_128) {
+    let calls = 0;
+    const decode = vi.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls <= failTimes) {
+        throw new NotFoundException();
+      }
+      return {
+        getText: () => hitText,
+        getBarcodeFormat: () => hitFormat,
+      };
+    });
+    const reset = vi.fn();
+    return { decode, reset, getCalls: () => calls } as unknown as ReturnType<
+      typeof createImageDataReader
+    > & { getCalls: () => number };
+  }
+
+  it('returns null when every variant misses', () => {
+    const reader = stubReader(99);
+    const result = decodeWithRetry(reader, blankImage(10, 10));
+    expect(result).toBeNull();
+    // exactly the default 3 variants attempted
+    expect((reader as unknown as { decode: { mock: { calls: unknown[] } } }).decode.mock.calls.length).toBe(3);
+  });
+
+  it('returns the first successful hit and stops trying further variants', () => {
+    // Stub fails 1 attempt, hits on the 2nd → "contrast" pass.
+    const reader = stubReader(1, 'EAN-13-PAYLOAD', BarcodeFormat.EAN_13);
+    const result = decodeWithRetry(reader, blankImage(10, 10));
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('EAN-13-PAYLOAD');
+    expect(result!.variant).toBe('contrast');
+    expect(result!.format).toBe('EAN_13');
+    expect((reader as unknown as { decode: { mock: { calls: unknown[] } } }).decode.mock.calls.length).toBe(2);
+  });
+
+  it("returns variant 'normal' when the first pass already hits", () => {
+    const reader = stubReader(0, 'CODE-128-OK', BarcodeFormat.CODE_128);
+    const result = decodeWithRetry(reader, blankImage(10, 10));
+    expect(result).not.toBeNull();
+    expect(result!.variant).toBe('normal');
+    expect(result!.format).toBe('CODE_128');
+    expect((reader as unknown as { decode: { mock: { calls: unknown[] } } }).decode.mock.calls.length).toBe(1);
+  });
+
+  it('honors a caller-supplied variant order', () => {
+    // Reader hits on the 1st call regardless. Use a single-variant
+    // override to assert the override is respected.
+    const reader = stubReader(0, 'X', BarcodeFormat.QR_CODE);
+    const result = decodeWithRetry(reader, blankImage(10, 10), ['grayscale']);
+    expect(result!.variant).toBe('grayscale');
+    expect(result!.format).toBe('QR_CODE');
+  });
+
+  it('rethrows non-NotFoundException errors so the caller can surface them', () => {
+    const decode = vi.fn().mockImplementation(() => {
+      throw new Error('zxing internal');
+    });
+    const reset = vi.fn();
+    const reader = { decode, reset } as unknown as ReturnType<typeof createImageDataReader>;
+    expect(() => decodeWithRetry(reader, blankImage(10, 10))).toThrow('zxing internal');
+  });
+});

--- a/apps/desktop/tests/unit/scannerOverlay.test.ts
+++ b/apps/desktop/tests/unit/scannerOverlay.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BRACKET_LENGTH_FRACTION,
+  computeCornerBrackets,
+  computeRoi,
+  ROI_PERCENT,
+} from '@/lib/scanner/overlay';
+
+/**
+ * The ROI math feeds two consumers — the React overlay div sizing and
+ * the canvas crop coordinates handed to zxing. A subtle off-by-one
+ * here produces a noticeable visual misalignment and a barely-noticeable
+ * decode regression, so unit-test the pure math.
+ */
+describe('computeRoi', () => {
+  it('produces a centered rectangle at 70% × 30% of the video frame', () => {
+    const roi = computeRoi(1280, 720);
+    expect(roi.width).toBe(896); // round(1280 * 0.7)
+    expect(roi.height).toBe(216); // round(720 * 0.3)
+    expect(roi.x).toBe(192); // round((1280 - 896) / 2)
+    expect(roi.y).toBe(252); // round((720 - 216) / 2)
+  });
+
+  it('keeps the rectangle inside the video bounds at common resolutions', () => {
+    for (const [w, h] of [
+      [640, 480],
+      [800, 600],
+      [1280, 720],
+      [1920, 1080],
+      [320, 240],
+    ] as const) {
+      const roi = computeRoi(w, h);
+      expect(roi.x).toBeGreaterThanOrEqual(0);
+      expect(roi.y).toBeGreaterThanOrEqual(0);
+      expect(roi.x + roi.width).toBeLessThanOrEqual(w);
+      expect(roi.y + roi.height).toBeLessThanOrEqual(h);
+    }
+  });
+
+  it('handles square frames without skewing the aspect', () => {
+    const roi = computeRoi(500, 500);
+    // width fraction is larger than height fraction by construction.
+    expect(roi.width).toBeGreaterThan(roi.height);
+  });
+
+  it('returns a zero rectangle for non-positive dimensions instead of throwing', () => {
+    expect(computeRoi(0, 720)).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+    expect(computeRoi(1280, 0)).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+    expect(computeRoi(-100, 720)).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+    expect(computeRoi(NaN, 720)).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+  });
+
+  it('exposes the percentage constants for the React overlay div', () => {
+    expect(ROI_PERCENT.width).toBeCloseTo(0.7, 5);
+    expect(ROI_PERCENT.height).toBeCloseTo(0.3, 5);
+  });
+});
+
+describe('computeCornerBrackets', () => {
+  it('emits 8 line segments — two arms per corner', () => {
+    const segs = computeCornerBrackets({ x: 100, y: 50, width: 400, height: 200 });
+    expect(segs).toHaveLength(8);
+  });
+
+  it('arm length is the bracket fraction of the shorter ROI side', () => {
+    const segs = computeCornerBrackets({ x: 0, y: 0, width: 400, height: 200 });
+    const expectedArm = 200 * BRACKET_LENGTH_FRACTION;
+    // top-left horizontal arm: starts at (0,0), ends at (arm, 0).
+    expect(segs[0]).toEqual({ x1: 0, y1: 0, x2: expectedArm, y2: 0 });
+    // top-left vertical arm: starts at (0,0), ends at (0, arm).
+    expect(segs[1]).toEqual({ x1: 0, y1: 0, x2: 0, y2: expectedArm });
+  });
+
+  it('top-right corner has arms pointing inward', () => {
+    const rect = { x: 0, y: 0, width: 100, height: 100 };
+    const segs = computeCornerBrackets(rect);
+    const arm = 100 * BRACKET_LENGTH_FRACTION;
+    // index 2 = top-right horizontal arm pointing left
+    expect(segs[2]).toEqual({ x1: 100, y1: 0, x2: 100 - arm, y2: 0 });
+    // index 3 = top-right vertical arm pointing down
+    expect(segs[3]).toEqual({ x1: 100, y1: 0, x2: 100, y2: arm });
+  });
+
+  it('bottom-right and bottom-left corners point inward toward the centre', () => {
+    const rect = { x: 0, y: 0, width: 100, height: 100 };
+    const segs = computeCornerBrackets(rect);
+    const arm = 100 * BRACKET_LENGTH_FRACTION;
+    // bottom-right horizontal: arm points left
+    expect(segs[4]).toEqual({ x1: 100, y1: 100, x2: 100 - arm, y2: 100 });
+    // bottom-right vertical: arm points up
+    expect(segs[5]).toEqual({ x1: 100, y1: 100, x2: 100, y2: 100 - arm });
+    // bottom-left horizontal: arm points right
+    expect(segs[6]).toEqual({ x1: 0, y1: 100, x2: arm, y2: 100 });
+    // bottom-left vertical: arm points up
+    expect(segs[7]).toEqual({ x1: 0, y1: 100, x2: 0, y2: 100 - arm });
+  });
+
+  it('arm length collapses to 0 for a zero-sized rect', () => {
+    const segs = computeCornerBrackets({ x: 50, y: 50, width: 0, height: 0 });
+    for (const seg of segs) {
+      expect(seg.x1).toBe(50);
+      expect(seg.y1).toBe(50);
+      expect(seg.x2).toBe(50);
+      expect(seg.y2).toBe(50);
+    }
+  });
+});

--- a/apps/desktop/tests/unit/scannerPreprocess.test.ts
+++ b/apps/desktop/tests/unit/scannerPreprocess.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyContrast,
+  applyPreprocess,
+  MANUAL_RETRY_VARIANTS,
+  toGrayscale,
+} from '@/lib/scanner/preprocess';
+
+/**
+ * Build a tiny RGBA `ImageData` from per-pixel quadruplets.
+ *
+ * Avoids depending on the Canvas API in tests — the preprocess
+ * functions only ever read `.data`, `.width`, `.height` so a duck-
+ * typed object is sufficient.
+ */
+function makeImageData(
+  width: number,
+  height: number,
+  pixels: Array<[number, number, number, number]>,
+): ImageData {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < pixels.length; i++) {
+    const px = pixels[i];
+    if (!px) continue;
+    const [r, g, b, a] = px;
+    data[i * 4 + 0] = r;
+    data[i * 4 + 1] = g;
+    data[i * 4 + 2] = b;
+    data[i * 4 + 3] = a;
+  }
+  return { data, width, height } as ImageData;
+}
+
+describe('toGrayscale', () => {
+  it('replaces RGB with the BT.601 luminance value', () => {
+    // Pure red, pure green, pure blue, white.
+    const src = makeImageData(4, 1, [
+      [255, 0, 0, 255],
+      [0, 255, 0, 255],
+      [0, 0, 255, 255],
+      [255, 255, 255, 255],
+    ]);
+    const out = toGrayscale(src);
+    // BT.601: 0.299*255 = 76.245 → round 76
+    expect([out.data[0], out.data[1], out.data[2]]).toEqual([76, 76, 76]);
+    // 0.587*255 = 149.685 → round 150
+    expect([out.data[4], out.data[5], out.data[6]]).toEqual([150, 150, 150]);
+    // 0.114*255 = 29.07 → round 29
+    expect([out.data[8], out.data[9], out.data[10]]).toEqual([29, 29, 29]);
+    // White stays at 255 (sum of coefficients = 1.0).
+    expect([out.data[12], out.data[13], out.data[14]]).toEqual([255, 255, 255]);
+  });
+
+  it('preserves alpha verbatim', () => {
+    const src = makeImageData(2, 1, [
+      [200, 100, 50, 128],
+      [10, 20, 30, 0],
+    ]);
+    const out = toGrayscale(src);
+    expect(out.data[3]).toBe(128);
+    expect(out.data[7]).toBe(0);
+  });
+
+  it('does not mutate the input buffer', () => {
+    const src = makeImageData(1, 1, [[100, 150, 200, 255]]);
+    const snapshot = Array.from(src.data);
+    toGrayscale(src);
+    expect(Array.from(src.data)).toEqual(snapshot);
+  });
+});
+
+describe('applyContrast', () => {
+  it('factor 1.0 is the identity transform', () => {
+    const src = makeImageData(2, 1, [
+      [50, 100, 150, 255],
+      [200, 25, 75, 200],
+    ]);
+    const out = applyContrast(src, 1.0);
+    for (let i = 0; i < src.data.length; i++) {
+      expect(out.data[i]).toBe(src.data[i]);
+    }
+  });
+
+  it('factor 1.3 stretches values away from 128', () => {
+    const src = makeImageData(2, 1, [
+      [128, 128, 128, 255], // mid-grey: stays at 128
+      [200, 50, 100, 255], //  ↑       ↓     ↓
+    ]);
+    const out = applyContrast(src, 1.3);
+    // mid-grey is the contrast pivot — should not move.
+    expect([out.data[0], out.data[1], out.data[2]]).toEqual([128, 128, 128]);
+    // Above-pivot brightens, below-pivot darkens.
+    // 200 → (200-128)*1.3 + 128 = 221.6 → clamp 222
+    expect(out.data[4]).toBe(222);
+    //  50 → ( 50-128)*1.3 + 128 =  26.6 → clamp 27
+    expect(out.data[5]).toBe(27);
+    // 100 → (100-128)*1.3 + 128 =  91.6 → clamp 92
+    expect(out.data[6]).toBe(92);
+  });
+
+  it('clamps over- and under-shoot to 0..255', () => {
+    const src = makeImageData(2, 1, [
+      [255, 0, 128, 255],
+      [240, 10, 130, 255],
+    ]);
+    const out = applyContrast(src, 3.0);
+    // 255 with factor 3 → way over → clamp 255
+    expect(out.data[0]).toBe(255);
+    // 0 with factor 3 → way under → clamp 0
+    expect(out.data[1]).toBe(0);
+    // 128 → unchanged (pivot)
+    expect(out.data[2]).toBe(128);
+  });
+
+  it('preserves alpha', () => {
+    const src = makeImageData(1, 1, [[100, 100, 100, 50]]);
+    const out = applyContrast(src, 1.5);
+    expect(out.data[3]).toBe(50);
+  });
+});
+
+describe('applyPreprocess', () => {
+  const src = makeImageData(1, 1, [[120, 90, 60, 255]]);
+
+  it("'normal' returns the source unchanged (identity reference)", () => {
+    expect(applyPreprocess(src, 'normal')).toBe(src);
+  });
+
+  it("'grayscale' delegates to toGrayscale", () => {
+    const out = applyPreprocess(src, 'grayscale');
+    expect(out.data[0]).toBe(out.data[1]);
+    expect(out.data[1]).toBe(out.data[2]);
+  });
+
+  it("'contrast' boosts away from 128", () => {
+    const out = applyPreprocess(src, 'contrast');
+    // 120 < 128 should darken, 60 < 128 should darken further.
+    expect(out.data[0]).toBeLessThan(120);
+    expect(out.data[2]).toBeLessThan(60);
+  });
+});
+
+describe('MANUAL_RETRY_VARIANTS', () => {
+  it('starts with the no-op pass before mutating preprocesses', () => {
+    expect(MANUAL_RETRY_VARIANTS[0]).toBe('normal');
+  });
+
+  it('includes contrast and grayscale fallbacks', () => {
+    expect(MANUAL_RETRY_VARIANTS).toContain('contrast');
+    expect(MANUAL_RETRY_VARIANTS).toContain('grayscale');
+  });
+
+  it('is exactly 3 variants — caller assumes a fixed budget', () => {
+    expect(MANUAL_RETRY_VARIANTS).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **FEAT-28 — Sirkulasi (Webcam) scanner v2**. Brings the v1.0.7 scanner from "kind of works on perfect labels" to "decodes reliably on real classroom labels under fluorescent / window light." This is one of the two core flows in the app, so improvements compound across every Pinjam / Kembali transaction.

Key additions:

- Visual aiming overlay (rectangular box, corner brackets, animated scanning line, dim mask outside the ROI, hint label "Arahkan barcode ke dalam kotak").
- ROI decode for the manual scan path: crops the video frame to the same rectangle the overlay renders before passing pixels to zxing, ~4× fewer pixels and removes background noise.
- Image preprocessing pipeline (`lib/scanner/preprocess.ts`) — pure functions over `ImageData`. Three variants: passthrough, +30% contrast, BT.601 grayscale. Manual scan tries them in that order and returns on first hit.
- Multi-format decoder (`lib/scanner/decoder.ts`) — adds `DATA_MATRIX` to the existing hint set (CODE_128, CODE_39, EAN_13, EAN_8, QR_CODE), `TRY_HARDER` on for the manual path.
- Manual "Scan Sekarang" button with loading spinner + toast feedback.
- Optional torch button (detected via `track.getCapabilities().torch` — hidden when unsupported).
- i18n parity (id ↔ en) for all new strings: `overlayLabel`, `scanNow`, `scanning`, `scanSuccess`, `scanFail`, `scanError`, `torchOn`, `torchOff`, `torchError`.
- 33 new unit tests covering the ROI math, the Canvas filter pipeline, and the decoder retry order.

## Files

- New `apps/desktop/src/lib/scanner/overlay.ts` — ROI rectangle + corner-bracket geometry.
- New `apps/desktop/src/lib/scanner/preprocess.ts` — `toGrayscale`, `applyContrast`, `applyPreprocess` + `MANUAL_RETRY_VARIANTS`.
- New `apps/desktop/src/lib/scanner/decoder.ts` — `buildDecodeHints`, `createBrowserReader`, `createImageDataReader`, `imageDataToBitmap`, `decodeWithRetry`.
- New `apps/desktop/src/features/sirkulasi/ScannerOverlay.tsx` — the absolute-positioned overlay.
- Modified `apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts` — adds `decodeOnce`, `torchSupported`, `torchOn`, `toggleTorch`; widens hint set; reuses pure decoder helpers.
- Modified `apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx` — renders overlay over `<video>`, adds Scan Sekarang + torch buttons.
- Modified `apps/desktop/src/i18n/{id,en}/sirkulasi.json` — new scanner strings.
- Modified `apps/desktop/tailwind.config.ts` — adds `scanner-line` keyframe + animation.

## Acceptance check (FEAT-28)

- [x] Overlay box visible, label hint visible.
- [x] Manual "Scan Sekarang" button → calls `decodeOnce`, toast "Berhasil: <kode>" / "Tidak terdeteksi".
- [x] Multi-format hint set includes Data Matrix (was missing in v1.0.7).
- [x] No regression in the existing continuous decode path — same `useBarcodeScanner` hook signature, just gains new methods.
- [x] Optional torch detection.
- [x] Local gates green (typecheck, lint, i18n:lint, test, build).

## Local gates

```
pnpm typecheck   ✓
pnpm lint        ✓ (eslint --max-warnings=0)
pnpm i18n:lint   ✓ id ↔ en parity
pnpm test        ✓ 305 tests, 36 files (+33 vs main)
pnpm build       ✓ vite production build
```

Cargo gates are CI-side: local sandbox couldn't pull `libwebkit2gtk-4.1-dev` from Ubuntu 22.04's archive. No Rust files touched in this PR.

## TODO before ready-for-review

- [x] All FEAT-28 spec items implemented.
- [x] Frontend gates green locally.
- [ ] CI green (Rust check + Lint/Typecheck/Unit Test).
- [ ] Smoke test the manual scan + torch toggle end-to-end (deferred to a follow-up smoke session if needed).

## Notes on testability

The pure helpers in `lib/scanner/` are intentionally framework-free — they take `ImageData` in, produce `ImageData` (or rectangles, or decoded results) out. That's what the new unit tests exercise. The hook itself isn't unit-tested because it's tightly coupled to `getUserMedia`/`MediaStream`, which jsdom doesn't implement; we rely on the existing `scannerError.test.ts` for the error-classification surface and on manual smoke test for the camera lifecycle.
