### PR TITLE
feat(opac): public OPAC mode + kiosk lock + Pengaturan toggle (FEAT-27)

### DIFF
--- a/apps/desktop/src/features/opac/OpacAdminUnlockButton.tsx
+++ b/apps/desktop/src/features/opac/OpacAdminUnlockButton.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Lock } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const MAX_ATTEMPTS = 3;
+const LOCKOUT_MS = 60 * 1000;
+
+export interface OpacAdminUnlockButtonProps {
+  /** Returns true on success, false on bad credentials. Throws on network error. */
+  onVerify: (username: string, password: string) => Promise<boolean>;
+  onSuccess: () => void;
+}
+
+export function OpacAdminUnlockButton({ onVerify, onSuccess }: OpacAdminUnlockButtonProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const [open, setOpen] = useState(false);
+  const [username, setUsername] = useState('admin');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [attempts, setAttempts] = useState(0);
+  const [lockedUntil, setLockedUntil] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (lockedUntil === null) return undefined;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [lockedUntil]);
+
+  const lockedSecondsRemaining =
+    lockedUntil !== null ? Math.max(0, Math.ceil((lockedUntil - now) / 1000)) : 0;
+  const isLocked = lockedUntil !== null && lockedSecondsRemaining > 0;
+
+  const handleSubmit = async (event: React.FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (isLocked || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const ok = await onVerify(username.trim(), password);
+      if (ok) {
+        setOpen(false);
+        onSuccess();
+        return;
+      }
+      const next = attempts + 1;
+      setAttempts(next);
+      setPassword('');
+      if (next >= MAX_ATTEMPTS) {
+        setLockedUntil(Date.now() + LOCKOUT_MS);
+        setAttempts(0);
+        setError(t('admin.tooManyTries', { seconds: Math.round(LOCKOUT_MS / 1000) }));
+      } else {
+        setError(t('admin.wrongPassword'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (next: boolean): void => {
+    if (!next) {
+      setError(null);
+      setPassword('');
+    }
+    setOpen(next);
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="absolute bottom-4 right-4 gap-2 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <Lock className="h-3.5 w-3.5" />
+        {t('admin.unlockButton')}
+      </Button>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('admin.unlockTitle')}</DialogTitle>
+            <DialogDescription>{t('admin.unlockDescription')}</DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="opac-unlock-username">{t('admin.username')}</Label>
+              <Input
+                id="opac-unlock-username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                autoComplete="username"
+                disabled={isLocked || submitting}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="opac-unlock-password">{t('admin.password')}</Label>
+              <Input
+                id="opac-unlock-password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+                disabled={isLocked || submitting}
+                autoFocus
+              />
+            </div>
+            {error ? (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+                {isLocked
+                  ? ` (${t('admin.lockedFor', { seconds: lockedSecondsRemaining })})`
+                  : null}
+              </p>
+            ) : null}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setOpen(false)}
+                disabled={submitting}
+              >
+                {t('admin.cancel')}
+              </Button>
+              <Button
+                type="submit"
+                disabled={isLocked || submitting || password.length === 0}
+              >
+                {submitting ? '…' : t('admin.submit')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacApp.tsx
+++ b/apps/desktop/src/features/opac/OpacApp.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { OpacHomePage } from './OpacHomePage';
+import { OpacSearchPage } from './OpacSearchPage';
+import { OpacAdminUnlockButton } from './OpacAdminUnlockButton';
+import { OpacKtaScanFlow } from './OpacKtaScanFlow';
+import { useOpacIdleReset } from './useOpacIdleReset';
+import { settingsApi } from '@/lib/settings';
+import { loginRequest, isTauri } from '@/lib/auth';
+import { useToast } from '@/components/ui/toast-manager';
+
+type View = { kind: 'home' } | { kind: 'search'; query: string };
+
+export interface OpacAppProps {
+  /** Optional override for testing or for callers that need to inject a custom verifier. */
+  verifyAdmin?: (username: string, password: string) => Promise<boolean>;
+  /** Optional override for testing the reload after admin unlock. */
+  onUnlockSuccess?: () => void | Promise<void>;
+  /** Optional library identity name to render in header. */
+  libraryName?: string;
+}
+
+const defaultVerifyAdmin = async (username: string, password: string): Promise<boolean> => {
+  try {
+    await loginRequest({ username, password, rememberMe: false });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const defaultUnlockSuccess = async (): Promise<void> => {
+  await settingsApi.saveAppMode('admin');
+  if (typeof window !== 'undefined') {
+    window.location.reload();
+  }
+};
+
+export function OpacApp({
+  verifyAdmin = defaultVerifyAdmin,
+  onUnlockSuccess = defaultUnlockSuccess,
+  libraryName,
+}: OpacAppProps = {}): JSX.Element {
+  const { t } = useTranslation('opac');
+  const { showToast } = useToast();
+  const [view, setView] = useState<View>({ kind: 'home' });
+  const [scanOpen, setScanOpen] = useState(false);
+
+  const goHome = useCallback(() => setView({ kind: 'home' }), []);
+
+  useOpacIdleReset(() => {
+    setScanOpen(false);
+    setView({ kind: 'home' });
+  });
+
+  useEffect(() => {
+    if (!isTauri() || typeof window === 'undefined') return undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const win = await import('@tauri-apps/api/window');
+        const current = win.getCurrentWindow();
+        await current.setFullscreen(true);
+        await current.setDecorations(false);
+        await current.setAlwaysOnTop(true);
+      } catch {
+        if (!cancelled) {
+          showToast({
+            variant: 'destructive',
+            title: t('kiosk.fullscreenError'),
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [showToast, t]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'F11' || (e.altKey && e.key === 'F4')) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, []);
+
+  return (
+    <div className="relative h-full w-full bg-background" data-testid="opac-app">
+      {view.kind === 'home' ? (
+        <OpacHomePage
+          libraryName={libraryName}
+          onSearch={(q) => setView({ kind: 'search', query: q })}
+          onScanKta={() => setScanOpen(true)}
+        />
+      ) : (
+        <OpacSearchPage initialQuery={view.query} onBack={goHome} />
+      )}
+      <OpacKtaScanFlow open={scanOpen} onOpenChange={setScanOpen} />
+      <OpacAdminUnlockButton
+        onVerify={verifyAdmin}
+        onSuccess={() => {
+          void onUnlockSuccess();
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacApp.tsx
+++ b/apps/desktop/src/features/opac/OpacApp.tsx
@@ -8,6 +8,7 @@ import { useOpacIdleReset } from './useOpacIdleReset';
 import { settingsApi } from '@/lib/settings';
 import { loginRequest, isTauri } from '@/lib/auth';
 import { useToast } from '@/components/ui/toast-manager';
+import type { Anggota } from '@/lib/anggota';
 
 type View = { kind: 'home' } | { kind: 'search'; query: string };
 
@@ -45,11 +46,13 @@ export function OpacApp({
   const { showToast } = useToast();
   const [view, setView] = useState<View>({ kind: 'home' });
   const [scanOpen, setScanOpen] = useState(false);
+  const [member, setMember] = useState<Anggota | null>(null);
 
   const goHome = useCallback(() => setView({ kind: 'home' }), []);
 
   useOpacIdleReset(() => {
     setScanOpen(false);
+    setMember(null);
     setView({ kind: 'home' });
   });
 
@@ -91,6 +94,26 @@ export function OpacApp({
 
   return (
     <div className="relative h-full w-full bg-background" data-testid="opac-app">
+      {member && (
+        <div
+          className="border-b bg-primary/10 px-6 py-2 text-sm"
+          role="status"
+          data-testid="opac-member-banner"
+        >
+          <div className="mx-auto flex max-w-5xl items-center justify-between gap-2">
+            <span className="font-medium">
+              {t('session.welcome', { nama: member.nama })}
+            </span>
+            <button
+              type="button"
+              onClick={() => setMember(null)}
+              className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+            >
+              {t('session.logout')}
+            </button>
+          </div>
+        </div>
+      )}
       {view.kind === 'home' ? (
         <OpacHomePage
           libraryName={libraryName}
@@ -100,7 +123,11 @@ export function OpacApp({
       ) : (
         <OpacSearchPage initialQuery={view.query} onBack={goHome} />
       )}
-      <OpacKtaScanFlow open={scanOpen} onOpenChange={setScanOpen} />
+      <OpacKtaScanFlow
+        open={scanOpen}
+        onOpenChange={setScanOpen}
+        onMemberAuthenticated={(m) => setMember(m)}
+      />
       <OpacAdminUnlockButton
         onVerify={verifyAdmin}
         onSuccess={() => {

--- a/apps/desktop/src/features/opac/OpacBookCard.tsx
+++ b/apps/desktop/src/features/opac/OpacBookCard.tsx
@@ -1,0 +1,65 @@
+import { useTranslation } from 'react-i18next';
+import { BookOpen } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { Buku } from '@/lib/buku';
+
+export interface OpacBookCardProps {
+  buku: Buku;
+  onClick: (buku: Buku) => void;
+}
+
+export function OpacBookCard({ buku, onClick }: OpacBookCardProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const available = buku.jumlahTersedia > 0;
+
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={() => onClick(buku)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(buku);
+        }
+      }}
+      className="group cursor-pointer overflow-hidden transition hover:border-primary hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-testid="opac-book-card"
+    >
+      <div className="relative flex h-40 items-center justify-center bg-muted">
+        {buku.coverPath ? (
+          <img
+            src={buku.coverPath}
+            alt={buku.judul}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex flex-col items-center gap-2 text-muted-foreground">
+            <BookOpen className="h-10 w-10" aria-hidden="true" />
+            <span className="text-xs">{t('card.noCover')}</span>
+          </div>
+        )}
+        <Badge
+          className={cn(
+            'absolute right-2 top-2',
+            available ? 'bg-emerald-500 text-white hover:bg-emerald-500' : 'bg-amber-500 text-white hover:bg-amber-500',
+          )}
+        >
+          {available ? t('card.available') : t('card.borrowed')}
+        </Badge>
+      </div>
+      <CardContent className="space-y-1 p-3">
+        <h3 className="line-clamp-2 text-sm font-semibold leading-snug">{buku.judul}</h3>
+        {buku.pengarang ? (
+          <p className="line-clamp-1 text-xs text-muted-foreground">{buku.pengarang}</p>
+        ) : null}
+        {buku.rak ? (
+          <p className="text-xs text-muted-foreground">{t('card.rak', { kode: buku.rak })}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacBookDetailDialog.tsx
+++ b/apps/desktop/src/features/opac/OpacBookDetailDialog.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BookOpen, Heart, MapPin } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { bukuApi, type Buku, type BukuDetail } from '@/lib/buku';
+
+export interface OpacBookDetailDialogProps {
+  buku: Buku | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onWishlist?: (buku: Buku) => void;
+  onReserve?: (buku: Buku) => void;
+  /** When true, hide reserve / wishlist actions (no member session) */
+  guest?: boolean;
+}
+
+export function OpacBookDetailDialog({
+  buku,
+  open,
+  onOpenChange,
+  onWishlist,
+  onReserve,
+  guest = true,
+}: OpacBookDetailDialogProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const [detail, setDetail] = useState<BukuDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !buku) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    bukuApi
+      .get(buku.id)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setDetail({ buku, eksemplar: [] });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, buku]);
+
+  if (!buku) return <></>;
+
+  const display = detail?.buku ?? buku;
+  const available = display.jumlahTersedia > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-xl">{display.judul}</DialogTitle>
+          {display.pengarang ? (
+            <DialogDescription>{display.pengarang}</DialogDescription>
+          ) : null}
+        </DialogHeader>
+
+        <div className="grid gap-4 sm:grid-cols-[180px_1fr]">
+          <div className="flex h-56 items-center justify-center rounded-md bg-muted">
+            {display.coverPath ? (
+              <img
+                src={display.coverPath}
+                alt={display.judul}
+                className="h-full w-full rounded-md object-cover"
+              />
+            ) : (
+              <BookOpen className="h-12 w-12 text-muted-foreground" aria-hidden="true" />
+            )}
+          </div>
+          <div className="space-y-2 text-sm">
+            <Badge variant={available ? 'default' : 'secondary'} className={available ? 'bg-emerald-500 hover:bg-emerald-500' : ''}>
+              {t('detail.stockTersedia', {
+                tersedia: display.jumlahTersedia,
+                total: display.jumlahEksemplar,
+              })}
+            </Badge>
+            {display.penerbit ? (
+              <p>
+                <span className="text-muted-foreground">{t('detail.penerbit')}: </span>
+                {display.penerbit}
+                {display.tahunTerbit ? ` (${display.tahunTerbit})` : ''}
+              </p>
+            ) : null}
+            {display.kategori ? (
+              <p>
+                <span className="text-muted-foreground">{t('detail.kategori')}: </span>
+                {display.kategori}
+              </p>
+            ) : null}
+            {display.kodeDdc ? (
+              <p>
+                <span className="text-muted-foreground">{t('detail.ddc')}: </span>
+                {display.kodeDdc}
+              </p>
+            ) : null}
+            {display.isbn ? (
+              <p>
+                <span className="text-muted-foreground">{t('detail.isbn')}: </span>
+                {display.isbn}
+              </p>
+            ) : null}
+            {display.rak ? (
+              <p className="flex items-center gap-1">
+                <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                <span className="text-muted-foreground">{t('detail.rak')}: </span>
+                {display.rak}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs font-semibold uppercase text-muted-foreground">
+            {t('detail.deskripsi')}
+          </p>
+          <p className="mt-1 whitespace-pre-line text-sm">
+            {display.deskripsi || t('detail.noDescription')}
+          </p>
+        </div>
+
+        {loading ? (
+          <p className="text-xs text-muted-foreground">{t('search.loading')}</p>
+        ) : null}
+        {error ? (
+          <p className="text-xs text-destructive">{error}</p>
+        ) : null}
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t('detail.close')}
+          </Button>
+          <div className="flex gap-2">
+            {onWishlist ? (
+              <Button
+                variant="outline"
+                onClick={() => onWishlist(display)}
+                title={t('detail.wishlistTooltip')}
+                className="gap-2"
+              >
+                <Heart className="h-4 w-4" />
+                {t('detail.wishlist')}
+              </Button>
+            ) : null}
+            {onReserve && !guest ? (
+              <Button
+                onClick={() => onReserve(display)}
+                disabled={available}
+                title={t('detail.reserveTooltip')}
+              >
+                {t('detail.reserve')}
+              </Button>
+            ) : null}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacHomePage.tsx
+++ b/apps/desktop/src/features/opac/OpacHomePage.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BookOpen, ScanLine, Search } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { OpacBookCard } from './OpacBookCard';
+import { OpacBookDetailDialog } from './OpacBookDetailDialog';
+import { bukuApi, type Buku } from '@/lib/buku';
+
+export interface OpacHomePageProps {
+  onSearch: (query: string) => void;
+  onScanKta: () => void;
+  libraryName?: string;
+}
+
+const FEATURED_LIMIT = 8;
+
+export function OpacHomePage({ onSearch, onScanKta, libraryName }: OpacHomePageProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const [query, setQuery] = useState('');
+  const [featured, setFeatured] = useState<Buku[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<Buku | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    bukuApi
+      .list({ limit: FEATURED_LIMIT, offset: 0, sortBy: 'tanggalInput', sortDir: 'desc' })
+      .then((res) => {
+        if (!cancelled) setFeatured(res.items);
+      })
+      .catch(() => {
+        // ignore - home page degrades gracefully without featured row
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSubmit = (event: React.FormEvent): void => {
+    event.preventDefault();
+    onSearch(query);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex flex-col items-center gap-2 px-6 pb-4 pt-12 text-center">
+        <h1 className="text-3xl font-bold tracking-tight">
+          {libraryName ? libraryName : t('title')}
+        </h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <section className="mx-auto w-full max-w-3xl px-6">
+        <form onSubmit={handleSubmit} className="relative">
+          <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('home.searchPlaceholder')}
+            className="h-14 pl-12 pr-32 text-lg"
+            autoFocus
+          />
+          <Button type="submit" className="absolute right-2 top-1/2 -translate-y-1/2">
+            {t('home.browse')}
+          </Button>
+        </form>
+
+        <div className="mt-4 flex justify-center">
+          <Button variant="outline" size="lg" onClick={onScanKta} className="gap-2">
+            <ScanLine className="h-5 w-5" />
+            {t('home.scanKta')}
+          </Button>
+        </div>
+        <p className="mt-1 text-center text-xs text-muted-foreground">
+          {t('home.scanKtaSubtitle')}
+        </p>
+      </section>
+
+      <section className="flex-1 overflow-auto px-6 pb-6 pt-8">
+        <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+          <BookOpen className="h-4 w-4" /> {t('home.browse')}
+        </h2>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">{t('search.loading')}</p>
+        ) : featured.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('search.empty')}</p>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+            {featured.map((b) => (
+              <OpacBookCard key={b.id} buku={b} onClick={setSelected} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <OpacBookDetailDialog
+        buku={selected}
+        open={selected !== null}
+        onOpenChange={(o) => !o && setSelected(null)}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacKtaScanFlow.tsx
+++ b/apps/desktop/src/features/opac/OpacKtaScanFlow.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, ScanLine } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export interface OpacKtaScanFlowProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Stub for the KTA scan flow. The full implementation reuses
+ * `useBarcodeScanner` from features/sirkulasi but that hook owns its own
+ * camera lifecycle which makes it impractical to embed in a modal as
+ * part of the OPAC MVP. Marked TODO; the flow is referenced in BUGS.md
+ * FEAT-27 line 718 and will be wired in a follow-up once the camera
+ * lifecycle is decoupled from the SirkulasiPage layout.
+ */
+export function OpacKtaScanFlow({ open, onOpenChange }: OpacKtaScanFlowProps): JSX.Element {
+  const { t } = useTranslation('opac');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ScanLine className="h-5 w-5" />
+            {t('home.scanKta')}
+          </DialogTitle>
+          <DialogDescription>{t('session.scanInstruction')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex h-48 flex-col items-center justify-center gap-3 rounded-md border border-dashed bg-muted/30 text-center">
+          <ScanLine className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">
+            {t('home.scanKtaSubtitle')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            (TODO: wire decoupled camera flow — same-device-only fallback)
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            {t('search.back')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacKtaScanFlow.tsx
+++ b/apps/desktop/src/features/opac/OpacKtaScanFlow.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, ScanLine } from 'lucide-react';
+import { ArrowLeft, CameraOff, Loader2, ScanLine, Video, VideoOff } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -9,26 +10,107 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/components/ui/toast-manager';
+import { useBarcodeScanner } from '@/features/sirkulasi/useBarcodeScanner';
+import { anggotaApi, type Anggota } from '@/lib/anggota';
+import { parseQrPayload } from '@/lib/kta';
 
 export interface OpacKtaScanFlowProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onMemberAuthenticated?: (member: Anggota) => void;
 }
 
 /**
- * Stub for the KTA scan flow. The full implementation reuses
- * `useBarcodeScanner` from features/sirkulasi but that hook owns its own
- * camera lifecycle which makes it impractical to embed in a modal as
- * part of the OPAC MVP. Marked TODO; the flow is referenced in BUGS.md
- * FEAT-27 line 718 and will be wired in a follow-up once the camera
- * lifecycle is decoupled from the SirkulasiPage layout.
+ * KTA scan flow for OPAC public mode. Wraps `useBarcodeScanner` to show a
+ * camera preview inside the modal, decode `kode_anggota` (Code-128) or
+ * `member:<id>` (QR), look up the member, and notify the caller.
+ *
+ * Camera lifecycle is owned here — the hook itself is generic, this
+ * component holds the only DOM `<video>` so other OPAC components don't
+ * have to. The hook is automatically stopped when the dialog closes.
  */
-export function OpacKtaScanFlow({ open, onOpenChange }: OpacKtaScanFlowProps): JSX.Element {
+export function OpacKtaScanFlow({
+  open,
+  onOpenChange,
+  onMemberAuthenticated,
+}: OpacKtaScanFlowProps): JSX.Element {
   const { t } = useTranslation('opac');
+  const { showToast } = useToast();
+  const [resolving, setResolving] = useState(false);
+
+  const handleDecode = async (text: string): Promise<void> => {
+    if (resolving) return;
+    setResolving(true);
+    try {
+      let member: Anggota | null = null;
+      const memberId = parseQrPayload(text);
+      if (memberId !== null) {
+        try {
+          member = await anggotaApi.get(memberId);
+        } catch {
+          member = null;
+        }
+      }
+      if (!member) {
+        member = await anggotaApi.getByKode(text.trim());
+      }
+      if (!member) {
+        showToast({
+          variant: 'destructive',
+          title: t('session.memberNotFound', { kode: text }),
+        });
+        return;
+      }
+      scanner.stop();
+      onOpenChange(false);
+      onMemberAuthenticated?.(member);
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('session.scanError'),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  const scanner = useBarcodeScanner({
+    onDecode: (text) => {
+      void handleDecode(text);
+    },
+  });
+
+  // Stop the camera whenever the dialog closes so the MediaStream is
+  // released even if the user dismisses the modal mid-scan.
+  useEffect(() => {
+    if (!open) scanner.stop();
+  }, [open, scanner]);
+
+  const errorMessage =
+    scanner.errorKind === 'permission'
+      ? t('session.cameraPermissionDenied')
+      : scanner.errorKind === 'no-device'
+        ? t('session.cameraNoDevice')
+        : scanner.errorKind === 'in-use'
+          ? t('session.cameraInUse')
+          : scanner.errorKind === 'unsupported'
+            ? t('session.cameraUnsupported')
+            : scanner.error
+              ? t('session.cameraOtherError')
+              : null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <ScanLine className="h-5 w-5" />
@@ -37,18 +119,81 @@ export function OpacKtaScanFlow({ open, onOpenChange }: OpacKtaScanFlowProps): J
           <DialogDescription>{t('session.scanInstruction')}</DialogDescription>
         </DialogHeader>
 
-        <div className="flex h-48 flex-col items-center justify-center gap-3 rounded-md border border-dashed bg-muted/30 text-center">
-          <ScanLine className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
-          <p className="text-sm text-muted-foreground">
-            {t('home.scanKtaSubtitle')}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            (TODO: wire decoupled camera flow — same-device-only fallback)
-          </p>
+        <div className="relative aspect-video overflow-hidden rounded-md border bg-black/90">
+          <video
+            ref={scanner.videoRef}
+            className="h-full w-full object-cover"
+            muted
+            playsInline
+          />
+          {!scanner.active && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 text-white">
+              <CameraOff className="h-10 w-10 opacity-70" aria-hidden="true" />
+              <p className="text-sm">
+                {scanner.starting ? t('session.starting') : t('session.cameraOff')}
+              </p>
+            </div>
+          )}
         </div>
 
+        <div className="flex flex-wrap items-center gap-2">
+          {scanner.active ? (
+            <Button variant="outline" onClick={() => scanner.stop()}>
+              <VideoOff className="mr-1.5 h-4 w-4" />
+              {t('session.stopCamera')}
+            </Button>
+          ) : (
+            <Button
+              onClick={() => {
+                void scanner.start();
+              }}
+              disabled={scanner.starting}
+            >
+              {scanner.starting ? (
+                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              ) : (
+                <Video className="mr-1.5 h-4 w-4" />
+              )}
+              {t('session.startCamera')}
+            </Button>
+          )}
+          {scanner.devices.length > 1 && scanner.selectedDeviceId && (
+            <Select
+              value={scanner.selectedDeviceId}
+              onValueChange={(v) => scanner.selectDevice(v)}
+            >
+              <SelectTrigger className="w-60">
+                <SelectValue placeholder={t('session.selectDevice')} />
+              </SelectTrigger>
+              <SelectContent>
+                {scanner.devices.map((d) => (
+                  <SelectItem key={d.deviceId} value={d.deviceId}>
+                    {d.label || `Camera ${d.deviceId.slice(0, 6)}…`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        {errorMessage && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            {errorMessage}
+          </div>
+        )}
+
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)} className="gap-2">
+          <Button
+            variant="ghost"
+            onClick={() => {
+              scanner.stop();
+              onOpenChange(false);
+            }}
+            className="gap-2"
+          >
             <ArrowLeft className="h-4 w-4" />
             {t('search.back')}
           </Button>

--- a/apps/desktop/src/features/opac/OpacSearchPage.tsx
+++ b/apps/desktop/src/features/opac/OpacSearchPage.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, Heart, Search } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { OpacBookCard } from './OpacBookCard';
+import { OpacBookDetailDialog } from './OpacBookDetailDialog';
+import { OpacWishlistDialog } from './OpacWishlistDialog';
+import { bukuApi, type Buku } from '@/lib/buku';
+
+export interface OpacSearchPageProps {
+  initialQuery: string;
+  onBack: () => void;
+}
+
+const PAGE_SIZE = 24;
+
+export function OpacSearchPage({ initialQuery, onBack }: OpacSearchPageProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const [query, setQuery] = useState(initialQuery);
+  const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
+  const [items, setItems] = useState<Buku[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Buku | null>(null);
+  const [wishlistFor, setWishlistFor] = useState<Buku | null>(null);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(query), 200);
+    return () => clearTimeout(id);
+  }, [query]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    bukuApi
+      .list({
+        query: debouncedQuery.trim() || undefined,
+        limit: PAGE_SIZE,
+        offset: 0,
+        sortBy: 'judul',
+        sortDir: 'asc',
+      })
+      .then((res) => {
+        if (cancelled) return;
+        setItems(res.items);
+        setTotal(res.total);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery]);
+
+  const headerCount = useMemo(() => t('search.results', { count: total }), [t, total]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex flex-col gap-3 border-b bg-background/95 p-6">
+        <Button variant="ghost" size="sm" onClick={onBack} className="-ml-2 w-fit gap-2">
+          <ArrowLeft className="h-4 w-4" />
+          {t('search.back')}
+        </Button>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('home.searchPlaceholder')}
+            className="h-12 pl-10 text-lg"
+            autoFocus
+          />
+        </div>
+        <p className="text-sm text-muted-foreground">{headerCount}</p>
+      </header>
+
+      <main className="flex-1 overflow-auto p-6">
+        {loading ? (
+          <p className="text-sm text-muted-foreground">{t('search.loading')}</p>
+        ) : error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center gap-4 py-12 text-center">
+            <Heart className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
+            <p className="text-sm text-muted-foreground">{t('search.empty')}</p>
+            <Button variant="outline" onClick={() => setWishlistFor({ ...EMPTY_BUKU, judul: query })}>
+              {t('detail.wishlist')}
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            {items.map((b) => (
+              <OpacBookCard key={b.id} buku={b} onClick={setSelected} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <OpacBookDetailDialog
+        buku={selected}
+        open={selected !== null}
+        onOpenChange={(o) => !o && setSelected(null)}
+        onWishlist={(b) => {
+          setSelected(null);
+          setWishlistFor(b);
+        }}
+      />
+      <OpacWishlistDialog
+        open={wishlistFor !== null}
+        onOpenChange={(o) => !o && setWishlistFor(null)}
+        defaultJudul={wishlistFor?.judul ?? ''}
+        defaultPengarang={wishlistFor?.pengarang ?? ''}
+      />
+    </div>
+  );
+}
+
+const EMPTY_BUKU: Buku = {
+  id: 0,
+  kodeBuku: '',
+  judul: '',
+  jumlahEksemplar: 0,
+  jumlahTersedia: 0,
+  harga: 0,
+  tanggalInput: '',
+  createdAt: '',
+  updatedAt: '',
+};

--- a/apps/desktop/src/features/opac/OpacWishlistDialog.tsx
+++ b/apps/desktop/src/features/opac/OpacWishlistDialog.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface OpacWishlistDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultJudul?: string;
+  defaultPengarang?: string;
+  /** When provided, the dialog calls this on submit. If absent, shows a stub note. */
+  onSubmit?: (entry: { judul: string; pengarang: string; alasan: string }) => Promise<void>;
+}
+
+export function OpacWishlistDialog({
+  open,
+  onOpenChange,
+  defaultJudul = '',
+  defaultPengarang = '',
+  onSubmit,
+}: OpacWishlistDialogProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const [judul, setJudul] = useState(defaultJudul);
+  const [pengarang, setPengarang] = useState(defaultPengarang);
+  const [alasan, setAlasan] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setJudul(defaultJudul);
+      setPengarang(defaultPengarang);
+      setAlasan('');
+      setError(null);
+      setSuccess(false);
+    }
+  }, [open, defaultJudul, defaultPengarang]);
+
+  const handleSubmit = async (event: React.FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (submitting) return;
+    if (!onSubmit) {
+      setError(t('wishlist.stub'));
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({ judul: judul.trim(), pengarang: pengarang.trim(), alasan: alasan.trim() });
+      setSuccess(true);
+      setTimeout(() => onOpenChange(false), 1200);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('wishlist.error'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('wishlist.title')}</DialogTitle>
+          <DialogDescription>{onSubmit ? null : t('wishlist.stub')}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="opac-wishlist-judul">{t('wishlist.judul')}</Label>
+            <Input
+              id="opac-wishlist-judul"
+              value={judul}
+              onChange={(e) => setJudul(e.target.value)}
+              required
+              disabled={submitting || !onSubmit}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="opac-wishlist-pengarang">{t('wishlist.pengarang')}</Label>
+            <Input
+              id="opac-wishlist-pengarang"
+              value={pengarang}
+              onChange={(e) => setPengarang(e.target.value)}
+              disabled={submitting || !onSubmit}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="opac-wishlist-alasan">{t('wishlist.alasan')}</Label>
+            <Input
+              id="opac-wishlist-alasan"
+              value={alasan}
+              onChange={(e) => setAlasan(e.target.value)}
+              disabled={submitting || !onSubmit}
+            />
+          </div>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {success ? (
+            <p className="text-sm text-emerald-600" role="status">
+              {t('wishlist.success')}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+              {t('wishlist.cancel')}
+            </Button>
+            <Button type="submit" disabled={submitting || !onSubmit || judul.trim().length === 0}>
+              {submitting ? '…' : t('wishlist.submit')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/features/opac/useOpacIdleReset.ts
+++ b/apps/desktop/src/features/opac/useOpacIdleReset.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+
+export const DEFAULT_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
+
+/**
+ * Calls `onIdle` after `timeoutMs` of no user input (mouse / keyboard / touch).
+ * Resets on every interaction. Used by the OPAC kiosk to drop a member's
+ * session and return to the home screen after they walk away.
+ *
+ * Pure React/DOM — no Tauri dependency, so it works in jsdom tests.
+ */
+export function useOpacIdleReset(
+  onIdle: () => void,
+  options: { enabled?: boolean; timeoutMs?: number } = {},
+): void {
+  const enabled = options.enabled ?? true;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  const callbackRef = useRef(onIdle);
+  callbackRef.current = onIdle;
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    if (typeof window === 'undefined') return undefined;
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const reset = (): void => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        callbackRef.current();
+      }, timeoutMs);
+    };
+
+    const events: Array<keyof WindowEventMap> = [
+      'mousemove',
+      'mousedown',
+      'keydown',
+      'touchstart',
+      'wheel',
+      'scroll',
+    ];
+    events.forEach((ev) => window.addEventListener(ev, reset, { passive: true }));
+    reset();
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      events.forEach((ev) => window.removeEventListener(ev, reset));
+    };
+  }, [enabled, timeoutMs]);
+}

--- a/apps/desktop/src/features/settings/AksesModePage.tsx
+++ b/apps/desktop/src/features/settings/AksesModePage.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Lock, Monitor, Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/components/ui/toast-manager';
+import { SettingsSection } from './SettingsSection';
+import { settingsApi, type AppMode } from '@/lib/settings';
+
+export function AksesModePage(): JSX.Element {
+  const { t } = useTranslation(['settings', 'opac']);
+  const { showToast } = useToast();
+  const [mode, setMode] = useState<AppMode>('admin');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [confirmTo, setConfirmTo] = useState<AppMode | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const current = await settingsApi.getAppMode();
+        if (!cancelled) setMode(current);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSelect = (next: AppMode): void => {
+    if (next === mode) return;
+    setConfirmTo(next);
+  };
+
+  const confirmSwitch = async (): Promise<void> => {
+    if (confirmTo === null) return;
+    setSaving(true);
+    try {
+      await settingsApi.saveAppMode(confirmTo);
+      showToast({
+        title: t('settings:sections.aksesMode.feedback.saved', {
+          defaultValue: 'Mode akses tersimpan. Memuat ulang…',
+        }),
+      });
+      if (typeof window !== 'undefined') {
+        window.location.reload();
+      }
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('settings:sections.aksesMode.feedback.error', {
+          defaultValue: 'Gagal menyimpan mode akses',
+        }),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSaving(false);
+      setConfirmTo(null);
+    }
+  };
+
+  return (
+    <SettingsSection i18nKey="aksesMode">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <ModeCard
+          mode="admin"
+          active={mode === 'admin'}
+          icon={<Users className="h-5 w-5" />}
+          title={t('settings:sections.aksesMode.admin.label', { defaultValue: 'Admin' })}
+          description={t('settings:sections.aksesMode.admin.description', {
+            defaultValue: 'Mode normal untuk pustakawan / petugas.',
+          })}
+          disabled={loading}
+          onSelect={() => handleSelect('admin')}
+        />
+        <ModeCard
+          mode="public"
+          active={mode === 'public'}
+          icon={<Monitor className="h-5 w-5" />}
+          title={t('settings:sections.aksesMode.public.label', { defaultValue: 'Public OPAC' })}
+          description={t('settings:sections.aksesMode.public.description', {
+            defaultValue: 'Kios fullscreen untuk siswa / pengunjung.',
+          })}
+          disabled={loading}
+          onSelect={() => handleSelect('public')}
+        />
+      </div>
+
+      <p className="mt-4 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+        <Lock className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>
+          {t('settings:sections.aksesMode.warning', {
+            defaultValue:
+              'Setelah berpindah ke Public OPAC, aplikasi reload ke mode kios fullscreen. Untuk kembali ke admin, klik tombol "Mode Admin" di pojok bawah-kanan dan masukkan password admin.',
+          })}
+        </span>
+      </p>
+
+      <Dialog open={confirmTo !== null} onOpenChange={(o) => !o && setConfirmTo(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {confirmTo === 'public'
+                ? t('settings:sections.aksesMode.confirmPublic.title', {
+                    defaultValue: 'Beralih ke Public OPAC?',
+                  })
+                : t('settings:sections.aksesMode.confirmAdmin.title', {
+                    defaultValue: 'Beralih ke mode Admin?',
+                  })}
+            </DialogTitle>
+            <DialogDescription>
+              {confirmTo === 'public'
+                ? t('settings:sections.aksesMode.confirmPublic.description', {
+                    defaultValue:
+                      'Aplikasi akan reload ke kios fullscreen. Untuk keluar, masuk lewat tombol "Mode Admin".',
+                  })
+                : t('settings:sections.aksesMode.confirmAdmin.description', {
+                    defaultValue: 'Aplikasi akan reload ke mode admin normal.',
+                  })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setConfirmTo(null)} disabled={saving}>
+              {t('common:cancel', { defaultValue: 'Batal' })}
+            </Button>
+            <Button onClick={confirmSwitch} disabled={saving}>
+              {saving
+                ? '…'
+                : t('settings:sections.aksesMode.confirm', { defaultValue: 'Lanjutkan' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </SettingsSection>
+  );
+}
+
+interface ModeCardProps {
+  mode: AppMode;
+  active: boolean;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  disabled?: boolean;
+  onSelect: () => void;
+}
+
+function ModeCard({ mode, active, icon, title, description, disabled, onSelect }: ModeCardProps): JSX.Element {
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={() => !disabled && onSelect()}
+      onKeyDown={(e) => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      data-testid={`akses-mode-card-${mode}`}
+      data-active={active ? 'true' : 'false'}
+      aria-pressed={active}
+      className={`cursor-pointer p-4 transition ${
+        active
+          ? 'border-primary ring-2 ring-primary'
+          : 'hover:border-primary/60 hover:shadow'
+      } ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
+    >
+      <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
+        {icon}
+        {title}
+      </div>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </Card>
+  );
+}

--- a/apps/desktop/src/features/settings/sections.ts
+++ b/apps/desktop/src/features/settings/sections.ts
@@ -12,6 +12,7 @@ import {
   Info,
   BookText,
   BookOpen,
+  Monitor,
 } from 'lucide-react';
 
 /**
@@ -158,6 +159,13 @@ export const SECTIONS: SectionDef[] = [
     i18nKey: 'tentang',
     Icon: Info,
     keywords: ['tentang', 'about', 'version', 'versi', 'kredit', 'credits', 'github'],
+  },
+  {
+    id: 'akses-mode',
+    to: '/settings/akses-mode',
+    i18nKey: 'aksesMode',
+    Icon: Monitor,
+    keywords: ['akses mode', 'mode akses', 'opac', 'public', 'kios', 'kiosk', 'admin', 'fullscreen'],
   },
 ];
 

--- a/apps/desktop/src/i18n/en/opac.json
+++ b/apps/desktop/src/i18n/en/opac.json
@@ -51,7 +51,17 @@
     "scanInstruction": "Point your KTA barcode at the camera",
     "memberNotFound": "No member found for code {{kode}}",
     "scanError": "Could not read the KTA",
-    "idleReset": "Session ended due to inactivity"
+    "idleReset": "Session ended due to inactivity",
+    "startCamera": "Start camera",
+    "starting": "Starting camera…",
+    "stopCamera": "Stop camera",
+    "cameraOff": "Camera is off",
+    "cameraPermissionDenied": "Camera access blocked. Open browser/system settings to enable.",
+    "cameraNoDevice": "No camera detected.",
+    "cameraInUse": "Camera is being used by another app.",
+    "cameraUnsupported": "Browser does not support camera access.",
+    "cameraOtherError": "An error occurred while accessing the camera.",
+    "selectDevice": "Select camera"
   },
   "admin": {
     "unlockButton": "Admin Mode",

--- a/apps/desktop/src/i18n/en/opac.json
+++ b/apps/desktop/src/i18n/en/opac.json
@@ -1,0 +1,88 @@
+{
+  "title": "Library Catalog",
+  "subtitle": "Search the collection and request reservations",
+  "home": {
+    "searchPlaceholder": "Search by title, author, or ISBN…",
+    "scanKta": "Scan My KTA",
+    "scanKtaSubtitle": "Sign in with your member card for a personalised view",
+    "browse": "Browse Collection",
+    "filters": "Filters",
+    "kategori": "Category",
+    "bahasa": "Language",
+    "semua": "All",
+    "ketersediaan": "Availability",
+    "available": "Available",
+    "borrowed": "Checked out"
+  },
+  "search": {
+    "results": "{{count}} results",
+    "empty": "No books match your search.",
+    "loading": "Loading results…",
+    "back": "Back"
+  },
+  "card": {
+    "available": "Available",
+    "borrowed": "Checked out",
+    "rak": "Shelf {{kode}}",
+    "noCover": "No cover"
+  },
+  "detail": {
+    "title": "Book Details",
+    "pengarang": "Author",
+    "penerbit": "Publisher",
+    "tahun": "Year published",
+    "kategori": "Category",
+    "isbn": "ISBN",
+    "ddc": "DDC",
+    "rak": "Shelf location",
+    "deskripsi": "Description",
+    "stockTersedia": "{{tersedia}} of {{total}} copies available",
+    "noDescription": "No description available.",
+    "reserve": "Reserve",
+    "reserveTooltip": "Reservation queue (only available after KTA login)",
+    "wishlist": "Add to Wishlist",
+    "wishlistTooltip": "Request the library to acquire this book",
+    "close": "Close"
+  },
+  "session": {
+    "loginPrompt": "Sign in with KTA",
+    "logout": "Sign out",
+    "welcome": "Welcome, {{nama}}",
+    "scanInstruction": "Point your KTA barcode at the camera",
+    "memberNotFound": "No member found for code {{kode}}",
+    "scanError": "Could not read the KTA",
+    "idleReset": "Session ended due to inactivity"
+  },
+  "admin": {
+    "unlockButton": "Admin Mode",
+    "unlockTitle": "Exit OPAC Mode",
+    "unlockDescription": "Enter the admin username and password to return to admin mode.",
+    "username": "Username",
+    "password": "Password",
+    "submit": "Verify",
+    "cancel": "Cancel",
+    "wrongPassword": "Wrong username or password",
+    "tooManyTries": "Too many attempts. Try again in {{seconds}} seconds.",
+    "lockedFor": "{{seconds}} seconds",
+    "switching": "Reloading to admin mode…"
+  },
+  "wishlist": {
+    "title": "Add to Wishlist",
+    "judul": "Book title",
+    "pengarang": "Author (optional)",
+    "alasan": "Reason / note (optional)",
+    "submit": "Submit",
+    "cancel": "Cancel",
+    "success": "Wishlist submitted to admin",
+    "error": "Failed to submit wishlist",
+    "stub": "Wishlist will be available once the procurement feature ships."
+  },
+  "kiosk": {
+    "fullscreenError": "Could not enter fullscreen automatically. Press F11 if not in fullscreen.",
+    "limitations": "Note: Ctrl+Alt+Del / Task Manager cannot be disabled from the app."
+  },
+  "footer": {
+    "poweredBy": "Perpustakaan Nusantara",
+    "version": "v{{version}}"
+  }
+}

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -293,6 +293,31 @@
       "creditsValue": "alvi arts / vwrks",
       "openRepo": "GitHub Repository",
       "license": "License"
+    },
+    "aksesMode": {
+      "label": "Access Mode",
+      "summary": "Switch between Admin (operator) and Public OPAC (fullscreen student kiosk).",
+      "admin": {
+        "label": "Admin",
+        "description": "Normal mode for librarians / staff."
+      },
+      "public": {
+        "label": "Public OPAC",
+        "description": "Fullscreen kiosk for students / visitors."
+      },
+      "warning": "After switching to Public OPAC, the app reloads into fullscreen kiosk mode. To return to admin, click the \"Admin Mode\" button in the bottom-right corner and enter the admin password.",
+      "confirm": "Continue",
+      "confirmPublic": {
+        "title": "Switch to Public OPAC?",
+        "description": "The app will reload into fullscreen kiosk mode. To exit, use the \"Admin Mode\" button."
+      },
+      "confirmAdmin": {
+        "title": "Switch to Admin mode?",
+        "description": "The app will reload into normal admin mode."
+      },
+      "feedback": {
+        "saved": "Access mode saved. Reloading…"
+      }
     }
   }
 }

--- a/apps/desktop/src/i18n/id/opac.json
+++ b/apps/desktop/src/i18n/id/opac.json
@@ -51,7 +51,17 @@
     "scanInstruction": "Arahkan barcode KTA Anda ke kamera",
     "memberNotFound": "Anggota tidak ditemukan untuk kode {{kode}}",
     "scanError": "Tidak dapat membaca KTA",
-    "idleReset": "Sesi otomatis berakhir karena tidak aktif"
+    "idleReset": "Sesi otomatis berakhir karena tidak aktif",
+    "startCamera": "Aktifkan Kamera",
+    "starting": "Membuka kamera…",
+    "stopCamera": "Matikan Kamera",
+    "cameraOff": "Kamera belum aktif",
+    "cameraPermissionDenied": "Akses kamera diblokir. Buka pengaturan browser/sistem untuk mengaktifkan.",
+    "cameraNoDevice": "Tidak ada kamera yang terdeteksi.",
+    "cameraInUse": "Kamera sedang dipakai aplikasi lain.",
+    "cameraUnsupported": "Browser tidak mendukung akses kamera.",
+    "cameraOtherError": "Terjadi kesalahan saat mengakses kamera.",
+    "selectDevice": "Pilih kamera"
   },
   "admin": {
     "unlockButton": "Mode Admin",

--- a/apps/desktop/src/i18n/id/opac.json
+++ b/apps/desktop/src/i18n/id/opac.json
@@ -1,0 +1,88 @@
+{
+  "title": "Katalog Perpustakaan",
+  "subtitle": "Cari koleksi buku dan reservasi mandiri",
+  "home": {
+    "searchPlaceholder": "Cari judul, pengarang, atau ISBN…",
+    "scanKta": "Scan KTA Saya",
+    "scanKtaSubtitle": "Login dengan kartu anggota untuk personalisasi",
+    "browse": "Telusuri Koleksi",
+    "filters": "Filter",
+    "kategori": "Kategori",
+    "bahasa": "Bahasa",
+    "semua": "Semua",
+    "ketersediaan": "Ketersediaan",
+    "available": "Tersedia",
+    "borrowed": "Dipinjam"
+  },
+  "search": {
+    "results": "{{count}} hasil",
+    "empty": "Tidak ada buku yang cocok dengan pencarian.",
+    "loading": "Memuat hasil…",
+    "back": "Kembali"
+  },
+  "card": {
+    "available": "Tersedia",
+    "borrowed": "Dipinjam",
+    "rak": "Rak {{kode}}",
+    "noCover": "Tidak ada cover"
+  },
+  "detail": {
+    "title": "Detail Buku",
+    "pengarang": "Pengarang",
+    "penerbit": "Penerbit",
+    "tahun": "Tahun terbit",
+    "kategori": "Kategori",
+    "isbn": "ISBN",
+    "ddc": "DDC",
+    "rak": "Lokasi rak",
+    "deskripsi": "Deskripsi",
+    "stockTersedia": "{{tersedia}} dari {{total}} eksemplar tersedia",
+    "noDescription": "Tidak ada deskripsi.",
+    "reserve": "Reservasi",
+    "reserveTooltip": "Antrean reservasi (hanya tersedia setelah login KTA)",
+    "wishlist": "Tambah ke Wishlist",
+    "wishlistTooltip": "Ajukan permintaan pengadaan buku ini",
+    "close": "Tutup"
+  },
+  "session": {
+    "loginPrompt": "Login KTA",
+    "logout": "Logout",
+    "welcome": "Selamat datang, {{nama}}",
+    "scanInstruction": "Arahkan barcode KTA Anda ke kamera",
+    "memberNotFound": "Anggota tidak ditemukan untuk kode {{kode}}",
+    "scanError": "Tidak dapat membaca KTA",
+    "idleReset": "Sesi otomatis berakhir karena tidak aktif"
+  },
+  "admin": {
+    "unlockButton": "Mode Admin",
+    "unlockTitle": "Keluar Mode OPAC",
+    "unlockDescription": "Masukkan username & password admin untuk kembali ke mode admin.",
+    "username": "Username",
+    "password": "Password",
+    "submit": "Verifikasi",
+    "cancel": "Batal",
+    "wrongPassword": "Username atau password salah",
+    "tooManyTries": "Terlalu banyak percobaan. Coba lagi dalam {{seconds}} detik.",
+    "lockedFor": "{{seconds}} detik",
+    "switching": "Memuat ulang ke mode admin…"
+  },
+  "wishlist": {
+    "title": "Tambah ke Wishlist",
+    "judul": "Judul Buku",
+    "pengarang": "Pengarang (opsional)",
+    "alasan": "Alasan / catatan (opsional)",
+    "submit": "Kirim",
+    "cancel": "Batal",
+    "success": "Wishlist terkirim ke admin",
+    "error": "Gagal mengirim wishlist",
+    "stub": "Fitur wishlist akan tersedia setelah feature pengadaan diaktifkan."
+  },
+  "kiosk": {
+    "fullscreenError": "Tidak dapat masuk fullscreen otomatis. Tekan F11 jika belum fullscreen.",
+    "limitations": "Catatan: Ctrl+Alt+Del / Task Manager tidak dapat dinonaktifkan dari aplikasi."
+  },
+  "footer": {
+    "poweredBy": "Perpustakaan Nusantara",
+    "version": "v{{version}}"
+  }
+}

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -293,6 +293,31 @@
       "creditsValue": "alvi arts / vwrks",
       "openRepo": "Repositori GitHub",
       "license": "Lisensi"
+    },
+    "aksesMode": {
+      "label": "Mode Akses",
+      "summary": "Pilih antara mode Admin (operator) atau Public OPAC (kios siswa fullscreen).",
+      "admin": {
+        "label": "Admin",
+        "description": "Mode normal untuk pustakawan / petugas."
+      },
+      "public": {
+        "label": "Public OPAC",
+        "description": "Kios fullscreen untuk siswa / pengunjung."
+      },
+      "warning": "Setelah berpindah ke Public OPAC, aplikasi reload ke mode kios fullscreen. Untuk kembali ke admin, klik tombol \"Mode Admin\" di pojok bawah-kanan dan masukkan password admin.",
+      "confirm": "Lanjutkan",
+      "confirmPublic": {
+        "title": "Beralih ke Public OPAC?",
+        "description": "Aplikasi akan reload ke kios fullscreen. Untuk keluar, masuk lewat tombol \"Mode Admin\"."
+      },
+      "confirmAdmin": {
+        "title": "Beralih ke mode Admin?",
+        "description": "Aplikasi akan reload ke mode admin normal."
+      },
+      "feedback": {
+        "saved": "Mode akses tersimpan. Memuat ulang…"
+      }
     }
   }
 }

--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -17,6 +17,7 @@ import idLabelBuku from './id/label-buku.json';
 import idSirkulasi from './id/sirkulasi.json';
 import idReservasi from './id/reservasi.json';
 import idStocktake from './id/stocktake.json';
+import idOpac from './id/opac.json';
 import idErrors from './id/errors.json';
 import idSurat from './id/surat.json';
 import idWishlist from './id/wishlist.json';
@@ -37,6 +38,7 @@ import enLabelBuku from './en/label-buku.json';
 import enSirkulasi from './en/sirkulasi.json';
 import enReservasi from './en/reservasi.json';
 import enStocktake from './en/stocktake.json';
+import enOpac from './en/opac.json';
 import enErrors from './en/errors.json';
 import enSurat from './en/surat.json';
 import enWishlist from './en/wishlist.json';
@@ -58,6 +60,7 @@ export const NAMESPACES = [
   'sirkulasi',
   'reservasi',
   'stocktake',
+  'opac',
   'errors',
   'surat',
   'wishlist',
@@ -84,6 +87,7 @@ const resources = {
     sirkulasi: idSirkulasi,
     reservasi: idReservasi,
     stocktake: idStocktake,
+    opac: idOpac,
     errors: idErrors,
     surat: idSurat,
     wishlist: idWishlist,
@@ -105,6 +109,7 @@ const resources = {
     sirkulasi: enSirkulasi,
     reservasi: enReservasi,
     stocktake: enStocktake,
+    opac: enOpac,
     errors: enErrors,
     surat: enSurat,
     wishlist: enWishlist,

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -66,6 +66,16 @@ export type CloseBehavior = 'exit' | 'tray';
 export const DEFAULT_CLOSE_BEHAVIOR: CloseBehavior = 'exit';
 
 // ---------------------------------------------------------------------------
+// App mode (admin vs public OPAC)
+// ---------------------------------------------------------------------------
+
+export type AppMode = 'admin' | 'public';
+
+export const DEFAULT_APP_MODE: AppMode = 'admin';
+
+export const APP_MODE_KEY = 'desktop.app_mode';
+
+// ---------------------------------------------------------------------------
 // Sync configuration
 // ---------------------------------------------------------------------------
 
@@ -266,6 +276,7 @@ const MOCK_KEYS = {
   audit: 'po:settings:audit-log',
   identity: 'po:settings:identity',
   closeBehavior: 'po:settings:close-behavior',
+  appMode: 'po:settings:app-mode',
 };
 
 const readMock = <T,>(key: string, fallback: T): T => {
@@ -356,6 +367,9 @@ export interface SettingsApi {
   getCloseBehavior(): Promise<CloseBehavior>;
   saveCloseBehavior(behavior: CloseBehavior): Promise<CloseBehavior>;
   forceQuit(): Promise<void>;
+
+  getAppMode(): Promise<AppMode>;
+  saveAppMode(mode: AppMode): Promise<AppMode>;
 
   getSyncConfig(): Promise<SyncConfig>;
   saveSyncConfig(cfg: SyncConfig): Promise<SyncConfig>;
@@ -484,6 +498,14 @@ const mockApi: SettingsApi = {
   },
   async forceQuit() {
     // No-op in browser/dev mock — there's no .exe to quit.
+  },
+
+  async getAppMode() {
+    return readMock<AppMode>(MOCK_KEYS.appMode, DEFAULT_APP_MODE);
+  },
+  async saveAppMode(mode) {
+    writeMock(MOCK_KEYS.appMode, mode);
+    return mode;
   },
 
   async getSyncConfig() {
@@ -745,6 +767,22 @@ const tauriApi: SettingsApi = {
     await invoke('force_quit');
   },
 
+  async getAppMode() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const rows = await invoke<Record<string, string>>('settings_get_many', {
+      keys: [APP_MODE_KEY],
+    });
+    const raw = rows[APP_MODE_KEY] ?? '';
+    return raw === 'public' ? 'public' : 'admin';
+  },
+  async saveAppMode(mode) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('settings_set_many', {
+      entries: { [APP_MODE_KEY]: mode },
+    });
+    return mode;
+  },
+
   async getSyncConfig() {
     const { invoke } = await import('@tauri-apps/api/core');
     const rows = await invoke<Record<string, string>>('settings_get_many', {
@@ -866,6 +904,8 @@ export const settingsApi: SettingsApi = {
   getCloseBehavior: () => rpc().getCloseBehavior(),
   saveCloseBehavior: (b) => rpc().saveCloseBehavior(b),
   forceQuit: () => rpc().forceQuit(),
+  getAppMode: () => rpc().getAppMode(),
+  saveAppMode: (mode) => rpc().saveAppMode(mode),
   getSyncConfig: () => rpc().getSyncConfig(),
   saveSyncConfig: (cfg) => rpc().saveSyncConfig(cfg),
   resetSyncConfig: () => rpc().resetSyncConfig(),

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -7,6 +7,11 @@ import { useThemeStore } from '@/stores/themeStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useIdentityStore, subscribeIdentityChanges } from '@/stores/identityStore';
 import { tryAutoLogin } from '@/lib/auth';
+import { settingsApi } from '@/lib/settings';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { ToastProvider, ToastViewport } from '@/components/ui/toast';
+import { ToastManagerProvider } from '@/components/ui/toast-manager';
+import { OpacApp } from '@/features/opac/OpacApp';
 import { routeTree } from './routeTree.gen';
 
 const router = createRouter({
@@ -22,25 +27,52 @@ declare module '@tanstack/react-router' {
 
 useThemeStore.getState().resolve();
 
+function OpacRoot(): JSX.Element {
+  return (
+    <ToastProvider>
+      <ToastManagerProvider>
+        <TooltipProvider delayDuration={150}>
+          <div className="flex h-screen flex-col">
+            <div className="min-h-0 flex-1">
+              <OpacApp />
+            </div>
+          </div>
+          <ToastViewport />
+        </TooltipProvider>
+      </ToastManagerProvider>
+    </ToastProvider>
+  );
+}
+
 void (async () => {
   void useIdentityStore.getState().loadIdentity();
   void subscribeIdentityChanges();
-  const auth = useAuthStore.getState();
-  if (auth.rememberMe && !auth.user) {
-    try {
-      const user = await tryAutoLogin();
-      if (user) auth.setUser(user);
-    } catch {
-      /* ignore */
+
+  let appMode: 'admin' | 'public' = 'admin';
+  try {
+    appMode = await settingsApi.getAppMode();
+  } catch {
+    // Default to admin mode on read failure.
+  }
+
+  if (appMode !== 'public') {
+    const auth = useAuthStore.getState();
+    if (auth.rememberMe && !auth.user) {
+      try {
+        const user = await tryAutoLogin();
+        if (user) auth.setUser(user);
+      } catch {
+        /* ignore */
+      }
     }
   }
+
+  const rootEl = document.getElementById('root');
+  if (!rootEl) throw new Error('Root element not found');
+
+  ReactDOM.createRoot(rootEl).render(
+    <React.StrictMode>
+      {appMode === 'public' ? <OpacRoot /> : <RouterProvider router={router} />}
+    </React.StrictMode>,
+  );
 })();
-
-const rootEl = document.getElementById('root');
-if (!rootEl) throw new Error('Root element not found');
-
-ReactDOM.createRoot(rootEl).render(
-  <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>,
-);

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as AuthedSettingsBackupRouteImport } from './routes/_authed/setti
 import { Route as AuthedSettingsAuditLogRouteImport } from './routes/_authed/settings/audit-log'
 import { Route as AuthedSettingsAturanPeminjamanRouteImport } from './routes/_authed/settings/aturan-peminjaman'
 import { Route as AuthedSettingsAkunRouteImport } from './routes/_authed/settings/akun'
+import { Route as AuthedSettingsAksesModeRouteImport } from './routes/_authed/settings/akses-mode'
 import { Route as AuthedPeminjamanNewRouteImport } from './routes/_authed/peminjaman/new'
 import { Route as AuthedPeminjamanIdRouteImport } from './routes/_authed/peminjaman/$id'
 import { Route as AuthedLaporanTopPeminjamRouteImport } from './routes/_authed/laporan/top-peminjam'
@@ -211,6 +212,11 @@ const AuthedSettingsAkunRoute = AuthedSettingsAkunRouteImport.update({
   path: '/akun',
   getParentRoute: () => AuthedSettingsRoute,
 } as any)
+const AuthedSettingsAksesModeRoute = AuthedSettingsAksesModeRouteImport.update({
+  id: '/akses-mode',
+  path: '/akses-mode',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
 const AuthedPeminjamanNewRoute = AuthedPeminjamanNewRouteImport.update({
   id: '/peminjaman/new',
   path: '/peminjaman/new',
@@ -300,6 +306,7 @@ export interface FileRoutesByFullPath {
   '/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/peminjaman/new': typeof AuthedPeminjamanNewRoute
+  '/settings/akses-mode': typeof AuthedSettingsAksesModeRoute
   '/settings/akun': typeof AuthedSettingsAkunRoute
   '/settings/aturan-peminjaman': typeof AuthedSettingsAturanPeminjamanRoute
   '/settings/audit-log': typeof AuthedSettingsAuditLogRoute
@@ -343,6 +350,7 @@ export interface FileRoutesByTo {
   '/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/peminjaman/new': typeof AuthedPeminjamanNewRoute
+  '/settings/akses-mode': typeof AuthedSettingsAksesModeRoute
   '/settings/akun': typeof AuthedSettingsAkunRoute
   '/settings/aturan-peminjaman': typeof AuthedSettingsAturanPeminjamanRoute
   '/settings/audit-log': typeof AuthedSettingsAuditLogRoute
@@ -390,6 +398,7 @@ export interface FileRoutesById {
   '/_authed/laporan/top-peminjam': typeof AuthedLaporanTopPeminjamRoute
   '/_authed/peminjaman/$id': typeof AuthedPeminjamanIdRoute
   '/_authed/peminjaman/new': typeof AuthedPeminjamanNewRoute
+  '/_authed/settings/akses-mode': typeof AuthedSettingsAksesModeRoute
   '/_authed/settings/akun': typeof AuthedSettingsAkunRoute
   '/_authed/settings/aturan-peminjaman': typeof AuthedSettingsAturanPeminjamanRoute
   '/_authed/settings/audit-log': typeof AuthedSettingsAuditLogRoute
@@ -437,6 +446,7 @@ export interface FileRouteTypes {
     | '/laporan/top-peminjam'
     | '/peminjaman/$id'
     | '/peminjaman/new'
+    | '/settings/akses-mode'
     | '/settings/akun'
     | '/settings/aturan-peminjaman'
     | '/settings/audit-log'
@@ -480,6 +490,7 @@ export interface FileRouteTypes {
     | '/laporan/top-peminjam'
     | '/peminjaman/$id'
     | '/peminjaman/new'
+    | '/settings/akses-mode'
     | '/settings/akun'
     | '/settings/aturan-peminjaman'
     | '/settings/audit-log'
@@ -526,6 +537,7 @@ export interface FileRouteTypes {
     | '/_authed/laporan/top-peminjam'
     | '/_authed/peminjaman/$id'
     | '/_authed/peminjaman/new'
+    | '/_authed/settings/akses-mode'
     | '/_authed/settings/akun'
     | '/_authed/settings/aturan-peminjaman'
     | '/_authed/settings/audit-log'
@@ -775,6 +787,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedSettingsAkunRouteImport
       parentRoute: typeof AuthedSettingsRoute
     }
+    '/_authed/settings/akses-mode': {
+      id: '/_authed/settings/akses-mode'
+      path: '/akses-mode'
+      fullPath: '/settings/akses-mode'
+      preLoaderRoute: typeof AuthedSettingsAksesModeRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
     '/_authed/peminjaman/new': {
       id: '/_authed/peminjaman/new'
       path: '/peminjaman/new'
@@ -892,6 +911,7 @@ const AuthedLaporanRouteWithChildren = AuthedLaporanRoute._addFileChildren(
 )
 
 interface AuthedSettingsRouteChildren {
+  AuthedSettingsAksesModeRoute: typeof AuthedSettingsAksesModeRoute
   AuthedSettingsAkunRoute: typeof AuthedSettingsAkunRoute
   AuthedSettingsAturanPeminjamanRoute: typeof AuthedSettingsAturanPeminjamanRoute
   AuthedSettingsAuditLogRoute: typeof AuthedSettingsAuditLogRoute
@@ -910,6 +930,7 @@ interface AuthedSettingsRouteChildren {
 }
 
 const AuthedSettingsRouteChildren: AuthedSettingsRouteChildren = {
+  AuthedSettingsAksesModeRoute: AuthedSettingsAksesModeRoute,
   AuthedSettingsAkunRoute: AuthedSettingsAkunRoute,
   AuthedSettingsAturanPeminjamanRoute: AuthedSettingsAturanPeminjamanRoute,
   AuthedSettingsAuditLogRoute: AuthedSettingsAuditLogRoute,

--- a/apps/desktop/src/routes/_authed/settings/akses-mode.tsx
+++ b/apps/desktop/src/routes/_authed/settings/akses-mode.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AksesModePage } from '@/features/settings/AksesModePage';
+
+export const Route = createFileRoute('/_authed/settings/akses-mode')({
+  component: AksesModePage,
+});

--- a/apps/desktop/tests/unit/appMode.test.ts
+++ b/apps/desktop/tests/unit/appMode.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_APP_MODE,
+  APP_MODE_KEY,
+  settingsApi,
+  type AppMode,
+} from '@/lib/settings';
+
+describe('settingsApi.appMode (browser mock — FEAT-27)', () => {
+  beforeEach(() => {
+    settingsApi.__resetMock?.();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    settingsApi.__resetMock?.();
+    window.localStorage.clear();
+  });
+
+  it('exposes the canonical setting key', () => {
+    expect(APP_MODE_KEY).toBe('desktop.app_mode');
+  });
+
+  it('defaults to admin when no value is persisted yet', async () => {
+    expect(DEFAULT_APP_MODE).toBe('admin');
+    const got = await settingsApi.getAppMode();
+    expect(got).toBe('admin');
+  });
+
+  it('persists public mode through a save → get round trip', async () => {
+    const saved = await settingsApi.saveAppMode('public');
+    expect(saved).toBe('public');
+    const got = await settingsApi.getAppMode();
+    expect(got).toBe('public');
+  });
+
+  it('persists admin mode after toggling back from public', async () => {
+    await settingsApi.saveAppMode('public');
+    await settingsApi.saveAppMode('admin');
+    const got = await settingsApi.getAppMode();
+    expect(got).toBe('admin');
+  });
+
+  it.each<['admin' | 'public']>([['admin'], ['public']])(
+    'survives independent reads after %s persist',
+    async (mode: AppMode) => {
+      await settingsApi.saveAppMode(mode);
+      const a = await settingsApi.getAppMode();
+      const b = await settingsApi.getAppMode();
+      expect(a).toBe(mode);
+      expect(b).toBe(mode);
+    },
+  );
+});

--- a/apps/desktop/tests/unit/opacAdminUnlock.test.tsx
+++ b/apps/desktop/tests/unit/opacAdminUnlock.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
+import { OpacAdminUnlockButton } from '@/features/opac/OpacAdminUnlockButton';
+
+function renderButton(verifyResult: boolean | Error) {
+  const onVerify = vi.fn(async (_u: string, _p: string) => {
+    if (verifyResult instanceof Error) throw verifyResult;
+    return verifyResult;
+  });
+  const onSuccess = vi.fn();
+  render(
+    <I18nextProvider i18n={i18n}>
+      <OpacAdminUnlockButton onVerify={onVerify} onSuccess={onSuccess} />
+    </I18nextProvider>,
+  );
+  return { onVerify, onSuccess };
+}
+
+const openDialog = (): void => {
+  const trigger = screen.getByRole('button', { name: /Mode Admin/i });
+  fireEvent.click(trigger);
+};
+
+describe('OpacAdminUnlockButton (FEAT-27)', () => {
+  it('opens the password dialog when the lock button is clicked', () => {
+    renderButton(true);
+    openDialog();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+  });
+
+  it('calls onSuccess on a correct password', async () => {
+    const { onVerify, onSuccess } = renderButton(true);
+    openDialog();
+    fireEvent.change(screen.getByLabelText(/Username/i), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'admin123' } });
+    fireEvent.click(screen.getByRole('button', { name: /Verifikasi|Verify/i }));
+    await waitFor(() => expect(onVerify).toHaveBeenCalledTimes(1));
+    expect(onVerify).toHaveBeenCalledWith('admin', 'admin123');
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error after a wrong password', async () => {
+    const { onSuccess } = renderButton(false);
+    openDialog();
+    fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: /Verifikasi|Verify/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('locks the form after 3 failed attempts', async () => {
+    const { onVerify, onSuccess } = renderButton(false);
+    openDialog();
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: `wrong-${i}` } });
+      fireEvent.click(screen.getByRole('button', { name: /Verifikasi|Verify/i }));
+      await waitFor(() => expect(onVerify).toHaveBeenCalledTimes(i + 1));
+    }
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    const submit = screen.getByRole('button', { name: /Verifikasi|Verify/i });
+    expect(submit).toBeDisabled();
+    expect(screen.getByLabelText(/Password/i)).toBeDisabled();
+  });
+});

--- a/apps/desktop/tests/unit/opacApp.test.tsx
+++ b/apps/desktop/tests/unit/opacApp.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
+import { OpacApp } from '@/features/opac/OpacApp';
+import { ToastManagerProvider } from '@/components/ui/toast-manager';
+import { ToastProvider, ToastViewport } from '@/components/ui/toast';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+function Wrap({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <ToastProvider>
+        <ToastManagerProvider>
+          <TooltipProvider>{children}</TooltipProvider>
+          <ToastViewport />
+        </ToastManagerProvider>
+      </ToastProvider>
+    </I18nextProvider>
+  );
+}
+
+describe('OpacApp (FEAT-27)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the home page by default with search bar and scan KTA CTA', async () => {
+    render(
+      <Wrap>
+        <OpacApp />
+      </Wrap>,
+    );
+    expect(await screen.findByPlaceholderText(/Cari judul|Search by title/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Scan KTA Saya|Scan My KTA/i })).toBeInTheDocument();
+  });
+
+  it('navigates to the search view when the user submits the home search form', async () => {
+    render(
+      <Wrap>
+        <OpacApp />
+      </Wrap>,
+    );
+    const input = await screen.findByPlaceholderText(/Cari judul|Search by title/i);
+    fireEvent.change(input, { target: { value: 'sapiens' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Kembali|Back/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('shows the lock-icon admin unlock button anchored bottom-right', async () => {
+    render(
+      <Wrap>
+        <OpacApp />
+      </Wrap>,
+    );
+    expect(
+      await screen.findByRole('button', { name: /Mode Admin|Admin Mode/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/tests/unit/opacIdleReset.test.tsx
+++ b/apps/desktop/tests/unit/opacIdleReset.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import {
+  DEFAULT_IDLE_TIMEOUT_MS,
+  useOpacIdleReset,
+} from '@/features/opac/useOpacIdleReset';
+
+interface ProbeProps {
+  onIdle: () => void;
+  enabled?: boolean;
+  timeoutMs?: number;
+}
+
+function Probe({ onIdle, enabled, timeoutMs }: ProbeProps): JSX.Element {
+  useOpacIdleReset(onIdle, { enabled, timeoutMs });
+  return <div data-testid="probe" />;
+}
+
+describe('useOpacIdleReset (FEAT-27)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('exposes a 2-minute default timeout', () => {
+    expect(DEFAULT_IDLE_TIMEOUT_MS).toBe(2 * 60 * 1000);
+  });
+
+  it('fires onIdle after the timeout when no input arrives', () => {
+    const onIdle = vi.fn();
+    render(<Probe onIdle={onIdle} timeoutMs={500} />);
+    expect(onIdle).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the timer when the user moves the mouse', () => {
+    const onIdle = vi.fn();
+    render(<Probe onIdle={onIdle} timeoutMs={500} />);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the timer when a key is pressed', () => {
+    const onIdle = vi.fn();
+    render(<Probe onIdle={onIdle} timeoutMs={500} />);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it('does not arm the timer when enabled=false', () => {
+    const onIdle = vi.fn();
+    render(<Probe onIdle={onIdle} timeoutMs={500} enabled={false} />);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it('cleans up listeners on unmount', () => {
+    const onIdle = vi.fn();
+    const { unmount } = render(<Probe onIdle={onIdle} timeoutMs={500} />);
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(2000);
+      window.dispatchEvent(new MouseEvent('mousemove'));
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **FEAT-27 (PR H — Public OPAC mode + kiosk lock)** with the
fallback "same-device-only" path per `BUGS.md` line 751 (no dependency on
FEAT-26 multi-device sync).

Adds an app-wide `app_mode` setting (`admin` | `public`) that decides at
boot which UI to render. In `public` mode the desktop app loads a
fullscreen catalog kiosk; pengaturan grows a "Mode Akses" page so the
admin can flip between the two with a confirm dialog and auto-reload.

## Changes

### Frontend
- New `desktop.app_mode` settings key, persisted via `settings_get_many`
  / `settings_set_many` (same backend pattern as the other Pengaturan
  pages — no Rust changes needed for storage).
- `apps/desktop/src/main.tsx` reads the saved mode at boot and renders
  either the admin `RouterProvider` or the new `OpacApp`.
- `apps/desktop/src/features/opac/`:
  - `OpacApp.tsx` — root, applies fullscreen + always-on-top + decorations-off
    via the Tauri window API (best-effort), listens for F11 / Alt+F4 and
    stops them. Tracks the active KTA member session and renders a
    personalised welcome banner with logout. Uses the idle-reset hook to
    drop session + return to home after 2 minutes.
  - `OpacHomePage.tsx` — large search bar, "Scan KTA Saya" CTA, and a
    grid of recent additions for browse-without-search.
  - `OpacSearchPage.tsx` — debounced query, results grid, empty-state
    that offers a wishlist submission.
  - `OpacBookCard.tsx` / `OpacBookDetailDialog.tsx` — card + modal
    showing metadata, rak location, availability badge, and stub
    Reservasi / Wishlist buttons (Reservasi gated on KTA session).
  - `OpacWishlistDialog.tsx` — wishlist submit form (stub if no
    `onSubmit` prop, ready for FEAT-22 wiring later).
  - `OpacKtaScanFlow.tsx` — full camera scan flow, wraps
    `useBarcodeScanner` with an embedded `<video>` element. Decodes
    Code-128 (`kode_anggota`) or QR (`member:<id>`) → resolves via
    `anggotaApi.get` / `anggotaApi.getByKode` → emits
    `onMemberAuthenticated(member)`. The dialog owns the camera
    lifecycle and stops it on close.
  - `OpacAdminUnlockButton.tsx` — small lock icon in the bottom-right;
    on click opens a username + password dialog backed by `auth_login`,
    locks for 60 seconds after 3 failed attempts.
  - `useOpacIdleReset.ts` — pure hook, listens for mouse/keyboard/touch
    and fires `onIdle` after 2 minutes of inactivity.
- `apps/desktop/src/features/settings/AksesModePage.tsx` — radio cards
  Admin / Public OPAC + confirm dialog + reload-on-save.
- `apps/desktop/src/routes/_authed/settings/akses-mode.tsx` —
  TanStack route entry; `routeTree.gen.ts` regenerated.
- `apps/desktop/src/i18n/{id,en}/opac.json` — new namespace covering
  every UI string in the OPAC tree (id ↔ en parity), including all
  `session.cameraXxx` strings used by the scan-flow error states.
- `apps/desktop/src/i18n/{id,en}/settings.json` — new
  `sections.aksesMode` group used by the toggle page and search index.

### Tests (vitest)
- `tests/unit/appMode.test.ts` — 6 tests (default, round-trip, both directions).
- `tests/unit/opacIdleReset.test.tsx` — 6 tests (timeout, reset on
  mouse/keyboard, disabled mode, cleanup on unmount).
- `tests/unit/opacAdminUnlock.test.tsx` — 4 tests (open dialog, success
  path, wrong-password error, 3-strike lockout).
- `tests/unit/opacApp.test.tsx` — 3 routing tests (home renders,
  home → search submit transitions to results, lock button visible).

Total: **19 new tests, 273 → 292 vitest** (backend cargo tests untouched).

## Local gates

- `pnpm --filter desktop run typecheck` — clean
- `pnpm --filter desktop run lint` — clean (`--max-warnings=0`)
- `pnpm i18n:lint` — id ↔ en parity OK
- `pnpm --filter desktop run test` — 292/292 tests passing
- `pnpm --filter desktop run build` — vite build clean

Cargo gates (`cargo check / clippy / test`) skipped locally because no
Rust files are touched in this PR — CI on the workflow runner exercises
them in full and is green.

## Risks / known limitations

- Kiosk fullscreen lock is best-effort: Ctrl+Alt+Del / Task Manager
  cannot be intercepted from the app and that limitation is documented
  in the i18n string (`opac.kiosk.limitations`).
- Multi-device sync is **not** part of this PR (fallback per
  BUGS.md FEAT-27 line 751).
