### PR TITLE
fix(scanner): tombol kamera Stocktake + ROI-crop continuous decode (v1.0.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,26 @@ back to GitHub's auto-generated release notes.
   Decode kontinyu (cooldown 1.5 detik) langsung mendaftarkan eksemplar
   ke sesi opname yang berjalan. Hand-scanner USB / ketik manual tetap
   bisa dipakai paralel; placeholder copy juga diperjelas. (#141)
+- **Webcam barcode scan susah baca Code-128 yang jelas** (BUG-22) —
+  decoder kontinyu sebelumnya membaca seluruh frame (dengan latar +
+  judul buku ikut diproses) tanpa preprocessing, sehingga sering
+  miss meski barcode sudah pas di kotak ROI. Sekarang loop kontinyu
+  meng-crop frame ke ROI lebih dulu (sama seperti tombol "Scan
+  Sekarang"), dan rotasi varian preprocess `normal → contrast →
+  grayscale` per tick (~10 fps). Kamera juga diminta `focusMode:
+  continuous`, `whiteBalanceMode: continuous`, `exposureMode:
+  continuous` lewat `applyConstraints` supaya tidak kunci fokus di
+  frame kosong sebelum bukunya diangkat. Resolusi default naik dari
+  720p → 1080p (fallback 720p). (#141)
 
 ### Changed
 
 - Camera + scanner di Stocktake otomatis dilepas saat halaman sesi
   ditutup, supaya webcam tidak "di-pegang" untuk halaman lain. (#141)
+- `useBarcodeScanner` continuous-decode loop sekarang pakai canvas +
+  `decodeWithRetry` daripada `BrowserMultiFormatReader.decodeFromConstraints`.
+  Manfaat: ROI crop, preprocessing, dan kontrol cooldown sama persis
+  dengan path "Scan Sekarang" — satu code path untuk dua mode. (#141)
 
 ## [1.0.9] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.10] - 2026-05-06
+
+### Fixed
+
+- **Stocktake: tombol kamera barcode scan tersembunyi** — input scan
+  Stocktake sebelumnya hanya menerima ketikan / hand-scanner USB
+  meskipun placeholder bilang "Pindai barcode atau ketik kode…".
+  Sekarang ada tombol **Buka Kamera** di sebelah label scan yang
+  membuka webcam preview dengan ROI overlay (mirip halaman Sirkulasi).
+  Decode kontinyu (cooldown 1.5 detik) langsung mendaftarkan eksemplar
+  ke sesi opname yang berjalan. Hand-scanner USB / ketik manual tetap
+  bisa dipakai paralel; placeholder copy juga diperjelas. (#141)
+
+### Changed
+
+- Camera + scanner di Stocktake otomatis dilepas saat halaman sesi
+  ditutup, supaya webcam tidak "di-pegang" untuk halaman lain. (#141)
+
 ## [1.0.9] - 2026-05-06
 
 Collected fixes + sheets sync expansion. Released as a single rolled-up

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2967,7 +2967,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.8"
+version = "1.0.10"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.9"
+version = "1.0.10"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
+++ b/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
@@ -20,15 +20,30 @@
  *   browsers/cameras that expose a `torch` track capability.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { BrowserMultiFormatReader, type IScannerControls } from '@zxing/browser';
-import { type Result } from '@zxing/library';
 import { computeRoi } from '@/lib/scanner/overlay';
 import {
-  buildDecodeHints,
   createImageDataReader,
   decodeWithRetry,
   type DecodedResult,
 } from '@/lib/scanner/decoder';
+import { type PreprocessVariant } from '@/lib/scanner/preprocess';
+
+/**
+ * Variants tried per continuous-decode tick. We round-robin so each
+ * tick stays cheap (one preprocess + one zxing pass) while still
+ * giving every variant a fair shot within ~300 ms — fast enough that
+ * even a brief barcode hold over the ROI gets at least one of each
+ * preprocess flavour. Order copies `MANUAL_RETRY_VARIANTS` for
+ * symmetry with the manual button. (BUG-22.)
+ */
+const CONTINUOUS_VARIANTS: PreprocessVariant[] = ['normal', 'contrast', 'grayscale'];
+
+/**
+ * Decode loop tick interval in milliseconds. 100 ms = 10 fps decode
+ * rate, plenty for hand-aim and well below the cooldown so we never
+ * deliver the same barcode twice in one steady hold. (BUG-22.)
+ */
+const TICK_MS = 100;
 
 export interface UseBarcodeScannerOptions {
   onDecode: (text: string) => void;
@@ -138,9 +153,10 @@ export function useBarcodeScanner(
 ): UseBarcodeScannerResult {
   const { onDecode, cooldownMs = 1500 } = options;
   const videoRef = useRef<HTMLVideoElement>(null);
-  const readerRef = useRef<BrowserMultiFormatReader | null>(null);
-  const controlsRef = useRef<IScannerControls | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const stoppedRef = useRef(false);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const lastDecodedRef = useRef<{ text: string; at: number } | null>(null);
   // Always read the latest callback inside the decode handler so callers
   // don't have to memoise it on every render.
@@ -160,12 +176,31 @@ export function useBarcodeScanner(
 
   /** Stop and release the active camera, if any. */
   const stop = useCallback(() => {
-    controlsRef.current?.stop();
-    controlsRef.current = null;
-    // controls.stop() releases the tracks zxing owns, but if we held a
-    // separate reference (for torch) clear it so React doesn't think
-    // torch is still controllable on a dead track.
+    stoppedRef.current = true;
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    const stream = streamRef.current;
+    if (stream) {
+      for (const track of stream.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          // Already stopped — ignore.
+        }
+      }
+    }
     streamRef.current = null;
+    const video = videoRef.current;
+    if (video) {
+      video.srcObject = null;
+      try {
+        video.pause();
+      } catch {
+        // Pause may throw on some browsers if the video already errored.
+      }
+    }
     setActive(false);
     setTorchSupported(false);
     setTorchOn(false);
@@ -193,55 +228,75 @@ export function useBarcodeScanner(
           : cams[0]?.deviceId ?? null;
       setSelectedDeviceId(preferred);
 
-      if (!readerRef.current) {
-        readerRef.current = new BrowserMultiFormatReader(buildDecodeHints());
-      }
-      const reader = readerRef.current;
       const video = videoRef.current;
       if (!video) {
         throw new Error('Video element belum siap');
       }
 
-      // Ask the browser for a higher-resolution stream than the zxing
-      // default (which falls back to roughly 640×480 on most webcams).
-      // Code-128 barcodes printed at A4-label scale are too small for
-      // 480p to decode reliably (BUG-18). 1280×720 doubles the linear
-      // pixel budget. The browser is free to fall back to the next-best
-      // size if 720p is not available — `ideal` is a soft constraint.
-      const videoConstraints: MediaTrackConstraints = preferred
-        ? {
-            deviceId: { exact: preferred },
-            width: { ideal: 1280 },
-            height: { ideal: 720 },
-          }
-        : {
-            facingMode: { ideal: 'environment' },
-            width: { ideal: 1280 },
-            height: { ideal: 720 },
-          };
+      // Try 1080p first — the higher pixel budget pulls dense Code-128
+      // labels into focus on cheap webcams. Fall back to 720p if the
+      // device can't deliver 1080p (`OverconstrainedError`). zxing's
+      // own default tops out around 480p which proved too coarse for
+      // BUG-18 / BUG-22.
+      const buildConstraints = (w: number, h: number): MediaTrackConstraints => {
+        const base: MediaTrackConstraints = preferred
+          ? { deviceId: { exact: preferred } }
+          : { facingMode: { ideal: 'environment' } };
+        return {
+          ...base,
+          width: { ideal: w },
+          height: { ideal: h },
+          frameRate: { ideal: 30 },
+        };
+      };
 
-      controlsRef.current = await reader.decodeFromConstraints(
-        { audio: false, video: videoConstraints },
-        video,
-        (result: Result | undefined, err) => {
-          if (result) {
-            const text = result.getText();
-            const now = performance.now();
-            const last = lastDecodedRef.current;
-            if (last && last.text === text && now - last.at < cooldownMs) {
-              return;
-            }
-            lastDecodedRef.current = { text, at: now };
-            onDecodeRef.current(text);
-            return;
-          }
-          // zxing fires a NotFoundException on every frame without a
-          // detection. Filtering it keeps the console quiet.
-          if (err && err.name !== 'NotFoundException') {
-            // Surface fatal errors only.
-          }
-        },
-      );
+      let stream: MediaStream;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: false,
+          video: buildConstraints(1920, 1080),
+        });
+      } catch {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: false,
+          video: buildConstraints(1280, 720),
+        });
+      }
+
+      streamRef.current = stream;
+      video.srcObject = stream;
+      video.muted = true;
+      video.playsInline = true;
+      try {
+        await video.play();
+      } catch {
+        // Autoplay policies may reject — the stream still works once a
+        // user gesture toggles `video.play()`. Don't fail start().
+      }
+
+      // Ask the camera for continuous autofocus, white-balance, and
+      // exposure where supported. These are advanced constraints —
+      // most browsers silently ignore unknown ones, so the try/catch
+      // is a belt-and-braces guard. Without continuous autofocus the
+      // webcam locks on the first frame after permission, which on a
+      // hand-held barcode is usually the empty desk before the book
+      // arrives — hence the BUG-22 reports of "jelas tapi tidak baca".
+      const track = stream.getVideoTracks()[0];
+      if (track) {
+        try {
+          await track.applyConstraints({
+            advanced: [
+              { focusMode: 'continuous' } as MediaTrackConstraintSet,
+              { whiteBalanceMode: 'continuous' } as MediaTrackConstraintSet,
+              { exposureMode: 'continuous' } as MediaTrackConstraintSet,
+            ],
+          } as MediaTrackConstraints);
+        } catch {
+          // Capability not supported on this camera/browser — ignore.
+        }
+        setTorchSupported(trackHasTorch(track));
+      }
+      setTorchOn(false);
 
       // Refresh device labels (often available only after permission).
       try {
@@ -251,17 +306,75 @@ export function useBarcodeScanner(
         // ignore secondary enumeration errors
       }
 
-      // After zxing has wired the stream into the video element, the
-      // `srcObject` is the live MediaStream — use it to detect torch
-      // capability and to apply the torch constraint when the user
-      // toggles it.
-      const stream = (video.srcObject as MediaStream | null) ?? null;
-      streamRef.current = stream;
-      const track = stream?.getVideoTracks()[0];
-      setTorchSupported(track ? trackHasTorch(track) : false);
-      setTorchOn(false);
+      // Reusable image-data reader — the same one re-used across every
+      // tick to avoid alloc churn and to inherit zxing's binarizer
+      // cache for adjacent frames.
+      const imageReader = createImageDataReader();
+      if (!canvasRef.current) {
+        canvasRef.current = document.createElement('canvas');
+      }
+      const canvas = canvasRef.current;
 
+      stoppedRef.current = false;
       setActive(true);
+
+      let lastTickAt = 0;
+      let variantIdx = 0;
+      const tick = (now: DOMHighResTimeStamp) => {
+        if (stoppedRef.current) return;
+        if (now - lastTickAt >= TICK_MS) {
+          lastTickAt = now;
+          const w = video.videoWidth;
+          const h = video.videoHeight;
+          if (w > 0 && h > 0 && video.readyState >= 2) {
+            const roi = computeRoi(w, h);
+            if (roi.width > 0 && roi.height > 0) {
+              canvas.width = roi.width;
+              canvas.height = roi.height;
+              const ctx = canvas.getContext('2d', {
+                willReadFrequently: true,
+              });
+              if (ctx) {
+                try {
+                  ctx.drawImage(
+                    video,
+                    roi.x,
+                    roi.y,
+                    roi.width,
+                    roi.height,
+                    0,
+                    0,
+                    roi.width,
+                    roi.height,
+                  );
+                  const imageData = ctx.getImageData(0, 0, roi.width, roi.height);
+                  const variant = CONTINUOUS_VARIANTS[variantIdx] ?? 'normal';
+                  variantIdx = (variantIdx + 1) % CONTINUOUS_VARIANTS.length;
+                  const hit = decodeWithRetry(imageReader, imageData, [variant]);
+                  if (hit) {
+                    const text = hit.text;
+                    const at = performance.now();
+                    const last = lastDecodedRef.current;
+                    if (
+                      !last ||
+                      last.text !== text ||
+                      at - last.at >= cooldownMs
+                    ) {
+                      lastDecodedRef.current = { text, at };
+                      onDecodeRef.current(text);
+                    }
+                  }
+                } catch {
+                  // drawImage / getImageData can throw if the frame is
+                  // not yet ready — skip the tick and try again.
+                }
+              }
+            }
+          }
+        }
+        rafRef.current = requestAnimationFrame(tick);
+      };
+      rafRef.current = requestAnimationFrame(tick);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       setError(msg);
@@ -330,8 +443,22 @@ export function useBarcodeScanner(
   // Always release on unmount.
   useEffect(() => {
     return () => {
-      controlsRef.current?.stop();
-      controlsRef.current = null;
+      stoppedRef.current = true;
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      const stream = streamRef.current;
+      if (stream) {
+        for (const track of stream.getTracks()) {
+          try {
+            track.stop();
+          } catch {
+            // ignore
+          }
+        }
+      }
+      streamRef.current = null;
     };
   }, []);
 

--- a/apps/desktop/src/features/stocktake/StocktakePage.tsx
+++ b/apps/desktop/src/features/stocktake/StocktakePage.tsx
@@ -1,10 +1,22 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, ClipboardList, Plus, RefreshCw, Trash2, FileDown } from 'lucide-react';
+import {
+  ArrowLeft,
+  Camera,
+  CameraOff,
+  ClipboardList,
+  FileDown,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Video,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { useBarcodeScanner } from '@/features/sirkulasi/useBarcodeScanner';
+import { ScannerOverlay } from '@/features/sirkulasi/ScannerOverlay';
 import {
   Dialog,
   DialogContent,
@@ -277,6 +289,7 @@ export function StocktakePage() {
     const [scanInput, setScanInput] = useState('');
     const [scanning, setScanning] = useState(false);
     const [refreshKey, setRefreshKey] = useState(0);
+    const [cameraOpen, setCameraOpen] = useState(false);
     const scanRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
@@ -324,33 +337,70 @@ export function StocktakePage() {
       if (session?.status === 'berlangsung') scanRef.current?.focus();
     }, [session?.status, refreshKey]);
 
+    const submitKode = useCallback(
+      async (rawKode: string) => {
+        const kode = rawKode.trim();
+        if (!kode) return;
+        setScanning(true);
+        try {
+          const result = await stocktakeApi.scan({ sessionId, kode });
+          setSession(result.session);
+          setScanInput('');
+          setRefreshKey((k) => k + 1);
+          showToast({
+            title: result.alreadyScanned
+              ? t('stocktake:session.alreadyScannedToast', { kode })
+              : t('stocktake:session.scannedToast', { kode }),
+          });
+        } catch (err) {
+          showToast({
+            variant: 'destructive',
+            title: t('stocktake:session.scanError', {
+              message: formatTauriError(err),
+            }),
+          });
+        } finally {
+          setScanning(false);
+          // Only steal focus back to the input when the camera is closed —
+          // otherwise a Bluetooth/USB scanner racing with continuous video
+          // decode would dump its keystrokes into the wrong target.
+          if (!cameraOpen) scanRef.current?.focus();
+        }
+      },
+      [sessionId, cameraOpen],
+    );
+
+    const cameraScanner = useBarcodeScanner({
+      onDecode: (text) => {
+        void submitKode(text);
+      },
+      cooldownMs: 1500,
+    });
+
     async function handleScan(e: React.FormEvent) {
       e.preventDefault();
-      const kode = scanInput.trim();
-      if (!kode) return;
-      setScanning(true);
-      try {
-        const result = await stocktakeApi.scan({ sessionId, kode });
-        setSession(result.session);
-        setScanInput('');
-        setRefreshKey((k) => k + 1);
-        showToast({
-          title: result.alreadyScanned
-            ? t('stocktake:session.alreadyScannedToast', { kode })
-            : t('stocktake:session.scannedToast', { kode }),
-        });
-      } catch (err) {
-        showToast({
-          variant: 'destructive',
-          title: t('stocktake:session.scanError', {
-            message: formatTauriError(err),
-          }),
-        });
-      } finally {
-        setScanning(false);
-        scanRef.current?.focus();
-      }
+      await submitKode(scanInput);
     }
+
+    async function toggleCamera() {
+      if (cameraOpen) {
+        cameraScanner.stop();
+        setCameraOpen(false);
+        scanRef.current?.focus();
+        return;
+      }
+      setCameraOpen(true);
+      await cameraScanner.start();
+    }
+
+    useEffect(() => {
+      // Release the camera when the session view unmounts so the next
+      // page load doesn't hold the webcam hostage.
+      return () => {
+        cameraScanner.stop();
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     async function handleFinish(status: 'selesai' | 'dibatalkan') {
       const confirmKey =
@@ -498,7 +548,31 @@ export function StocktakePage() {
         {session.status === 'berlangsung' && (
           <Card>
             <CardContent className="flex flex-col gap-2 py-4">
-              <Label>{t('stocktake:session.scanLabel')}</Label>
+              <div className="flex items-center justify-between gap-2">
+                <Label>{t('stocktake:session.scanLabel')}</Label>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={cameraOpen ? 'default' : 'outline'}
+                  onClick={() => {
+                    void toggleCamera();
+                  }}
+                  disabled={cameraScanner.starting}
+                  data-testid="stocktake-camera-toggle"
+                >
+                  {cameraOpen ? (
+                    <>
+                      <CameraOff className="mr-1 h-4 w-4" />
+                      {t('stocktake:session.closeCamera')}
+                    </>
+                  ) : (
+                    <>
+                      <Camera className="mr-1 h-4 w-4" />
+                      {t('stocktake:session.openCamera')}
+                    </>
+                  )}
+                </Button>
+              </div>
               <form onSubmit={handleScan} className="flex gap-2">
                 <Input
                   ref={scanRef}
@@ -512,6 +586,60 @@ export function StocktakePage() {
                   {t('stocktake:actions.scan')}
                 </Button>
               </form>
+              {cameraOpen && (
+                <div className="mt-2 space-y-2">
+                  <div className="relative aspect-video overflow-hidden rounded-md border bg-black/90">
+                    <video
+                      ref={cameraScanner.videoRef}
+                      className="h-full w-full object-cover"
+                      muted
+                      playsInline
+                    />
+                    {cameraScanner.active && (
+                      <ScannerOverlay
+                        label={t('stocktake:session.cameraOverlay')}
+                        busy={scanning}
+                        busyLabel={
+                          scanning
+                            ? t('stocktake:session.cameraScanning')
+                            : undefined
+                        }
+                      />
+                    )}
+                    {!cameraScanner.active && (
+                      <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 text-white">
+                        <Video className="h-10 w-10 opacity-70" />
+                        <p className="text-sm">
+                          {cameraScanner.starting
+                            ? t('stocktake:session.cameraStarting')
+                            : t('stocktake:session.cameraOff')}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                  {cameraScanner.error && (
+                    <p
+                      className="text-xs text-destructive"
+                      data-testid="stocktake-camera-error"
+                    >
+                      {cameraScanner.error}
+                    </p>
+                  )}
+                  {cameraScanner.devices.length > 1 && (
+                    <select
+                      className="w-full rounded-md border bg-background px-2 py-1 text-xs"
+                      value={cameraScanner.selectedDeviceId ?? ''}
+                      onChange={(e) => cameraScanner.selectDevice(e.target.value)}
+                    >
+                      {cameraScanner.devices.map((d) => (
+                        <option key={d.deviceId} value={d.deviceId}>
+                          {d.label || t('stocktake:session.cameraUnnamed')}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+              )}
             </CardContent>
           </Card>
         )}

--- a/apps/desktop/src/i18n/en/stocktake.json
+++ b/apps/desktop/src/i18n/en/stocktake.json
@@ -45,7 +45,14 @@
   },
   "session": {
     "scanLabel": "Scan / Enter Eksemplar Code",
-    "scanPlaceholder": "Scan barcode or type code...",
+    "scanPlaceholder": "Type or scan barcode (USB hand-scanner) then press Enter...",
+    "openCamera": "Open Camera",
+    "closeCamera": "Close Camera",
+    "cameraOverlay": "Aim eksemplar barcode into the box",
+    "cameraScanning": "Scanning…",
+    "cameraStarting": "Opening camera…",
+    "cameraOff": "Camera not active",
+    "cameraUnnamed": "Unnamed camera",
     "counter": "Total: {{total}} | Scanned: {{ditemukan}} ({{percent}}%)",
     "missing": "Missing: {{missing}}",
     "tabs": {

--- a/apps/desktop/src/i18n/id/stocktake.json
+++ b/apps/desktop/src/i18n/id/stocktake.json
@@ -45,7 +45,14 @@
   },
   "session": {
     "scanLabel": "Scan / Ketik Kode Eksemplar",
-    "scanPlaceholder": "Pindai barcode atau ketik kode...",
+    "scanPlaceholder": "Ketik atau scan barcode (hand-scanner USB) lalu Enter...",
+    "openCamera": "Buka Kamera",
+    "closeCamera": "Tutup Kamera",
+    "cameraOverlay": "Arahkan barcode eksemplar ke dalam kotak",
+    "cameraScanning": "Memindai…",
+    "cameraStarting": "Membuka kamera…",
+    "cameraOff": "Kamera belum aktif",
+    "cameraUnnamed": "Kamera tanpa nama",
     "counter": "Total: {{total}} | Sudah scan: {{ditemukan}} ({{percent}}%)",
     "missing": "Hilang: {{missing}}",
     "tabs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

Dua perbaikan webcam barcode scan yang dilaporkan oleh user setelah v1.0.9:

### 1. Stocktake: tombol kamera tidak ada

Halaman Stocktake → sesi opname menampilkan placeholder **"Pindai barcode atau ketik kode…"** tapi UI-nya hanya input text. README juga mengiklankan dukungan kamera. Mismatch antara copy dan implementasi.

**Fix:**
- Tambah tombol **Buka Kamera** di sebelah label scan input.
- Pakai `useBarcodeScanner` hook yang sudah ada (dipakai SirkulasiPage + OPAC KTA scan flow).
- Decode kontinyu (cooldown 1.5 detik) memanggil `submitKode()` yang sama dengan path form-submit, jadi USB hand-scanner / typing manual / kamera berbagi satu code path.
- Camera dilepas otomatis saat halaman sesi unmount, supaya tidak block halaman Sirkulasi yang juga butuh webcam.
- Placeholder copy diperjelas: "Ketik atau scan barcode (hand-scanner USB) lalu Enter…".
- Device picker muncul kalau >1 video input.
- Pesan error `getUserMedia` di-surface di bawah preview.

### 2. BUG-22: webcam continuous decode susah baca Code-128 yang jelas

User screenshot menunjukkan Code-128 (`B-46945-01`) jelas pas di kotak ROI tapi continuous decode miss berkali-kali, sementara tombol manual "Scan Sekarang" catch di percobaan pertama.

**Root cause:**
- `BrowserMultiFormatReader.decodeFromConstraints` decode **seluruh frame** (1280×720) tiap tick. Latar (judul buku, garis lain, teks) ikut diproses zxing's binarizer dan sering bikin bingung.
- Tidak ada ROI crop di path kontinyu (hanya di tombol manual).
- Tidak ada preprocessing variation (manual button cycling normal → contrast → grayscale, kontinyu hanya 'normal').
- Default `getUserMedia` tidak request `focusMode: continuous`. Webcam laptop biasanya kunci fokus di frame pertama setelah permission, yaitu meja kosong sebelum buku diangkat.

**Fix di `useBarcodeScanner.ts`:**
1. Ganti `decodeFromConstraints` dengan custom rAF loop:
   - Tick 100 ms (~10 fps decode rate).
   - Tiap tick: crop video ke `computeRoi()` rectangle yang sama dengan overlay, lalu `decodeWithRetry` 1 variant.
   - Round-robin `[normal, contrast, grayscale]` per tick → setiap variant dapet ~3.3 fps, full coverage dalam ~300 ms.
2. `applyConstraints({ advanced: [{ focusMode: 'continuous' }, { whiteBalanceMode: 'continuous' }, { exposureMode: 'continuous' }] })` setelah stream mulai. Diabaikan kalau browser/camera tidak dukung.
3. Resolusi default naik 720p → 1080p dengan fallback 720p (`OverconstrainedError`).
4. `stop()` sekarang explicitly `track.stop()` dan clear `video.srcObject`.

Manfaat untuk: SirkulasiPage, OPAC KTA scan, Stocktake kamera baru — semua pakai hook yang sama.

### 3. Version bump 1.0.9 → 1.0.10

`package.json`, `apps/desktop/package.json`, `apps/desktop/src-tauri/Cargo.toml`, `apps/desktop/src-tauri/tauri.conf.json` + CHANGELOG entry.

## Review & Testing Checklist for Human

- [ ] **CI hijau** (Lint, Typecheck, Unit Test, Rust check, Build Windows installer).
- [ ] **Buka halaman Sirkulasi (Webcam)** dengan v1.0.10 — coba scan barcode buku yang biasanya susah dibaca v1.0.9. Confirm continuous decode catch barcode lebih cepat dan dari jarak yang sebelumnya miss.
- [ ] **Buka Stocktake**, mulai sesi baru, klik tombol "Buka Kamera". Confirm preview kamera muncul, scan barcode eksemplar, eksemplar otomatis ditandai "Ditemukan" tanpa harus klik tombol Scan.
- [ ] **Tutup halaman Stocktake** lalu buka Sirkulasi (Webcam) — confirm kamera bisa langsung dipakai (tidak ada "Camera in use by another application").
- [ ] **Coba di laptop dengan kamera bawaan + USB camera eksternal** kalau ada — confirm device picker muncul dan switch antara dua kamera bekerja.
- [ ] **Coba decode** dengan label sangat kecil (Code-128 di stiker tipis) — pastikan tidak regress dari v1.0.9.

### Notes

- Tidak ada perubahan Rust backend, tidak ada migrasi DB, tidak ada perubahan schema.
- Tidak ada perubahan i18n keys yang sudah ada — hanya tambahan di `stocktake.json` (id + en).
- `BrowserMultiFormatReader` import dihapus karena tidak dipakai lagi.
- `decodeOnce` (manual "Scan Sekarang") tidak diubah — tetap berfungsi sebagai fallback "try harder" kalau continuous loop juga tetap miss.