### PR TITLE
chore(release): v1.0.8 — 14 items batch (1 BUG + 13 FEAT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,73 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-05-06
+
+### Added
+
+- **KTA: 10 desain template baru (total ~20)** — preset library sekarang
+  kaver gaya formal, modern, vibrant, dan bertema sekolah. Editor live
+  preview otomatis menyesuaikan field per template. (FEAT-16, #127)
+- **Peminjaman: perpanjangan otomatis 1-klik** — tombol "Perpanjang" di
+  detail peminjaman tambah jatuh tempo via aturan global, log audit
+  per-perpanjangan, dan hormati batas maksimum yang dikonfigurasi di
+  Aturan Peminjaman. (FEAT-17, #128)
+- **Buku: reservasi/booking saat dipinjam** — anggota bisa antri waiting
+  list buku yang sedang dipinjam. Saat eksemplar kembali, slot
+  reservasi tertua dipromosikan otomatis dan operator dapat notifikasi
+  di dashboard. (FEAT-18, #128)
+- **Anggota: bulk import dari Excel/CSV** — wizard upload + auto-detect
+  header + preview + validasi NIS unik. Mode "Perbarui anggota yang
+  sudah ada" baru memungkinkan re-import overwrite tanpa menghapus
+  field yang dibiarkan kosong di spreadsheet (COALESCE-protected
+  UPDATE). Hasil panel sekarang punya 4 metrik: Ditambahkan,
+  Diperbarui, Dilewati, Error. (FEAT-19, #129)
+- **Buku: bulk import via ISBN** — paste daftar ISBN, aplikasi resolve
+  metadata via Open Library lalu Google Books (~1 req/sec throttle),
+  preview hasil per-baris dengan kode buku auto-suggest yang bisa
+  dioverride sebelum disimpan ke katalog. (FEAT-20, #129)
+- **Anggota: cetak Surat Bebas Pustaka (SBP)** — auto-generate PDF saat
+  anggota eligible (tidak ada peminjaman aktif, tidak ada denda
+  outstanding). Template editable di pengaturan. (FEAT-21, #130)
+- **Wishlist anggota: request pengadaan buku** — anggota submit wishlist
+  via OPAC; admin punya queue review dengan upvote count, transition
+  state machine (pending → disetujui → acquired), dan link otomatis ke
+  buku saat sudah masuk katalog. (FEAT-22, #130)
+- **Stocktake/Opname mode** — sesi opname terisolasi: scan barcode
+  eksemplar batch (camera atau hand-scanner), real-time tally
+  found/missing, export laporan PDF + CSV, audit log per sesi.
+  (FEAT-23, #131)
+- **Backup: cloud target (rclone) + AES-256 encrypted + history audit** —
+  schedule backup ke remote rclone (Google Drive, S3, dll) dengan
+  enkripsi AES-256-GCM. History panel surface 50 backup terakhir +
+  size + status, decrypt langsung dari UI dengan password. (FEAT-24,
+  #132)
+- **Dashboard: trend chart + heatmap + insights cards** — grafik
+  peminjaman 30/90/365 hari, heatmap kalender aktivitas, dan kartu
+  insight (top kategori, top anggota, buku populer minggu ini).
+  (FEAT-25, #134)
+- **Sinkronisasi: Google Sheets bidirectional sync MVP (anggota)** —
+  hubungkan service-account JSON, pilih spreadsheet target, lalu push
+  / pull anggota dua-arah dengan konflik resolution last-write-wins +
+  audit log per-sinkronisasi. Foundation untuk sync entitas lain di
+  rilis berikutnya. (FEAT-26, #133)
+- **OPAC: public mode + kiosk lock** — toggle Pengaturan baru
+  mengaktifkan halaman OPAC tanpa login (search-only) dan kunci kiosk
+  full-screen yang reset idle setelah 60 detik. Admin bisa unlock dari
+  shortcut keyboard + password. (FEAT-27, #136)
+- **Sirkulasi: scanner overlay + ROI decode + multi-format + manual scan** —
+  overlay frame guide di webcam, decode hanya region of interest
+  (lebih cepat + akurat), dukungan EAN-13/Code128/QR sekaligus, dan
+  fallback input manual saat kamera tidak tersedia. (FEAT-28, #135)
+
+### Fixed
+
+- **KTA PDF export: foto anggota gepeng (stretch ke aspect ratio slot)** —
+  rendering smart-fit 2-layer baru: outer container = slot ratio, inner
+  image = `object-fit: cover` dengan center crop sehingga foto KTA
+  selalu tampil proporsional sambil tetap mengisi slot template.
+  (BUG-19, #127)
+
 ## [1.0.7] - 2026-05-05
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2967,7 +2967,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.7"
+version = "1.0.8"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

Bumps the project to **v1.0.8** and ships the 14-item batch landed in `main` since the [v1.0.7](https://github.com/alviarts/perpustakaan-offline/releases/tag/v1.0.7) release. Once this PR merges and the `v1.0.8` git tag is pushed, the `release-v2` GitHub Actions workflow will produce signed Windows MSI / NSIS installers and publish the GitHub Release.

## Versions bumped

| File | 1.0.7 → 1.0.8 |
| --- | --- |
| `package.json` | ✓ |
| `apps/desktop/package.json` | ✓ |
| `apps/desktop/src-tauri/Cargo.toml` (+ `Cargo.lock`) | ✓ |
| `apps/desktop/src-tauri/tauri.conf.json` | ✓ |

## Batch contents (merged into main)

| Item | PR | Title |
| --- | --- | --- |
| BUG-19 | [#127](https://github.com/alviarts/perpustakaan-offline/pull/127) | KTA PDF foto preserve aspect-ratio (smart-fit) |
| FEAT-16 | [#127](https://github.com/alviarts/perpustakaan-offline/pull/127) | KTA: 10 desain template baru |
| FEAT-17 | [#128](https://github.com/alviarts/perpustakaan-offline/pull/128) | Peminjaman: perpanjangan otomatis |
| FEAT-18 | [#128](https://github.com/alviarts/perpustakaan-offline/pull/128) | Buku: reservasi/booking |
| FEAT-19 | [#129](https://github.com/alviarts/perpustakaan-offline/pull/129) | Anggota: bulk import + overwrite mode |
| FEAT-20 | [#129](https://github.com/alviarts/perpustakaan-offline/pull/129) | Buku: bulk import via ISBN |
| FEAT-21 | [#130](https://github.com/alviarts/perpustakaan-offline/pull/130) | Anggota: cetak SBP |
| FEAT-22 | [#130](https://github.com/alviarts/perpustakaan-offline/pull/130) | Wishlist anggota |
| FEAT-23 | [#131](https://github.com/alviarts/perpustakaan-offline/pull/131) | Stocktake/Opname mode |
| FEAT-24 | [#132](https://github.com/alviarts/perpustakaan-offline/pull/132) | Backup cloud + AES-256 + history |
| FEAT-25 | [#134](https://github.com/alviarts/perpustakaan-offline/pull/134) | Dashboard trend + heatmap |
| FEAT-26 | [#133](https://github.com/alviarts/perpustakaan-offline/pull/133) | Google Sheets sync MVP |
| FEAT-27 | [#136](https://github.com/alviarts/perpustakaan-offline/pull/136) | OPAC public mode + kiosk |
| FEAT-28 | [#135](https://github.com/alviarts/perpustakaan-offline/pull/135) | Sirkulasi scanner overlay + ROI + manual scan |

Full narrative: see the new `## [1.0.8] - 2026-05-06` section in `CHANGELOG.md`.

## Test plan

All local gates ran green on this branch on top of `main` (already merged-up):

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm -w run i18n:lint`
- [x] `pnpm test` — **442 / 442** vitest specs pass.
- [x] `pnpm build`
- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` — **247 / 247** Rust tests pass.

## After merge

1. Tag `v1.0.8` on the merge commit and push the tag.
2. The `release-v2` workflow at `.github/workflows/ci-v2.yml` runs `scripts/extract-changelog.mjs v1.0.8`, builds the desktop installers, and publishes the GitHub Release.
3. Verify at https://github.com/alviarts/perpustakaan-offline/releases/tag/v1.0.8.