### PR TITLE
feat(scanner): live tracking overlay + jsQR fallback + dark/low-contrast retry pipeline (v1.0.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,83 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.0.11] - 2026-05-06
+
+### Added
+
+- **Live tracking overlay untuk scanner Sirkulasi / OPAC / Stocktake** —
+  begitu decoder mendeteksi barcode atau QR di frame, sebuah polygon
+  hijau langsung "menempel" di posisi simbol di preview kamera (mirip
+  scanner QR di kamera HP). Polygon flash kuning singkat ketika
+  decode sukses, dan fade-out otomatis ~600 ms setelah deteksi
+  hilang. Memberi feedback visual yang jelas ke operator bahwa
+  scanner benar-benar melihat kode — bukan hanya "diam saja".
+- **jsQR sebagai decoder paralel khusus QR** — library spesialis QR
+  (~30 KB) yang jauh lebih tahan moiré pattern (raster layar HP ×
+  raster webcam), QR low-res, dan QR di tepi viewport daripada
+  binarizer ZXing. Dipanggil sebagai fallback setelah ZXing gagal,
+  jadi tidak menambah latensi pada kasus-kasus mudah. Mode
+  `attemptBoth` menangani QR dark-mode (kotak putih di latar hitam)
+  tanpa preprocess tambahan.
+- **Preprocess variant baru**: `inverted`, `brighten` (gamma 0.5),
+  `darken` (gamma 1.6), dan `adaptiveThreshold` (block-mean lokal).
+  Tombol "Scan Sekarang" sekarang siklus lengkap 7 varian per klik
+  daripada 3, sehingga jauh lebih banyak kasus pencahayaan tertangkap
+  (gelap, terlalu terang, kontras rendah, lampu kelas yang tidak
+  rata).
+- **`analyzeImageStats(image)` helper** — rangkuman luminansi (mean,
+  min, max). Dipakai `useBarcodeScanner` untuk skip frame
+  pitch-black (mean < 8) sebelum membayar biaya zxing/jsQR, dan
+  membuka jalan untuk pemilihan varian adaptif berbasis statistik.
+
+### Fixed
+
+- **QR di layar HP tidak terbaca walaupun sudah jelas (#141 follow-up)** —
+  kombinasi 3 hal: ROI 70% × 30% terlalu sempit untuk QR persegi,
+  ZXing tidak mencoba bitmap yang dibalik (dark-mode QR), dan tidak
+  ada decoder QR-specialist. v1.0.11 memperbesar ROI ke 70% × 55%,
+  menambahkan varian `inverted` di pipeline, dan jsQR fallback —
+  catch-rate naik signifikan untuk QR di layar HP / phone screen.
+- **"Scan Sekarang" miss kalau barcode di tepi ROI** — kalau decode
+  ROI gagal, sekarang otomatis retry decode seluruh frame sebagai
+  fallback (koordinat lokasi di-clamp ke kotak ROI supaya overlay
+  tetap menampilkan lokasi yang benar).
+- **Continuous decode sering miss QR dark-mode** — loop kontinyu
+  sekarang siklus 4 varian (`normal → contrast → inverted →
+  grayscale`) bukan 3, dengan tick rate dinaikkan dari 100 ms ke 80 ms
+  (12.5 fps). Total siklus ~320 ms — masih di bawah cooldown
+  decode, tapi tiap varian dapat ronde baru lebih cepat.
+- **Decoder crash di frame pitch-black** — luminance summary di
+  awal tiap tick mengeluarkan frame dengan max < 8 sebelum sampai
+  ke ZXing/jsQR. Mengurangi error log noise di console saat kamera
+  baru terbuka / ditutup penutup lensa.
+
+### Changed
+
+- `MANUAL_RETRY_VARIANTS` diperluas dari 3 ke 7 varian. Tombol
+  "Scan Sekarang" sekarang lebih lambat sedikit pada kasus terburuk
+  (~7 × 50 ms = 350 ms) tapi catch-rate jauh lebih tinggi pada
+  kondisi pencahayaan klasroom yang sulit.
+- `DecodedResult` sekarang membawa `location` (polygon 2-4 titik
+  di koordinat ROI) dan `source` (`zxing` atau `jsqr`). Dipakai
+  oleh overlay tracking; data flow lain tidak bergantung padanya
+  jadi backward-compatible.
+- Hint `ALSO_INVERTED` ZXing tidak ditambahkan karena
+  `@zxing/library` 0.21 tidak mengekspor enum tersebut. Fungsi yang
+  sama dipenuhi oleh varian `inverted` di retry chain dan jsQR
+  `attemptBoth`.
+
+### Tests
+
+- 36 unit test baru di `scannerPreprocess.test.ts` mencakup setiap
+  varian baru + helper `analyzeImageStats` + adaptive threshold
+  edge cases.
+- 13 skenario end-to-end di `scannerScenarios.test.ts` — render QR
+  sintetis dengan `qrcode` lalu uji decode pada kondisi:
+  bright/baseline, gelap (25%/10% brightness), gelap total
+  (pitch-black), kontras rendah, dark-mode (inverted), glare
+  overexposed, dan low-res (3 px / module). Semua 478 test pass.
+
 ## [1.0.10] - 2026-05-06
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "type": "module",
   "scripts": {
@@ -45,6 +45,7 @@
     "i18next": "^24.2.1",
     "jsbarcode": "^3.12.3",
     "jspdf": "^2.5.2",
+    "jsqr": "^1.4.0",
     "lucide-react": "^0.468.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2967,7 +2967,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.10"
+version = "1.0.11"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src/features/opac/OpacKtaScanFlow.tsx
+++ b/apps/desktop/src/features/opac/OpacKtaScanFlow.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/components/ui/toast-manager';
 import { useBarcodeScanner } from '@/features/sirkulasi/useBarcodeScanner';
+import { ScannerTrackingOverlay } from '@/features/sirkulasi/ScannerTrackingOverlay';
 import { anggotaApi, type Anggota } from '@/lib/anggota';
 import { parseQrPayload } from '@/lib/kta';
 
@@ -126,6 +127,14 @@ export function OpacKtaScanFlow({
             muted
             playsInline
           />
+          {scanner.active && scanner.lastDetection && (
+            <ScannerTrackingOverlay
+              location={scanner.lastDetection.location}
+              roiWidth={scanner.lastDetection.roiWidth}
+              roiHeight={scanner.lastDetection.roiHeight}
+              flash={scanner.decodeFlash}
+            />
+          )}
           {!scanner.active && (
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 text-white">
               <CameraOff className="h-10 w-10 opacity-70" aria-hidden="true" />

--- a/apps/desktop/src/features/sirkulasi/ScannerTrackingOverlay.tsx
+++ b/apps/desktop/src/features/sirkulasi/ScannerTrackingOverlay.tsx
@@ -1,0 +1,150 @@
+/**
+ * Live tracking overlay for the Sirkulasi webcam scanner (v1.0.11).
+ *
+ * Renders an SVG polygon over the `<video>` element that follows the
+ * decoded barcode / QR location returned by the decoder. The polygon:
+ *
+ * - Is **green** while a recent detection is in flight (≤ ~600 ms ago).
+ *   This is the "I see something useful in the frame" feedback —
+ *   especially helpful for QR codes where the operator otherwise has
+ *   no visual cue that they're aimed correctly.
+ * - **Flashes yellow** for ~350 ms after a successful decode (i.e. when
+ *   the cooldown gate emits the value to the consumer). This gives the
+ *   operator the same kind of "got it" feedback as a physical hand-
+ *   scanner's beep + LED.
+ * - Fades out cleanly when detections stop landing — no flicker, no
+ *   stuck ghost polygons.
+ *
+ * The polygon is purely decorative — none of the data flow depends on
+ * it. If the decoder doesn't report a location (e.g. zxing on a 1-D
+ * Code-128 in some library versions), the overlay simply renders
+ * nothing and the rest of the UI keeps working.
+ *
+ * Coordinates: the overlay is positioned over the *ROI rectangle*
+ * (the same one painted by {@link ScannerOverlay}). Detection
+ * locations are reported in ROI-pixel space (the cropped canvas the
+ * decoder ran against) so the SVG transform is just a percentage
+ * rescale — no awareness of full-frame geometry needed.
+ */
+import { type Point2D } from '@/lib/scanner/decoder';
+import { ROI_PERCENT } from '@/lib/scanner/overlay';
+
+export interface ScannerTrackingOverlayProps {
+  /**
+   * Polygon vertices in ROI-pixel coordinates (origin top-left of
+   * the ROI crop). Typically 4 points for QR / Data Matrix, 2 for
+   * 1-D codes.
+   */
+  location: Point2D[];
+  /** Pixel width of the ROI the location was measured against. */
+  roiWidth: number;
+  /** Pixel height of the ROI the location was measured against. */
+  roiHeight: number;
+  /**
+   * When true, render the polygon in the "decode succeeded" yellow
+   * flash colour rather than the default green. The caller is
+   * responsible for clearing this back to `false` after the flash
+   * window — typically managed by the scanner hook.
+   */
+  flash?: boolean;
+}
+
+/**
+ * Build the SVG `points` attribute for a closed polygon. For 1-D
+ * codes (2 points) we emit just the line segment so the overlay
+ * shows a bar across the barcode; for 2-D codes (≥3 points) we close
+ * the loop into a quad.
+ */
+function buildPointsAttr(points: Point2D[]): string {
+  return points.map((p) => `${p.x},${p.y}`).join(' ');
+}
+
+export function ScannerTrackingOverlay({
+  location,
+  roiWidth,
+  roiHeight,
+  flash = false,
+}: ScannerTrackingOverlayProps) {
+  if (!location || location.length === 0 || roiWidth <= 0 || roiHeight <= 0) {
+    return null;
+  }
+  // Position the overlay over the same ROI rectangle the
+  // ScannerOverlay paints. Computing percentages here keeps the
+  // tracking polygon in sync even if the operator resizes the window
+  // — the SVG viewBox handles the pixel-to-CSS scaling automatically.
+  const left = `${((1 - ROI_PERCENT.width) / 2) * 100}%`;
+  const top = `${((1 - ROI_PERCENT.height) / 2) * 100}%`;
+  const width = `${ROI_PERCENT.width * 100}%`;
+  const height = `${ROI_PERCENT.height * 100}%`;
+
+  // Stroke / fill style:
+  // - flash=true → bright yellow + stronger fill (≈ shutter flash).
+  // - flash=false → green; lower-opacity fill so the polygon reads as
+  //   a "lock-on" outline rather than a solid mask.
+  const stroke = flash ? '#facc15' : '#22c55e';
+  const fillOpacity = flash ? 0.25 : 0.12;
+  const isClosed = location.length >= 3;
+  const pointsAttr = buildPointsAttr(location);
+
+  return (
+    <div
+      className="pointer-events-none absolute"
+      style={{ left, top, width, height }}
+      data-testid="scanner-tracking-overlay"
+      data-flash={flash ? 'true' : 'false'}
+    >
+      <svg
+        viewBox={`0 0 ${roiWidth} ${roiHeight}`}
+        preserveAspectRatio="none"
+        className="h-full w-full"
+        // SVG inherits CSS sizing from the wrapper `<div>` so the
+        // polygon grows/shrinks with the video element. Tailwind's
+        // `transition-colors` handles the green↔yellow tween.
+      >
+        {isClosed ? (
+          <polygon
+            points={pointsAttr}
+            fill={stroke}
+            fillOpacity={fillOpacity}
+            stroke={stroke}
+            strokeWidth={Math.max(2, Math.min(roiWidth, roiHeight) * 0.006)}
+            strokeLinejoin="round"
+            style={{
+              filter: flash
+                ? 'drop-shadow(0 0 6px rgba(250, 204, 21, 0.85))'
+                : 'drop-shadow(0 0 4px rgba(34, 197, 94, 0.6))',
+              transition: 'fill 200ms ease, stroke 200ms ease',
+            }}
+          />
+        ) : (
+          <polyline
+            points={pointsAttr}
+            fill="none"
+            stroke={stroke}
+            strokeWidth={Math.max(2, Math.min(roiWidth, roiHeight) * 0.008)}
+            strokeLinecap="round"
+            style={{
+              filter: flash
+                ? 'drop-shadow(0 0 6px rgba(250, 204, 21, 0.85))'
+                : 'drop-shadow(0 0 4px rgba(34, 197, 94, 0.6))',
+              transition: 'stroke 200ms ease',
+            }}
+          />
+        )}
+        {/* Corner dots reinforce the lock-on cue at the polygon
+            vertices — particularly helpful at small QR sizes where
+            the polygon outline alone is hard to see. */}
+        {location.map((p, idx) => (
+          <circle
+            key={idx}
+            cx={p.x}
+            cy={p.y}
+            r={Math.max(3, Math.min(roiWidth, roiHeight) * 0.012)}
+            fill={stroke}
+            opacity={0.95}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
+++ b/apps/desktop/src/features/sirkulasi/SirkulasiPage.tsx
@@ -55,6 +55,7 @@ import {
 import { formatTauriError } from '@/lib/errors';
 import { useBarcodeScanner } from './useBarcodeScanner';
 import { ScannerOverlay } from './ScannerOverlay';
+import { ScannerTrackingOverlay } from './ScannerTrackingOverlay';
 
 type Mode = 'pinjam' | 'kembalikan';
 
@@ -530,19 +531,29 @@ export function SirkulasiPage() {
                 playsInline
               />
               {scanner.active && (
-                <ScannerOverlay
-                  label={t('sirkulasi:scanner.overlayLabel', {
-                    defaultValue: 'Arahkan barcode ke dalam kotak',
-                  })}
-                  busy={scanningOnce}
-                  busyLabel={
-                    scanningOnce
-                      ? t('sirkulasi:scanner.scanning', {
-                          defaultValue: 'Memindai…',
-                        })
-                      : undefined
-                  }
-                />
+                <>
+                  <ScannerOverlay
+                    label={t('sirkulasi:scanner.overlayLabel', {
+                      defaultValue: 'Arahkan barcode ke dalam kotak',
+                    })}
+                    busy={scanningOnce}
+                    busyLabel={
+                      scanningOnce
+                        ? t('sirkulasi:scanner.scanning', {
+                            defaultValue: 'Memindai…',
+                          })
+                        : undefined
+                    }
+                  />
+                  {scanner.lastDetection && (
+                    <ScannerTrackingOverlay
+                      location={scanner.lastDetection.location}
+                      roiWidth={scanner.lastDetection.roiWidth}
+                      roiHeight={scanner.lastDetection.roiHeight}
+                      flash={scanner.decodeFlash}
+                    />
+                  )}
+                </>
               )}
               {!scanner.active && (
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 text-white">

--- a/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
+++ b/apps/desktop/src/features/sirkulasi/useBarcodeScanner.ts
@@ -23,27 +23,35 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { computeRoi } from '@/lib/scanner/overlay';
 import {
   createImageDataReader,
+  decodeAny,
+  decodeWithJsQR,
   decodeWithRetry,
   type DecodedResult,
+  type Point2D,
 } from '@/lib/scanner/decoder';
-import { type PreprocessVariant } from '@/lib/scanner/preprocess';
+import {
+  analyzeImageStats,
+  CONTINUOUS_VARIANTS,
+  MANUAL_RETRY_VARIANTS,
+} from '@/lib/scanner/preprocess';
 
 /**
- * Variants tried per continuous-decode tick. We round-robin so each
- * tick stays cheap (one preprocess + one zxing pass) while still
- * giving every variant a fair shot within ~300 ms — fast enough that
- * even a brief barcode hold over the ROI gets at least one of each
- * preprocess flavour. Order copies `MANUAL_RETRY_VARIANTS` for
- * symmetry with the manual button. (BUG-22.)
+ * Decode loop tick interval in milliseconds. 80 ms ≈ 12.5 fps decode
+ * rate (v1.0.11, down from 100 ms). Cycling through the four
+ * {@link CONTINUOUS_VARIANTS} now takes ~320 ms — still well under
+ * the cooldown, so we never deliver the same barcode twice in one
+ * steady hold, but each variant gets a fresh shot every cycle.
  */
-const CONTINUOUS_VARIANTS: PreprocessVariant[] = ['normal', 'contrast', 'grayscale'];
+const TICK_MS = 80;
 
 /**
- * Decode loop tick interval in milliseconds. 100 ms = 10 fps decode
- * rate, plenty for hand-aim and well below the cooldown so we never
- * deliver the same barcode twice in one steady hold. (BUG-22.)
+ * Below this mean luminance we treat the frame as effectively black
+ * (camera covered, autoexposure not converged, lights out) and skip
+ * the decode entirely. Saves the cost of running zxing + jsQR over
+ * pure noise and prevents the decoder from raising spurious internal
+ * exceptions on degenerate bitmaps.
  */
-const TICK_MS = 100;
+const DARK_FRAME_MEAN_THRESHOLD = 8;
 
 export interface UseBarcodeScannerOptions {
   onDecode: (text: string) => void;
@@ -97,7 +105,54 @@ export interface UseBarcodeScannerResult {
    * applied; rejects if the track no longer exists.
    */
   toggleTorch: () => Promise<void>;
+  /**
+   * Most recent decoded barcode location in ROI-pixel coordinates,
+   * along with the pixel size of the ROI it was decoded against.
+   * Drives the live tracking SVG overlay. Cleared automatically
+   * after `LOCATION_FADE_MS` of no new detection.
+   *
+   * `null` when no detection is currently in flight.
+   */
+  lastDetection: ScannerDetection | null;
+  /**
+   * True for a brief moment after a successful decode triggers a
+   * cooldown-emit. The overlay flashes yellow during this window.
+   */
+  decodeFlash: boolean;
 }
+
+/**
+ * Snapshot of the most recent decoded barcode position, in the
+ * coordinate system of the ROI crop the decoder ran against. The
+ * rendering layer rescales these into CSS units using the ROI
+ * percentages from {@link ROI_PERCENT}.
+ */
+export interface ScannerDetection {
+  location: Point2D[];
+  /** Pixel width of the ROI crop the location was measured in. */
+  roiWidth: number;
+  /** Pixel height of the ROI crop the location was measured in. */
+  roiHeight: number;
+  /** Format of the barcode (e.g. `'CODE_128'`, `'QR_CODE'`). */
+  format: string;
+  /** Source of the decode (`'zxing'` or `'jsqr'`). */
+  source: 'zxing' | 'jsqr';
+  /** Wall-clock timestamp (ms since epoch) when this detection landed. */
+  at: number;
+}
+
+/**
+ * Lifetime of a tracking polygon after the last successful detection.
+ * Visible state lingers a few hundred ms so the overlay doesn't
+ * flicker away the instant the operator's hand drifts and the next
+ * tick misses.
+ */
+const LOCATION_FADE_MS = 600;
+
+/**
+ * Duration of the yellow "decode succeeded" flash on the overlay.
+ */
+const DECODE_FLASH_MS = 350;
 
 /**
  * Map a `getUserMedia` failure to one of {@link ScannerErrorKind}.
@@ -173,6 +228,44 @@ export function useBarcodeScanner(
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
   const [torchSupported, setTorchSupported] = useState(false);
   const [torchOn, setTorchOn] = useState(false);
+  const [lastDetection, setLastDetection] = useState<ScannerDetection | null>(null);
+  const [decodeFlash, setDecodeFlash] = useState(false);
+  const detectionFadeTimerRef = useRef<number | null>(null);
+  const decodeFlashTimerRef = useRef<number | null>(null);
+
+  /**
+   * Record a fresh detection for the live tracking overlay and
+   * schedule a fade-out if no further detection lands within
+   * {@link LOCATION_FADE_MS}. Successive detections refresh the
+   * timer, so a steady aim keeps the polygon visible.
+   */
+  const pushDetection = useCallback((detection: ScannerDetection) => {
+    setLastDetection(detection);
+    if (detectionFadeTimerRef.current !== null) {
+      clearTimeout(detectionFadeTimerRef.current);
+    }
+    detectionFadeTimerRef.current = window.setTimeout(() => {
+      setLastDetection(null);
+      detectionFadeTimerRef.current = null;
+    }, LOCATION_FADE_MS);
+  }, []);
+
+  /**
+   * Briefly flash the overlay yellow to acknowledge a successful
+   * decode. The flash is independent of the polygon fade so the
+   * operator gets a clear "got it" signal even if the polygon was
+   * already visible.
+   */
+  const triggerFlash = useCallback(() => {
+    setDecodeFlash(true);
+    if (decodeFlashTimerRef.current !== null) {
+      clearTimeout(decodeFlashTimerRef.current);
+    }
+    decodeFlashTimerRef.current = window.setTimeout(() => {
+      setDecodeFlash(false);
+      decodeFlashTimerRef.current = null;
+    }, DECODE_FLASH_MS);
+  }, []);
 
   /** Stop and release the active camera, if any. */
   const stop = useCallback(() => {
@@ -204,6 +297,16 @@ export function useBarcodeScanner(
     setActive(false);
     setTorchSupported(false);
     setTorchOn(false);
+    setLastDetection(null);
+    setDecodeFlash(false);
+    if (detectionFadeTimerRef.current !== null) {
+      clearTimeout(detectionFadeTimerRef.current);
+      detectionFadeTimerRef.current = null;
+    }
+    if (decodeFlashTimerRef.current !== null) {
+      clearTimeout(decodeFlashTimerRef.current);
+      decodeFlashTimerRef.current = null;
+    }
   }, []);
 
   const start = useCallback(async (): Promise<void> => {
@@ -348,10 +451,36 @@ export function useBarcodeScanner(
                     roi.height,
                   );
                   const imageData = ctx.getImageData(0, 0, roi.width, roi.height);
+                  // Skip pitch-black frames before paying for zxing
+                  // + jsQR. Cheap luminance summary; bail-out keeps
+                  // the loop responsive when the camera is covered
+                  // or the room lights drop. (v1.0.11 BUG-22.)
+                  const stats = analyzeImageStats(imageData);
+                  if (stats.max < DARK_FRAME_MEAN_THRESHOLD) {
+                    rafRef.current = requestAnimationFrame(tick);
+                    return;
+                  }
                   const variant = CONTINUOUS_VARIANTS[variantIdx] ?? 'normal';
                   variantIdx = (variantIdx + 1) % CONTINUOUS_VARIANTS.length;
-                  const hit = decodeWithRetry(imageReader, imageData, [variant]);
+                  // Try zxing first with the current variant; fall
+                  // back to jsQR (QR-only, more tolerant of moiré)
+                  // on every miss. jsQR is a single call per tick
+                  // — it's already fast enough for the 80 ms budget.
+                  let hit = decodeWithRetry(imageReader, imageData, [variant]);
+                  if (!hit) {
+                    hit = decodeWithJsQR(imageData);
+                  }
                   if (hit) {
+                    if (hit.location) {
+                      pushDetection({
+                        location: hit.location,
+                        roiWidth: roi.width,
+                        roiHeight: roi.height,
+                        format: hit.format,
+                        source: hit.source,
+                        at: Date.now(),
+                      });
+                    }
                     const text = hit.text;
                     const at = performance.now();
                     const last = lastDecodedRef.current;
@@ -361,6 +490,7 @@ export function useBarcodeScanner(
                       at - last.at >= cooldownMs
                     ) {
                       lastDecodedRef.current = { text, at };
+                      triggerFlash();
                       onDecodeRef.current(text);
                     }
                   }
@@ -383,7 +513,7 @@ export function useBarcodeScanner(
     } finally {
       setStarting(false);
     }
-  }, [selectedDeviceId, cooldownMs]);
+  }, [selectedDeviceId, cooldownMs, pushDetection, triggerFlash]);
 
   // Restart the stream if the user picks a different camera while running.
   const selectDevice = useCallback(
@@ -411,7 +541,11 @@ export function useBarcodeScanner(
     // Crop to the same ROI rectangle the overlay renders. Decoding
     // only this region speeds the manual scan up (~4× fewer pixels)
     // and removes the cluttered background that otherwise confuses
-    // zxing's binarizer.
+    // zxing's binarizer. (v1.0.11) If the ROI pass misses, fall back
+    // to the full frame — operators sometimes hold the barcode at
+    // the edge of the viewport and the ROI crop excludes part of
+    // the symbol; the full-frame retry catches those without
+    // requiring a second click.
     const roi = computeRoi(w, h);
     if (roi.width <= 0 || roi.height <= 0) return null;
 
@@ -420,12 +554,70 @@ export function useBarcodeScanner(
     canvas.height = roi.height;
     const ctx = canvas.getContext('2d');
     if (!ctx) return null;
-    ctx.drawImage(video, roi.x, roi.y, roi.width, roi.height, 0, 0, roi.width, roi.height);
+    ctx.drawImage(
+      video,
+      roi.x,
+      roi.y,
+      roi.width,
+      roi.height,
+      0,
+      0,
+      roi.width,
+      roi.height,
+    );
     const imageData = ctx.getImageData(0, 0, roi.width, roi.height);
-
     const reader = createImageDataReader();
-    return decodeWithRetry(reader, imageData);
-  }, []);
+
+    const roiHit = decodeAny(reader, imageData, MANUAL_RETRY_VARIANTS);
+    if (roiHit) {
+      if (roiHit.location) {
+        pushDetection({
+          location: roiHit.location,
+          roiWidth: roi.width,
+          roiHeight: roi.height,
+          format: roiHit.format,
+          source: roiHit.source,
+          at: Date.now(),
+        });
+      }
+      triggerFlash();
+      return roiHit;
+    }
+
+    // Full-frame fallback. Reuse the same canvas at the larger size
+    // so we don't pay for two allocations when the manual button
+    // gets clicked rapidly.
+    canvas.width = w;
+    canvas.height = h;
+    const ctxFull = canvas.getContext('2d');
+    if (!ctxFull) return null;
+    ctxFull.drawImage(video, 0, 0, w, h);
+    const fullImage = ctxFull.getImageData(0, 0, w, h);
+    const fullHit = decodeAny(reader, fullImage, MANUAL_RETRY_VARIANTS);
+    if (fullHit) {
+      if (fullHit.location) {
+        // Convert from full-frame coords back into ROI coords so the
+        // overlay (which is positioned over the ROI) draws the
+        // polygon in the right place. Out-of-ROI hits clamp to the
+        // ROI edges so the overlay still shows the operator that
+        // we caught the symbol — they can re-aim from there.
+        const adjusted = fullHit.location.map((p) => ({
+          x: Math.max(0, Math.min(roi.width, p.x - roi.x)),
+          y: Math.max(0, Math.min(roi.height, p.y - roi.y)),
+        }));
+        pushDetection({
+          location: adjusted,
+          roiWidth: roi.width,
+          roiHeight: roi.height,
+          format: fullHit.format,
+          source: fullHit.source,
+          at: Date.now(),
+        });
+      }
+      triggerFlash();
+    }
+    return fullHit;
+  }, [pushDetection, triggerFlash]);
 
   const toggleTorch = useCallback(async (): Promise<void> => {
     const stream = streamRef.current;
@@ -459,6 +651,14 @@ export function useBarcodeScanner(
         }
       }
       streamRef.current = null;
+      if (detectionFadeTimerRef.current !== null) {
+        clearTimeout(detectionFadeTimerRef.current);
+        detectionFadeTimerRef.current = null;
+      }
+      if (decodeFlashTimerRef.current !== null) {
+        clearTimeout(decodeFlashTimerRef.current);
+        decodeFlashTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -477,5 +677,7 @@ export function useBarcodeScanner(
     torchSupported,
     torchOn,
     toggleTorch,
+    lastDetection,
+    decodeFlash,
   };
 }

--- a/apps/desktop/src/features/stocktake/StocktakePage.tsx
+++ b/apps/desktop/src/features/stocktake/StocktakePage.tsx
@@ -17,6 +17,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useBarcodeScanner } from '@/features/sirkulasi/useBarcodeScanner';
 import { ScannerOverlay } from '@/features/sirkulasi/ScannerOverlay';
+import { ScannerTrackingOverlay } from '@/features/sirkulasi/ScannerTrackingOverlay';
 import {
   Dialog,
   DialogContent,
@@ -596,15 +597,25 @@ export function StocktakePage() {
                       playsInline
                     />
                     {cameraScanner.active && (
-                      <ScannerOverlay
-                        label={t('stocktake:session.cameraOverlay')}
-                        busy={scanning}
-                        busyLabel={
-                          scanning
-                            ? t('stocktake:session.cameraScanning')
-                            : undefined
-                        }
-                      />
+                      <>
+                        <ScannerOverlay
+                          label={t('stocktake:session.cameraOverlay')}
+                          busy={scanning}
+                          busyLabel={
+                            scanning
+                              ? t('stocktake:session.cameraScanning')
+                              : undefined
+                          }
+                        />
+                        {cameraScanner.lastDetection && (
+                          <ScannerTrackingOverlay
+                            location={cameraScanner.lastDetection.location}
+                            roiWidth={cameraScanner.lastDetection.roiWidth}
+                            roiHeight={cameraScanner.lastDetection.roiHeight}
+                            flash={cameraScanner.decodeFlash}
+                          />
+                        )}
+                      </>
                     )}
                     {!cameraScanner.active && (
                       <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 text-white">

--- a/apps/desktop/src/lib/scanner/decoder.ts
+++ b/apps/desktop/src/lib/scanner/decoder.ts
@@ -14,11 +14,24 @@
  * Format coverage matches the FEAT-28 acceptance:
  *   EAN-13, EAN-8, Code-128, Code-39, QR Code, Data Matrix.
  *
+ * v1.0.11 additions:
+ * - Dedicated `'inverted'` preprocess variant in
+ *   {@link MANUAL_RETRY_VARIANTS} (zxing 0.21 doesn't expose the
+ *   `ALSO_INVERTED` hint, so we invert the bitmap ourselves before
+ *   handing it to the binarizer). Handles dark-mode QR codes and
+ *   white-on-black labels.
+ * - {@link decodeWithJsQR} fallback for QR codes — jsQR is much more
+ *   tolerant of moiré (phone screen × webcam) and small / low-res QR
+ *   than zxing's QR reader. It runs only after zxing misses to keep
+ *   the happy path fast.
+ * - {@link DecodedResult.location} polygon (4 corners + finder
+ *   patterns when available) for the live tracking overlay.
+ *
  * We deliberately keep the same library family the app already
  * shipped (zxing) — switching to quagga2 would have meant a fresh
  * audit of decode rates, license, and bundle size. zxing already
- * supports every format we need; the v1.0.7 hint list just didn't
- * include Data Matrix.
+ * supports every format we need; jsQR is added strictly as a
+ * focused QR-only fallback.
  */
 import { BrowserMultiFormatReader } from '@zxing/browser';
 import {
@@ -30,7 +43,9 @@ import {
   NotFoundException,
   RGBLuminanceSource,
   type Result,
+  type ResultPoint,
 } from '@zxing/library';
+import jsQR from 'jsqr';
 import {
   applyPreprocess,
   MANUAL_RETRY_VARIANTS,
@@ -58,10 +73,16 @@ export const SUPPORTED_FORMATS: BarcodeFormat[] = [
  * `Map<DecodeHintType, unknown>` is non-trivial to type-check across
  * versions so we encapsulate the construction in one place.
  *
- * `TRY_HARDER` enables the slower-but-more-thorough decode path. The
- * frame budget on a manual click is generous (~500ms) so the perf
- * cost is fine, and it noticeably improves the catch rate on
- * partially-occluded or skewed barcodes.
+ * - `TRY_HARDER` enables the slower-but-more-thorough decode path.
+ *   The frame budget on a manual click is generous (~500 ms) so the
+ *   perf cost is fine, and it noticeably improves the catch rate on
+ *   partially-occluded or skewed barcodes.
+ *
+ * Note: the `ALSO_INVERTED` hint (newer ZXing builds) is not present
+ * in @zxing/library 0.21, so the equivalent behaviour is provided by
+ * the `'inverted'` preprocess variant in
+ * {@link MANUAL_RETRY_VARIANTS} (and jsQR's `attemptBoth` mode for
+ * the QR fallback path).
  */
 export function buildDecodeHints(): Map<DecodeHintType, unknown> {
   const hints = new Map<DecodeHintType, unknown>();
@@ -107,6 +128,15 @@ export function imageDataToBitmap(image: ImageData): BinaryBitmap {
   return new BinaryBitmap(new HybridBinarizer(luminance));
 }
 
+/**
+ * 2-D point in image coordinates (origin top-left). Used by both the
+ * decoder location output and the SVG tracking overlay.
+ */
+export interface Point2D {
+  x: number;
+  y: number;
+}
+
 export interface DecodedResult {
   /** Decoded payload text. */
   text: string;
@@ -114,6 +144,35 @@ export interface DecodedResult {
   variant: PreprocessVariant;
   /** Which barcode format matched, e.g. `'CODE_128'`. */
   format: string;
+  /**
+   * Polygon outlining the decoded barcode in input-image coordinates
+   * (typically the ROI crop, occasionally the full frame). 2 points
+   * for 1-D barcodes (start + end of the bar pattern), 4 points for
+   * QR / Data Matrix (the corners). Always present when the decoder
+   * exposes location info; `null` when no location was returned.
+   *
+   * The live tracking overlay transforms these from ROI-pixel space
+   * to overlay-CSS space at render time.
+   */
+  location: Point2D[] | null;
+  /** Which decoder produced the hit. `'zxing'` or `'jsqr'`. */
+  source: 'zxing' | 'jsqr';
+}
+
+/**
+ * Convert zxing's `ResultPoint[]` into our portable `Point2D[]`.
+ * Returns `null` when the result has no points (rare — `getResultPoints`
+ * may return an empty array on malformed bitmaps).
+ */
+function extractZxingLocation(result: Result): Point2D[] | null {
+  const points = result.getResultPoints();
+  if (!points || points.length === 0) return null;
+  const out: Point2D[] = [];
+  for (const p of points as ResultPoint[]) {
+    if (!p) continue;
+    out.push({ x: p.getX(), y: p.getY() });
+  }
+  return out.length > 0 ? out : null;
 }
 
 /**
@@ -138,7 +197,10 @@ function decodeOnce(
     return {
       text: result.getText(),
       variant,
-      format: BarcodeFormat[result.getBarcodeFormat()] ?? String(result.getBarcodeFormat()),
+      format:
+        BarcodeFormat[result.getBarcodeFormat()] ?? String(result.getBarcodeFormat()),
+      location: extractZxingLocation(result),
+      source: 'zxing',
     };
   } catch (e) {
     if (e instanceof NotFoundException) {
@@ -155,7 +217,8 @@ function decodeOnce(
  * the first successful decode, or `null` if all variants miss.
  *
  * Default order is {@link MANUAL_RETRY_VARIANTS}: normal → contrast
- * → grayscale, tuned for Indonesian classroom lighting.
+ * → grayscale → inverted → brighten → darken → adaptiveThreshold.
+ * Tuned for Indonesian classroom lighting + phone-screen QR mix.
  */
 export function decodeWithRetry(
   reader: MultiFormatReader,
@@ -169,4 +232,80 @@ export function decodeWithRetry(
     }
   }
   return null;
+}
+
+/**
+ * jsQR adapter — focused QR-only decoder used as a fallback after
+ * zxing misses. jsQR's binarizer (a custom one tuned for camera-grade
+ * QR codes) outperforms zxing on:
+ *
+ * - Phone-screen QR codes (moiré pattern between the screen raster
+ *   and the webcam raster).
+ * - Low-resolution QR (zxing wants ≥ ~80 px per side; jsQR holds up
+ *   to ~50 px).
+ * - QR codes near the viewport edge that zxing's "centred" finder
+ *   pattern search rejects.
+ *
+ * Returns the same {@link DecodedResult} shape as zxing for a
+ * uniform consumer experience. The location polygon comes straight
+ * from jsQR's `location` (4 corners) — finder patterns are dropped
+ * because the overlay only needs the outer rectangle.
+ *
+ * `inversionAttempts` defaults to `'attemptBoth'` so jsQR also tries
+ * the inverted image (matches our zxing `ALSO_INVERTED` hint and
+ * makes dark-mode QR codes a one-call decode).
+ */
+export function decodeWithJsQR(image: ImageData): DecodedResult | null {
+  if (image.width <= 0 || image.height <= 0) return null;
+  const result = jsQR(image.data, image.width, image.height, {
+    inversionAttempts: 'attemptBoth',
+  });
+  if (!result) return null;
+  const loc = result.location;
+  // jsQR's location object always has the 4 corner fields populated,
+  // but we still defend against unexpected shapes since it's a
+  // run-time input from a third-party library.
+  const corners: Point2D[] = [
+    loc.topLeftCorner,
+    loc.topRightCorner,
+    loc.bottomRightCorner,
+    loc.bottomLeftCorner,
+  ]
+    .filter((p): p is { x: number; y: number } => !!p && typeof p.x === 'number')
+    .map((p) => ({ x: p.x, y: p.y }));
+  return {
+    text: result.data,
+    variant: 'normal',
+    format: 'QR_CODE',
+    location: corners.length > 0 ? corners : null,
+    source: 'jsqr',
+  };
+}
+
+/**
+ * Combined decoder used by both the continuous loop and the manual
+ * scan button. Tries zxing first (covers Code-128, Code-39, EAN-13/8,
+ * QR, Data Matrix) and falls back to jsQR on a miss for the QR-only
+ * cases zxing's QR reader rejects.
+ *
+ * The fallback runs strictly after zxing because:
+ * - zxing is faster on average across our format mix.
+ * - jsQR returns spurious matches on tightly-packed Code-128 labels
+ *   (their guard bars sometimes look like a QR finder pattern under
+ *   certain crops). Running jsQR only when zxing misses sidesteps
+ *   this.
+ *
+ * `variants` controls how many zxing preprocess passes to run before
+ * trying jsQR. Continuous decode passes `[currentVariant]` (one
+ * variant per tick), manual decode passes the full
+ * {@link MANUAL_RETRY_VARIANTS}.
+ */
+export function decodeAny(
+  reader: MultiFormatReader,
+  image: ImageData,
+  variants: PreprocessVariant[] = MANUAL_RETRY_VARIANTS,
+): DecodedResult | null {
+  const zxingHit = decodeWithRetry(reader, image, variants);
+  if (zxingHit) return zxingHit;
+  return decodeWithJsQR(image);
 }

--- a/apps/desktop/src/lib/scanner/overlay.ts
+++ b/apps/desktop/src/lib/scanner/overlay.ts
@@ -27,17 +27,20 @@
 /**
  * ROI rectangle as a fraction of the video frame.
  *
- * - 70% width × 30% height matches a typical landscape barcode aspect
- *   ratio (EAN-13 ≈ 2.4:1, Code-128 varies). Wide enough to fit the
- *   full barcode at a normal arm's-length distance, tall enough that
- *   slight tilt or vertical drift still keeps the bars in frame.
+ * - 70% width × 55% height (v1.0.11) — wider than the v1.0.10
+ *   70% × 30% rectangle so square QR codes (and Data Matrix) fit
+ *   comfortably alongside landscape Code-128 / EAN labels. The
+ *   55% height is a compromise: tall enough that a centered QR at
+ *   normal arm's-length distance fills most of the box, short enough
+ *   that the operator still sees their hands and the surroundings
+ *   for context.
  * - Centered (left/top = (1 - size)/2). Easier for operators than
  *   off-center alignment and matches every other phone-camera
  *   scanner UI in the wild.
  */
 export const ROI_PERCENT = {
   width: 0.7,
-  height: 0.3,
+  height: 0.55,
 } as const;
 
 export interface RoiRect {

--- a/apps/desktop/src/lib/scanner/preprocess.ts
+++ b/apps/desktop/src/lib/scanner/preprocess.ts
@@ -8,9 +8,16 @@
  * after BUG-18's resolution bump.
  *
  * The manual "Scan Sekarang" button trades latency for accuracy by
- * running up to three decode passes per click — each pass uses a
+ * running multiple decode passes per click — each pass uses a
  * different preprocessing variant. {@link applyPreprocess} produces
  * the variant; the decoder picks the first one that returns a hit.
+ *
+ * v1.0.11 expanded the variant set to handle:
+ * - **Inverted** (white-on-black labels, dark-mode QR on phone screens).
+ * - **Brighten** (gamma < 1) for under-exposed frames in dim rooms.
+ * - **Darken** (gamma > 1) for blown-out highlights and glare.
+ * - **Adaptive threshold** for very uneven lighting (window-side glare
+ *   that washes out one half of the barcode).
  *
  * All transforms here are pure functions over `ImageData`. They are
  * intentionally easy to test in isolation: pass in a synthetic
@@ -18,7 +25,14 @@
  * no async.
  */
 
-export type PreprocessVariant = 'normal' | 'grayscale' | 'contrast';
+export type PreprocessVariant =
+  | 'normal'
+  | 'grayscale'
+  | 'contrast'
+  | 'inverted'
+  | 'brighten'
+  | 'darken'
+  | 'adaptiveThreshold';
 
 /**
  * Build a fresh ImageData buffer the same size as the source. Used by
@@ -100,12 +114,209 @@ export function applyContrast(src: ImageData, factor: number): ImageData {
 }
 
 /**
+ * Invert each colour channel (255 - v). Useful for white-on-dark
+ * barcodes — phone-screen QR codes in dark mode are the canonical
+ * case, but laser-engraved labels on dark plastic also show up that
+ * way after binarisation. zxing's `ALSO_INVERTED` hint covers many of
+ * these natively, but the explicit pre-inverted pass gives jsQR a
+ * second chance too.
+ *
+ * Alpha is preserved.
+ */
+export function applyInvert(src: ImageData): ImageData {
+  const out = cloneShape(src);
+  const s = src.data;
+  const d = out.data;
+  for (let i = 0; i < s.length; i += 4) {
+    d[i] = 255 - (s[i] ?? 0);
+    d[i + 1] = 255 - (s[i + 1] ?? 0);
+    d[i + 2] = 255 - (s[i + 2] ?? 0);
+    d[i + 3] = s[i + 3] ?? 255;
+  }
+  return out;
+}
+
+/**
+ * Apply a per-channel gamma curve. `gamma < 1` brightens midtones
+ * (rescues under-exposed frames in dim classrooms); `gamma > 1`
+ * darkens midtones (tames blown-out highlights from sunlight glare).
+ *
+ * Implementation uses a 256-entry lookup table for the per-channel
+ * map — much faster than calling `Math.pow` per pixel on a 1080p
+ * crop. Alpha is left untouched.
+ */
+export function applyGamma(src: ImageData, gamma: number): ImageData {
+  const out = cloneShape(src);
+  const lut = new Uint8ClampedArray(256);
+  for (let v = 0; v < 256; v++) {
+    lut[v] = Math.round(255 * Math.pow(v / 255, gamma));
+  }
+  const s = src.data;
+  const d = out.data;
+  for (let i = 0; i < s.length; i += 4) {
+    d[i] = lut[s[i] ?? 0] ?? 0;
+    d[i + 1] = lut[s[i + 1] ?? 0] ?? 0;
+    d[i + 2] = lut[s[i + 2] ?? 0] ?? 0;
+    d[i + 3] = s[i + 3] ?? 255;
+  }
+  return out;
+}
+
+/**
+ * Block-mean adaptive threshold. For each pixel, compute the mean
+ * luminance over a square block centered on it; binarise to black
+ * or white based on whether the pixel is below or above
+ * `(blockMean - bias)`.
+ *
+ * A small constant `bias` (default 8) suppresses noise in flat
+ * regions — without it, an evenly-lit white page ends up speckled
+ * because every pixel sits arbitrarily close to its own block mean.
+ *
+ * This is a stripped-down version of Bradley/Sauvola adaptive
+ * thresholding tuned for our use case (binarising the ROI before
+ * handing it to zxing). It rescues the "half the page is in shadow"
+ * case where global contrast boosts can't push everything into the
+ * same dynamic range.
+ *
+ * Block size defaults to ~1/16 of the image's shorter side, capped
+ * to odd integers in `[3, 51]`. Larger blocks smooth more aggressively
+ * (good for text-heavy pages) but slow the decode down.
+ *
+ * Implementation note: we use an integral-image (summed-area table)
+ * so each block lookup is O(1) regardless of block size — total cost
+ * is O(N) for an N-pixel image rather than O(N · blockSize²).
+ */
+export function applyAdaptiveThreshold(
+  src: ImageData,
+  options: { blockSize?: number; bias?: number } = {},
+): ImageData {
+  const w = src.width;
+  const h = src.height;
+  const out = cloneShape(src);
+  if (w <= 0 || h <= 0) {
+    return out;
+  }
+  const minDim = Math.min(w, h);
+  const requestedBlock = options.blockSize ?? Math.max(15, Math.round(minDim / 16));
+  // Force odd, clamp to a reasonable range — large blocks hurt perf
+  // disproportionately because of the integral-image edge handling.
+  let blockSize = requestedBlock;
+  if (blockSize < 3) blockSize = 3;
+  if (blockSize > 51) blockSize = 51;
+  if (blockSize % 2 === 0) blockSize += 1;
+  const half = (blockSize - 1) >> 1;
+  const bias = options.bias ?? 8;
+
+  // Integral image of the per-pixel luminance. Width/height are +1
+  // larger so the (-1)-indexed boundary case becomes a free 0 row.
+  const iw = w + 1;
+  const ih = h + 1;
+  const integral = new Float64Array(iw * ih);
+  const s = src.data;
+  for (let y = 0; y < h; y++) {
+    let rowSum = 0;
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      const r = s[i] ?? 0;
+      const g = s[i + 1] ?? 0;
+      const b = s[i + 2] ?? 0;
+      const lum = 0.299 * r + 0.587 * g + 0.114 * b;
+      rowSum += lum;
+      integral[(y + 1) * iw + (x + 1)] = (integral[y * iw + (x + 1)] ?? 0) + rowSum;
+    }
+  }
+
+  const d = out.data;
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      const x0 = Math.max(0, x - half);
+      const y0 = Math.max(0, y - half);
+      const x1 = Math.min(w - 1, x + half);
+      const y1 = Math.min(h - 1, y + half);
+      const area = (x1 - x0 + 1) * (y1 - y0 + 1);
+      const sum =
+        (integral[(y1 + 1) * iw + (x1 + 1)] ?? 0) -
+        (integral[y0 * iw + (x1 + 1)] ?? 0) -
+        (integral[(y1 + 1) * iw + x0] ?? 0) +
+        (integral[y0 * iw + x0] ?? 0);
+      const mean = sum / area;
+      const r = s[i] ?? 0;
+      const g = s[i + 1] ?? 0;
+      const b = s[i + 2] ?? 0;
+      const lum = 0.299 * r + 0.587 * g + 0.114 * b;
+      const v = lum < mean - bias ? 0 : 255;
+      d[i] = v;
+      d[i + 1] = v;
+      d[i + 2] = v;
+      d[i + 3] = s[i + 3] ?? 255;
+    }
+  }
+  return out;
+}
+
+export interface ImageStats {
+  /** Average luminance over all pixels (0..255). */
+  mean: number;
+  /** Minimum per-pixel luminance encountered. */
+  min: number;
+  /** Maximum per-pixel luminance encountered. */
+  max: number;
+}
+
+/**
+ * Cheap one-pass luminance histogram summary. Used by the decoder
+ * to:
+ *
+ * - Skip pitch-black frames (e.g. camera covered, autoexposure not
+ *   converged yet). `max < 10` → no point feeding zxing anything,
+ *   it's all noise.
+ * - Pick which preprocess variants to try first. A frame whose mean
+ *   sits below 70 is much more likely to decode after a brighten
+ *   pass than a contrast pass; a frame with mean above 200 wants
+ *   darken first; a frame with `max - min < 40` wants the adaptive
+ *   threshold first because it has almost no global contrast.
+ *
+ * Only samples luminance — colour cast is handled separately by the
+ * grayscale variant.
+ */
+export function analyzeImageStats(src: ImageData): ImageStats {
+  const s = src.data;
+  if (s.length < 4) {
+    return { mean: 0, min: 0, max: 0 };
+  }
+  let total = 0;
+  let count = 0;
+  let min = 255;
+  let max = 0;
+  for (let i = 0; i < s.length; i += 4) {
+    const r = s[i] ?? 0;
+    const g = s[i + 1] ?? 0;
+    const b = s[i + 2] ?? 0;
+    const y = 0.299 * r + 0.587 * g + 0.114 * b;
+    total += y;
+    count += 1;
+    if (y < min) min = y;
+    if (y > max) max = y;
+  }
+  return {
+    mean: count > 0 ? total / count : 0,
+    min: count > 0 ? min : 0,
+    max: count > 0 ? max : 0,
+  };
+}
+
+/**
  * Pick the preprocessing variant requested by the caller.
  *
  * The decoder tries variants in this order:
- *   1. `'normal'`   — pass-through (still useful as a baseline pass).
- *   2. `'contrast'` — +30% contrast boost (most common decode rescue).
- *   3. `'grayscale'`— pure luminance (last resort: handles colour cast).
+ *   1. `'normal'`              — pass-through (still useful as a baseline pass).
+ *   2. `'contrast'`            — +30% contrast boost (most common decode rescue).
+ *   3. `'grayscale'`           — pure luminance (handles colour cast).
+ *   4. `'inverted'`            — flip black/white (white-on-dark labels, dark-mode QR).
+ *   5. `'brighten'`            — gamma 0.5 (rescues under-exposed frames).
+ *   6. `'darken'`              — gamma 1.6 (tames overexposed glare).
+ *   7. `'adaptiveThreshold'`   — local mean binarisation (uneven lighting / shadow).
  *
  * We expose them as discrete variants rather than as a single
  * configurable pipeline because the manual scan button benefits from
@@ -119,6 +330,14 @@ export function applyPreprocess(src: ImageData, variant: PreprocessVariant): Ima
       return toGrayscale(src);
     case 'contrast':
       return applyContrast(src, 1.3);
+    case 'inverted':
+      return applyInvert(src);
+    case 'brighten':
+      return applyGamma(src, 0.5);
+    case 'darken':
+      return applyGamma(src, 1.6);
+    case 'adaptiveThreshold':
+      return applyAdaptiveThreshold(src);
     default: {
       // Exhaustiveness guard. Compile-time `never` ensures all cases
       // are handled; the runtime fallback returns the source unchanged.
@@ -130,15 +349,43 @@ export function applyPreprocess(src: ImageData, variant: PreprocessVariant): Ima
 }
 
 /**
- * Default retry order for the manual scan button.
+ * Default retry order for the manual scan button. Ordered by how
+ * often each variant rescues a missed decode in practice — `'normal'`
+ * first because most frames are fine, then progressively heavier
+ * preprocesses.
  *
- * The order is designed for the median classroom case: most decodes
- * miss because of low contrast (under-lit barcodes on white paper),
- * so contrast boost is tried *before* grayscale. Grayscale is kept
- * last as the safety net for colour-cast failures.
+ * The full ordered list trades latency (~50 ms per variant on a 1080p
+ * ROI) for catch-rate. Manual scan's budget is generous; continuous
+ * decode picks a smaller subset {@link CONTINUOUS_VARIANTS}.
  */
 export const MANUAL_RETRY_VARIANTS: PreprocessVariant[] = [
   'normal',
   'contrast',
+  'grayscale',
+  'inverted',
+  'brighten',
+  'darken',
+  'adaptiveThreshold',
+];
+
+/**
+ * Variant subset cycled by the continuous-decode loop, one per tick.
+ *
+ * Smaller than the manual list (continuous mode runs ~12.5 fps and
+ * each tick must finish well within the 80 ms budget) but covers the
+ * lighting cases that most often trip up real classroom scans:
+ *
+ * - `normal` — the easy case, hit immediately when conditions are good.
+ * - `contrast` — rescues mild under-/over-exposure.
+ * - `inverted` — dark-mode phone QR.
+ * - `grayscale` — colour-cast under warm LEDs.
+ *
+ * The remaining heavy variants (brighten/darken/adaptiveThreshold)
+ * are only tried by the manual button.
+ */
+export const CONTINUOUS_VARIANTS: PreprocessVariant[] = [
+  'normal',
+  'contrast',
+  'inverted',
   'grayscale',
 ];

--- a/apps/desktop/tests/unit/scannerDecoder.test.ts
+++ b/apps/desktop/tests/unit/scannerDecoder.test.ts
@@ -7,6 +7,7 @@ import {
   imageDataToBitmap,
   SUPPORTED_FORMATS,
 } from '@/lib/scanner/decoder';
+import { MANUAL_RETRY_VARIANTS } from '@/lib/scanner/preprocess';
 
 /**
  * Minimal RGBA `ImageData` factory shared with the preprocess tests —
@@ -83,6 +84,9 @@ describe('decodeWithRetry', () => {
       return {
         getText: () => hitText,
         getBarcodeFormat: () => hitFormat,
+        // Provide an empty result-point list so the v1.0.11 location
+        // extractor short-circuits to `null` instead of throwing.
+        getResultPoints: () => [],
       };
     });
     const reset = vi.fn();
@@ -95,8 +99,11 @@ describe('decodeWithRetry', () => {
     const reader = stubReader(99);
     const result = decodeWithRetry(reader, blankImage(10, 10));
     expect(result).toBeNull();
-    // exactly the default 3 variants attempted
-    expect((reader as unknown as { decode: { mock: { calls: unknown[] } } }).decode.mock.calls.length).toBe(3);
+    // Exactly one decode pass per default variant.
+    expect(
+      (reader as unknown as { decode: { mock: { calls: unknown[] } } }).decode.mock.calls
+        .length,
+    ).toBe(MANUAL_RETRY_VARIANTS.length);
   });
 
   it('returns the first successful hit and stops trying further variants', () => {

--- a/apps/desktop/tests/unit/scannerOverlay.test.ts
+++ b/apps/desktop/tests/unit/scannerOverlay.test.ts
@@ -13,12 +13,12 @@ import {
  * decode regression, so unit-test the pure math.
  */
 describe('computeRoi', () => {
-  it('produces a centered rectangle at 70% × 30% of the video frame', () => {
+  it('produces a centered rectangle at 70% × 55% of the video frame', () => {
     const roi = computeRoi(1280, 720);
     expect(roi.width).toBe(896); // round(1280 * 0.7)
-    expect(roi.height).toBe(216); // round(720 * 0.3)
+    expect(roi.height).toBe(396); // round(720 * 0.55)
     expect(roi.x).toBe(192); // round((1280 - 896) / 2)
-    expect(roi.y).toBe(252); // round((720 - 216) / 2)
+    expect(roi.y).toBe(162); // round((720 - 396) / 2)
   });
 
   it('keeps the rectangle inside the video bounds at common resolutions', () => {
@@ -39,7 +39,8 @@ describe('computeRoi', () => {
 
   it('handles square frames without skewing the aspect', () => {
     const roi = computeRoi(500, 500);
-    // width fraction is larger than height fraction by construction.
+    // width fraction (0.7) is still larger than height fraction (0.55)
+    // — the box stays landscape even on square frames.
     expect(roi.width).toBeGreaterThan(roi.height);
   });
 
@@ -52,7 +53,7 @@ describe('computeRoi', () => {
 
   it('exposes the percentage constants for the React overlay div', () => {
     expect(ROI_PERCENT.width).toBeCloseTo(0.7, 5);
-    expect(ROI_PERCENT.height).toBeCloseTo(0.3, 5);
+    expect(ROI_PERCENT.height).toBeCloseTo(0.55, 5);
   });
 });
 

--- a/apps/desktop/tests/unit/scannerPreprocess.test.ts
+++ b/apps/desktop/tests/unit/scannerPreprocess.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  analyzeImageStats,
+  applyAdaptiveThreshold,
   applyContrast,
+  applyGamma,
+  applyInvert,
   applyPreprocess,
+  CONTINUOUS_VARIANTS,
   MANUAL_RETRY_VARIANTS,
   toGrayscale,
 } from '@/lib/scanner/preprocess';
@@ -145,12 +150,230 @@ describe('MANUAL_RETRY_VARIANTS', () => {
     expect(MANUAL_RETRY_VARIANTS[0]).toBe('normal');
   });
 
-  it('includes contrast and grayscale fallbacks', () => {
+  it('includes the v1.0.10 contrast + grayscale fallbacks', () => {
     expect(MANUAL_RETRY_VARIANTS).toContain('contrast');
     expect(MANUAL_RETRY_VARIANTS).toContain('grayscale');
   });
 
-  it('is exactly 3 variants — caller assumes a fixed budget', () => {
-    expect(MANUAL_RETRY_VARIANTS).toHaveLength(3);
+  it('includes the v1.0.11 lighting fallbacks for tricky scans', () => {
+    // These four cover dark-mode QR (inverted), under-/over-exposed
+    // (brighten/darken), and uneven lighting (adaptive threshold).
+    expect(MANUAL_RETRY_VARIANTS).toContain('inverted');
+    expect(MANUAL_RETRY_VARIANTS).toContain('brighten');
+    expect(MANUAL_RETRY_VARIANTS).toContain('darken');
+    expect(MANUAL_RETRY_VARIANTS).toContain('adaptiveThreshold');
+  });
+
+  it('orders the v1.0.10 variants before the heavier v1.0.11 ones', () => {
+    const idx = (v: string) => MANUAL_RETRY_VARIANTS.indexOf(v as never);
+    expect(idx('normal')).toBeLessThan(idx('inverted'));
+    expect(idx('contrast')).toBeLessThan(idx('inverted'));
+    expect(idx('grayscale')).toBeLessThan(idx('inverted'));
+    // Adaptive threshold is the heaviest preprocess and runs last.
+    expect(idx('adaptiveThreshold')).toBe(MANUAL_RETRY_VARIANTS.length - 1);
+  });
+});
+
+describe('CONTINUOUS_VARIANTS', () => {
+  it('is a strict subset of the manual retry list', () => {
+    for (const v of CONTINUOUS_VARIANTS) {
+      expect(MANUAL_RETRY_VARIANTS).toContain(v);
+    }
+  });
+
+  it('includes inverted so dark-mode QR is caught in continuous mode', () => {
+    expect(CONTINUOUS_VARIANTS).toContain('inverted');
+  });
+
+  it('is short enough to cycle within the cooldown window (≤4 variants)', () => {
+    expect(CONTINUOUS_VARIANTS.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('applyInvert', () => {
+  it('flips each RGB channel via 255 − v', () => {
+    const src = makeImageData(2, 1, [
+      [0, 128, 255, 255],
+      [50, 100, 200, 200],
+    ]);
+    const out = applyInvert(src);
+    expect([out.data[0], out.data[1], out.data[2]]).toEqual([255, 127, 0]);
+    expect([out.data[4], out.data[5], out.data[6]]).toEqual([205, 155, 55]);
+  });
+
+  it('preserves alpha verbatim', () => {
+    const src = makeImageData(1, 1, [[10, 20, 30, 128]]);
+    expect(applyInvert(src).data[3]).toBe(128);
+  });
+
+  it('is its own inverse on every channel', () => {
+    const src = makeImageData(1, 1, [[37, 91, 200, 255]]);
+    const round = applyInvert(applyInvert(src));
+    for (let i = 0; i < 3; i++) {
+      expect(round.data[i]).toBe(src.data[i]);
+    }
+  });
+});
+
+describe('applyGamma', () => {
+  it('gamma 1.0 is the identity transform', () => {
+    const src = makeImageData(2, 1, [
+      [10, 100, 200, 255],
+      [255, 0, 128, 255],
+    ]);
+    const out = applyGamma(src, 1.0);
+    for (let i = 0; i < src.data.length; i++) {
+      expect(out.data[i]).toBe(src.data[i]);
+    }
+  });
+
+  it('gamma < 1 brightens midtones (rescues dim frames)', () => {
+    const src = makeImageData(1, 1, [[60, 60, 60, 255]]);
+    const out = applyGamma(src, 0.5);
+    // 0.5 brings the mid-low value way up.
+    expect(out.data[0]).toBeGreaterThan(120);
+  });
+
+  it('gamma > 1 darkens midtones (tames glare)', () => {
+    const src = makeImageData(1, 1, [[200, 200, 200, 255]]);
+    const out = applyGamma(src, 1.6);
+    // High value pulls toward black.
+    expect(out.data[0]).toBeLessThan(180);
+  });
+
+  it('clamps endpoints exactly to 0 and 255', () => {
+    const src = makeImageData(2, 1, [
+      [0, 0, 0, 255],
+      [255, 255, 255, 255],
+    ]);
+    const out = applyGamma(src, 0.4);
+    expect(out.data[0]).toBe(0);
+    expect(out.data[4]).toBe(255);
+  });
+});
+
+describe('applyAdaptiveThreshold', () => {
+  it('binarises a uniform mid-grey image to all-white (no contrast)', () => {
+    // Uniform grey: every pixel equals its block mean → all bright.
+    const px: Array<[number, number, number, number]> = [];
+    for (let i = 0; i < 16 * 16; i++) {
+      px.push([128, 128, 128, 255]);
+    }
+    const src = makeImageData(16, 16, px);
+    const out = applyAdaptiveThreshold(src);
+    for (let i = 0; i < out.data.length; i += 4) {
+      expect(out.data[i]).toBe(255);
+    }
+  });
+
+  it('produces a 2-tone output (only 0 or 255 in RGB channels)', () => {
+    // Half-dark, half-light vertical strip.
+    const px: Array<[number, number, number, number]> = [];
+    for (let y = 0; y < 16; y++) {
+      for (let x = 0; x < 16; x++) {
+        const v = x < 8 ? 50 : 200;
+        px.push([v, v, v, 255]);
+      }
+    }
+    const src = makeImageData(16, 16, px);
+    const out = applyAdaptiveThreshold(src);
+    for (let i = 0; i < out.data.length; i += 4) {
+      expect(out.data[i]).toBeOneOf([0, 255]);
+      expect(out.data[i + 1]).toBe(out.data[i]);
+      expect(out.data[i + 2]).toBe(out.data[i]);
+    }
+  });
+
+  it('does not mutate the input buffer', () => {
+    const src = makeImageData(2, 2, [
+      [50, 50, 50, 255],
+      [200, 200, 200, 255],
+      [10, 10, 10, 255],
+      [240, 240, 240, 255],
+    ]);
+    const snapshot = Array.from(src.data);
+    applyAdaptiveThreshold(src);
+    expect(Array.from(src.data)).toEqual(snapshot);
+  });
+
+  it('handles zero-sized inputs without throwing', () => {
+    const src = { data: new Uint8ClampedArray(0), width: 0, height: 0 } as ImageData;
+    expect(() => applyAdaptiveThreshold(src)).not.toThrow();
+  });
+});
+
+describe('analyzeImageStats', () => {
+  it('reports zeros for an empty buffer', () => {
+    const src = { data: new Uint8ClampedArray(0), width: 0, height: 0 } as ImageData;
+    expect(analyzeImageStats(src)).toEqual({ mean: 0, min: 0, max: 0 });
+  });
+
+  it('captures min, max, mean of a 2-pixel image', () => {
+    const src = makeImageData(2, 1, [
+      [255, 255, 255, 255],
+      [0, 0, 0, 255],
+    ]);
+    const stats = analyzeImageStats(src);
+    expect(stats.min).toBe(0);
+    expect(stats.max).toBe(255);
+    // mean of (255, 0) = 127.5
+    expect(stats.mean).toBeCloseTo(127.5, 5);
+  });
+
+  it('flags a pitch-black frame (max ≈ 0) for the dark-frame guard', () => {
+    const px: Array<[number, number, number, number]> = [];
+    for (let i = 0; i < 100; i++) {
+      px.push([0, 0, 0, 255]);
+    }
+    const src = makeImageData(10, 10, px);
+    const stats = analyzeImageStats(src);
+    expect(stats.max).toBeLessThan(10);
+    expect(stats.mean).toBeLessThan(10);
+  });
+
+  it('flags a uniformly bright frame (min ≈ 255) so glare-detection can react', () => {
+    const px: Array<[number, number, number, number]> = [];
+    for (let i = 0; i < 100; i++) {
+      px.push([250, 250, 250, 255]);
+    }
+    const src = makeImageData(10, 10, px);
+    const stats = analyzeImageStats(src);
+    expect(stats.min).toBeGreaterThan(240);
+    expect(stats.max).toBeLessThanOrEqual(255);
+  });
+});
+
+describe('applyPreprocess (v1.0.11 variants)', () => {
+  const src = makeImageData(1, 1, [[120, 90, 60, 255]]);
+
+  it("'inverted' delegates to applyInvert", () => {
+    const out = applyPreprocess(src, 'inverted');
+    expect([out.data[0], out.data[1], out.data[2]]).toEqual([135, 165, 195]);
+  });
+
+  it("'brighten' applies a sub-1 gamma (raises midtones)", () => {
+    const out = applyPreprocess(src, 'brighten');
+    // All three channels should brighten.
+    expect(out.data[0]).toBeGreaterThan(120);
+  });
+
+  it("'darken' applies a >1 gamma (lowers midtones)", () => {
+    const out = applyPreprocess(src, 'darken');
+    expect(out.data[0]).toBeLessThan(120);
+  });
+
+  it("'adaptiveThreshold' returns a 2-tone image", () => {
+    // Use a small but realistic sample so the threshold produces both
+    // 0 and 255 outputs depending on local mean.
+    const px: Array<[number, number, number, number]> = [];
+    for (let i = 0; i < 64; i++) {
+      const v = i % 2 === 0 ? 30 : 210;
+      px.push([v, v, v, 255]);
+    }
+    const big = makeImageData(8, 8, px);
+    const out = applyPreprocess(big, 'adaptiveThreshold');
+    for (let i = 0; i < out.data.length; i += 4) {
+      expect(out.data[i]).toBeOneOf([0, 255]);
+    }
   });
 });

--- a/apps/desktop/tests/unit/scannerScenarios.test.ts
+++ b/apps/desktop/tests/unit/scannerScenarios.test.ts
@@ -1,0 +1,311 @@
+/**
+ * End-to-end barcode decode scenarios for v1.0.11.
+ *
+ * The user explicitly asked for the scanner to be tested with dark,
+ * low-contrast, total-darkness, and inverted barcodes — not just unit
+ * tests of individual transforms. This file generates real QR codes
+ * with the `qrcode` library, renders them into ImageData buffers
+ * under various adverse lighting conditions, and asserts that:
+ *
+ * 1. The full decode pipeline (zxing retry chain + jsQR fallback)
+ *    reads them back.
+ * 2. The dark-frame guard short-circuits on pitch-black inputs
+ *    without throwing.
+ * 3. Each preprocess variant produces output the decoder can act on
+ *    (i.e. the scanner stays responsive under classroom lighting).
+ *
+ * The intent is to reproduce the failure modes the user reported in
+ * v1.0.10 (QR codes that are clearly visible to the eye but that the
+ * decoder misses) and to confirm v1.0.11 fixes them. Each scenario
+ * is named in plain language so a regression makes the failure
+ * obvious without deep-diving into the test code.
+ */
+import { describe, expect, it } from 'vitest';
+import QRCode from 'qrcode';
+import {
+  createImageDataReader,
+  decodeAny,
+  decodeWithJsQR,
+  decodeWithRetry,
+} from '@/lib/scanner/decoder';
+import {
+  analyzeImageStats,
+  applyGamma,
+  applyInvert,
+  CONTINUOUS_VARIANTS,
+} from '@/lib/scanner/preprocess';
+
+interface QrImage {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+/**
+ * Render a synthetic QR code into an `ImageData`-shaped buffer at a
+ * configurable scale + with optional horizontal padding so jsQR /
+ * zxing have a real "quiet zone" around the symbol.
+ *
+ * - `text`: payload to encode.
+ * - `scale`: pixels per QR module. Real cameras typically deliver
+ *   3–6 px/module; we default to 6 for crisp tests and step down
+ *   in low-resolution scenarios.
+ * - `quietZone`: extra modules of white border. The QR spec mandates
+ *   ≥4. Skipping the quiet zone is the most common reason zxing
+ *   misses an otherwise-clear QR.
+ * - `darkColor` / `lightColor`: rendered "ink" intensities. Adjust
+ *   to simulate low contrast (`darkColor` close to `lightColor`).
+ * - `invert`: swap dark and light to simulate dark-mode QR codes
+ *   on phone screens.
+ */
+function renderQR(
+  text: string,
+  options: {
+    scale?: number;
+    quietZone?: number;
+    darkColor?: number;
+    lightColor?: number;
+    invert?: boolean;
+  } = {},
+): QrImage {
+  const scale = options.scale ?? 6;
+  const quietZone = options.quietZone ?? 4;
+  const darkColor = options.darkColor ?? 0;
+  const lightColor = options.lightColor ?? 255;
+  const matrix = QRCode.create(text, { errorCorrectionLevel: 'M' });
+  const moduleSize = matrix.modules.size;
+  const modules = matrix.modules.data;
+  const sideModules = moduleSize + quietZone * 2;
+  const sidePixels = sideModules * scale;
+  const data = new Uint8ClampedArray(sidePixels * sidePixels * 4);
+  for (let py = 0; py < sidePixels; py++) {
+    for (let px = 0; px < sidePixels; px++) {
+      const mx = Math.floor(px / scale) - quietZone;
+      const my = Math.floor(py / scale) - quietZone;
+      let isDark = false;
+      if (mx >= 0 && mx < moduleSize && my >= 0 && my < moduleSize) {
+        isDark = modules[my * moduleSize + mx] === 1;
+      }
+      const dark = options.invert ? !isDark : isDark;
+      const v = dark ? darkColor : lightColor;
+      const i = (py * sidePixels + px) * 4;
+      data[i] = v;
+      data[i + 1] = v;
+      data[i + 2] = v;
+      data[i + 3] = 255;
+    }
+  }
+  return { data, width: sidePixels, height: sidePixels };
+}
+
+/** Dim every channel by a fixed multiplier (simulates underexposure). */
+function darken(img: QrImage, factor: number): QrImage {
+  const data = new Uint8ClampedArray(img.data.length);
+  for (let i = 0; i < img.data.length; i += 4) {
+    data[i] = Math.round((img.data[i] ?? 0) * factor);
+    data[i + 1] = Math.round((img.data[i + 1] ?? 0) * factor);
+    data[i + 2] = Math.round((img.data[i + 2] ?? 0) * factor);
+    data[i + 3] = img.data[i + 3] ?? 255;
+  }
+  return { data, width: img.width, height: img.height };
+}
+
+describe('Scanner scenarios — bright / well-lit (baseline)', () => {
+  it('decodes a high-contrast QR via jsQR path', () => {
+    const img = renderQR('SCAN-OK-001', { scale: 6 });
+    const result = decodeWithJsQR(img as ImageData);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('SCAN-OK-001');
+    // Location polygon present so the live tracking overlay can render.
+    expect(result!.location).not.toBeNull();
+    expect(result!.location!.length).toBe(4);
+    expect(result!.source).toBe('jsqr');
+  });
+
+  it('decodes via the combined zxing+jsQR pipeline', () => {
+    const reader = createImageDataReader();
+    const img = renderQR('SCAN-OK-002', { scale: 6 });
+    const result = decodeAny(reader, img as ImageData, ['normal']);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('SCAN-OK-002');
+  });
+});
+
+describe('Scanner scenarios — dark / underexposed', () => {
+  it('decodes a 25%-brightness QR (reportedly the user complaint case)', () => {
+    const bright = renderQR('DARK-25PCT', { scale: 6 });
+    const dim = darken(bright, 0.25);
+    const stats = analyzeImageStats(dim as ImageData);
+    expect(stats.mean).toBeLessThan(80);
+    // jsQR alone may struggle; the brighten variant rescues it.
+    const reader = createImageDataReader();
+    const result = decodeAny(reader, dim as ImageData, [
+      'normal',
+      'brighten',
+      'contrast',
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('DARK-25PCT');
+  });
+
+  it('decodes a really dim QR (≈10% brightness) after gamma rescue', () => {
+    const bright = renderQR('VERY-DIM-QR', { scale: 6 });
+    const dim = darken(bright, 0.1);
+    const stats = analyzeImageStats(dim as ImageData);
+    expect(stats.mean).toBeLessThan(40);
+    // Apply the brighten variant manually so we directly test that
+    // the gamma curve recovers a usable bitmap.
+    const recovered = applyGamma(dim as ImageData, 0.4);
+    const result = decodeWithJsQR(recovered);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('VERY-DIM-QR');
+  });
+
+  it('returns null cleanly on a pitch-black frame (dark-frame guard scenario)', () => {
+    // Empty pixels → mean ≈ 0. The decoder must not crash and must
+    // not return a phantom result.
+    const black: QrImage = {
+      data: new Uint8ClampedArray(64 * 64 * 4),
+      width: 64,
+      height: 64,
+    };
+    const stats = analyzeImageStats(black as ImageData);
+    expect(stats.max).toBeLessThan(10);
+    const reader = createImageDataReader();
+    expect(() =>
+      decodeAny(reader, black as ImageData, ['normal', 'brighten']),
+    ).not.toThrow();
+    expect(decodeWithJsQR(black as ImageData)).toBeNull();
+  });
+});
+
+describe('Scanner scenarios — low contrast', () => {
+  it('decodes a moderately low-contrast QR via the contrast variant', () => {
+    // Inks compressed into a 90-200 range — flat-but-still-decodable.
+    // This is the realistic ceiling for what the decoder can handle
+    // without an explicit adaptive-threshold pass.
+    const img = renderQR('LOW-CONTRAST', {
+      scale: 6,
+      darkColor: 90,
+      lightColor: 200,
+    });
+    const stats = analyzeImageStats(img as ImageData);
+    expect(stats.max - stats.min).toBeLessThan(130);
+    const reader = createImageDataReader();
+    const result = decodeAny(reader, img as ImageData, [
+      'normal',
+      'contrast',
+      'adaptiveThreshold',
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('LOW-CONTRAST');
+  });
+
+  it('survives an extreme low-contrast frame (≤40 range) without throwing', () => {
+    // Both inks compressed into a 110-150 range. zxing + jsQR may
+    // both miss this — the important property is that no decoder
+    // throws and the dark-frame guard does not fire (max ≥ 10).
+    const img = renderQR('EXTREME-LOW-CONTRAST', {
+      scale: 6,
+      darkColor: 110,
+      lightColor: 150,
+    });
+    const stats = analyzeImageStats(img as ImageData);
+    expect(stats.max).toBeGreaterThan(10);
+    const reader = createImageDataReader();
+    expect(() =>
+      decodeAny(reader, img as ImageData, [
+        'normal',
+        'contrast',
+        'brighten',
+        'adaptiveThreshold',
+      ]),
+    ).not.toThrow();
+  });
+});
+
+describe('Scanner scenarios — inverted (dark-mode phone screen)', () => {
+  it('decodes a white-on-black QR via jsQR attemptBoth', () => {
+    // White QR on black background — common when the user sticks a
+    // phone in dark mode against a webcam. jsQR's `attemptBoth`
+    // mode handles this without any preprocess, which is exactly
+    // why we plumb jsQR in as a fallback.
+    const inverted = renderQR('DARK-MODE-QR', { scale: 6, invert: true });
+    const direct = decodeWithJsQR(inverted as ImageData);
+    expect(direct).not.toBeNull();
+    expect(direct!.text).toBe('DARK-MODE-QR');
+  });
+
+  it('decodeAny() catches dark-mode QR via the jsQR fallback even when zxing misses', () => {
+    // Reproduces the user-reported v1.0.10 failure: a dark-mode QR
+    // that zxing's binarizer rejects as not-a-finder-pattern. The
+    // combined pipeline must still hand back a decode.
+    const inverted = renderQR('FALLBACK-QR', { scale: 6, invert: true });
+    const reader = createImageDataReader();
+    const result = decodeAny(reader, inverted as ImageData, ['normal']);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('FALLBACK-QR');
+  });
+
+  it('the inverted preprocess variant flips bits cleanly (255 − v)', () => {
+    // Verify the variant itself: a re-inverted dark-mode QR should
+    // be byte-equivalent to the original light-mode QR (modulo
+    // alpha). Used by the manual scan retry chain.
+    const inverted = renderQR('INV-CHECK', { scale: 6, invert: true });
+    const reInverted = applyInvert(inverted as ImageData);
+    // Background of original was black (0); after re-inversion it's
+    // 255 (white) again.
+    expect(reInverted.data[0]).toBe(255);
+    expect(reInverted.data[1]).toBe(255);
+    expect(reInverted.data[2]).toBe(255);
+  });
+});
+
+describe('Scanner scenarios — glare / overexposed', () => {
+  it('decodes a near-saturated QR after darken variant', () => {
+    // Compress the dynamic range up against the highlights:
+    // dark = 130, light = 250. Mean is way above 200.
+    const glare = renderQR('GLARE-QR', {
+      scale: 6,
+      darkColor: 130,
+      lightColor: 250,
+    });
+    const stats = analyzeImageStats(glare as ImageData);
+    expect(stats.mean).toBeGreaterThan(180);
+    const reader = createImageDataReader();
+    const result = decodeAny(reader, glare as ImageData, [
+      'normal',
+      'darken',
+      'contrast',
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('GLARE-QR');
+  });
+});
+
+describe('Scanner scenarios — small / low-res QR', () => {
+  it('decodes a 3 px / module QR (about the smallest jsQR can read)', () => {
+    const small = renderQR('SMALL-QR', { scale: 3 });
+    const result = decodeWithJsQR(small as ImageData);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('SMALL-QR');
+  });
+});
+
+describe('Scanner scenarios — continuous variant cycle', () => {
+  it('every continuous variant survives a moderate-contrast frame without throwing', () => {
+    // Same QR rendered with tighter contrast so each variant has a
+    // chance to "fail safely" without erroring.
+    const img = renderQR('CYCLE-QR', {
+      scale: 5,
+      darkColor: 60,
+      lightColor: 200,
+    });
+    const reader = createImageDataReader();
+    for (const variant of CONTINUOUS_VARIANTS) {
+      // Each variant should at minimum return either a Result or
+      // null — never throw.
+      expect(() => decodeWithRetry(reader, img as ImageData, [variant])).not.toThrow();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       jspdf:
         specifier: ^2.5.2
         version: 2.5.2
+      jsqr:
+        specifier: ^1.4.0
+        version: 1.4.0
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@18.3.1)
@@ -1483,6 +1486,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -2516,6 +2520,9 @@ packages:
 
   jspdf@2.5.2:
     resolution: {integrity: sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==}
+
+  jsqr@1.4.0:
+    resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -6195,6 +6202,8 @@ snapshots:
       core-js: 3.49.0
       dompurify: 2.5.9
       html2canvas: 1.4.1
+
+  jsqr@1.4.0: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:


### PR DESCRIPTION
## Summary

Follow-up ke v1.0.10 (#141) untuk menutup keluhan user: **QR code di layar HP yang jelas terlihat tetap miss berulang**, dan **tidak ada feedback visual** saat decoder benar-benar mendeteksi kode. v1.0.11 menambahkan live tracking overlay, decoder QR-spesialis (jsQR) sebagai fallback, dan memperluas retry pipeline ke kondisi pencahayaan yang sebelumnya tidak ditangani (dark, low-contrast, inverted/dark-mode, glare).

User explicitly meminta: _"buat barcode lebih sensitif lagi agar bisa membaca nya... live tracking automatis mendeteksi titik titik barcode"_ dan _"kamu lakukan test dengan barcode gelap tidak kelihatan sedang gelap total, atau keterangan tes semua nya lalu lakukan perbaikan kalau ada"_. PR ini meng-cover keduanya — implementasi + test scenario lengkap.

### 1. Live tracking overlay (Sirkulasi / OPAC / Stocktake)

Setiap tick decode (~80 ms), kalau decoder mendeteksi barcode/QR, koordinat 4 sudut (atau 2 untuk 1D barcode) di-extract ke `DecodedResult.location`. `useBarcodeScanner` menyimpan `lastDetection` + flag `decodeFlash`, dan komponen baru `<ScannerTrackingOverlay>` menggambar SVG polygon yang:

- **Hijau** saat barcode terdeteksi tapi belum decode (atau cooldown).
- **Flash kuning** ~350 ms saat decode sukses (cooldown trigger).
- **Fade-out** otomatis ~600 ms setelah deteksi terakhir hilang dari frame.
- **Drop shadow** + corner dots biar terlihat di latar webcam yang ramai.

Overlay dipasang di Sirkulasi, OPAC KTA scan, dan Stocktake — semua pakai hook yang sama jadi tidak ada duplikasi state.

### 2. jsQR sebagai decoder paralel khusus QR

ZXing's binarizer punya kelemahan terkenal terhadap **moiré pattern** (raster layar HP × raster webcam) dan QR di **dark mode** (kotak putih di latar hitam). v1.0.10 user kirim screenshot QR di layar HP yang jelas tapi miss 3× klik manual.

`jsQR` (~30 KB) adalah library spesialis QR yang sangat tahan moiré + low-res + inverted. Dipanggil **setelah** ZXing miss (jadi tidak menambah latensi pada kasus mudah Code-128). Mode `inversionAttempts: 'attemptBoth'` menangani dark-mode QR tanpa preprocess tambahan — cukup hand back ke `decodeAny()`.

`decodeAny(reader, image, variants)` adalah pipeline tunggal yang dipakai semua call site: ZXing dengan retry chain → jsQR fallback. Returns `DecodedResult { text, format, location, source }` di mana `source` mengindikasikan decoder mana yang berhasil (untuk debugging / telemetry nanti).

### 3. ROI bumped 70%×30% → 70%×55%

ROI v1.0.10 di-tune untuk Code-128 landscape (kartu buku). QR persegi sering tidak muat penuh di kotak ROI dengan tinggi 30% — sudut-sudut QR ter-crop, finder pattern hilang. v1.0.11 naikkan tinggi ke 55% supaya QR persegi muat lega + Data Matrix juga catch.

Sebagai bonus: **full-frame fallback** di "Scan Sekarang" — kalau ROI miss, retry sekali lagi pakai seluruh frame, lalu `clamp` lokasi kembali ke koordinat ROI supaya overlay tetap menampilkan posisi yang masuk akal.

### 4. Preprocess variant baru (4 tambahan, total 7)

Sebelum:
```ts
['normal', 'contrast', 'grayscale']  // 3 variants
```

Sekarang:
```ts
const MANUAL_RETRY_VARIANTS = [
  'normal', 'contrast', 'grayscale',
  'inverted',           // 255 − v, untuk dark-mode
  'brighten',           // gamma 0.5, untuk underexposed
  'darken',             // gamma 1.6, untuk glare/overexposed
  'adaptiveThreshold',  // block-mean lokal, untuk lampu klasroom yang tidak rata
];
```

Continuous decode loop tetap pakai 4 varian (bukan 7) supaya tetap responsif: `[normal, contrast, inverted, grayscale]` — siklus ~320 ms (4 × 80 ms tick).

`analyzeImageStats(image)` helper baru menghitung mean/min/max luminansi dalam satu pass O(n). `useBarcodeScanner` pakai ini untuk **skip frame pitch-black** (max < 8) sebelum membayar biaya zxing/jsQR — cuts decoder error noise saat kamera baru terbuka atau ditutup penutup lensa.

### 5. ZXing 0.21 tidak mengekspor `ALSO_INVERTED`

Investigasi: `@zxing/library@0.21.3` (versi yang sedang dipakai) tidak punya `DecodeHintType.ALSO_INVERTED` — itu di-add di versi lebih baru. Daripada upgrade zxing (risk regression), v1.0.11 mencapai fungsi yang sama via:
- Varian `inverted` di `MANUAL_RETRY_VARIANTS` (preprocess sebelum feed ke zxing)
- jsQR `attemptBoth` mode (auto-coba inverted di dalam jsQR)

Hasil real-world equivalent ke ALSO_INVERTED tanpa upgrade dependency.

### 6. Tests — 49 test baru, 478/478 pass total

User minta test scenario lengkap. Saya tambahkan dua file test baru:

**`tests/unit/scannerPreprocess.test.ts`** (36 tests, was 7)
- `MANUAL_RETRY_VARIANTS` + `CONTINUOUS_VARIANTS`: ordering, completeness, no overlap.
- `applyInvert`: byte flip, alpha preservation, self-inverse.
- `applyGamma`: identity at γ=1, brightens at γ<1, darkens at γ>1, endpoint clamping.
- `applyAdaptiveThreshold`: uniform grey → all white, binarizes to 2-tone, immutability, zero-size safety.
- `analyzeImageStats`: empty buffer, 2-pixel image, pitch-black frame detection, bright frame detection.
- `applyPreprocess` v1.0.11 variants: behavioral check for inverted/brighten/darken/adaptiveThreshold.

**`tests/unit/scannerScenarios.test.ts`** (13 tests, NEW)
End-to-end scenarios — render QR sintetis dengan `qrcode` library lalu uji decode pipeline penuh:

| Scenario                                | Result |
| --------------------------------------- | ------ |
| Bright high-contrast QR (baseline)      | jsQR catches at 6 px/module, location polygon present |
| 25% brightness QR (user complaint case) | brighten variant rescues |
| 10% brightness QR                       | gamma 0.4 manual rescue then jsQR catches |
| Pitch-black frame (mean < 10)           | dark-frame guard returns null cleanly, no throw |
| Low-contrast (90-200 range)             | contrast variant catches |
| Extreme low-contrast (110-150 range)    | survives without throw (best-effort) |
| Dark-mode QR (white on black)           | jsQR `attemptBoth` catches directly |
| Dark-mode QR via `decodeAny`            | jsQR fallback catches when zxing misses |
| Inverted preprocess byte verification   | 255 − v applied correctly |
| Glare/overexposed (mean > 180)          | darken variant catches |
| Low-res QR (3 px/module)                | jsQR catches at minimum readable scale |
| Continuous variant cycle                | every variant survives moderate-contrast frame without throw |

Semua scenario dirancang untuk reproduce kondisi yang user laporkan + kondisi adversarial yang ditemukan di v1.0.10. **478/478 tests pass total.**

### 7. Version bump 1.0.10 → 1.0.11

`package.json`, `apps/desktop/package.json`, `apps/desktop/src-tauri/Cargo.toml`, `apps/desktop/src-tauri/Cargo.lock` (perpustakaan-desktop crate version), `apps/desktop/src-tauri/tauri.conf.json` + CHANGELOG entry under `[1.0.11]`.

## Review & Testing Checklist for Human

- [ ] **CI hijau** (Lint, Typecheck, Unit Test 478/478, Rust check, Build Windows installer).
- [ ] **Buka Sirkulasi (Webcam)** — coba QR di layar HP (yang biasanya susah dibaca v1.0.10). Confirm:
  - [ ] Polygon hijau muncul di sekitar QR begitu kamera melihatnya, **sebelum** decode sukses.
  - [ ] Polygon flash kuning singkat saat decode sukses + hasil masuk ke list peminjaman.
  - [ ] Polygon fade-out otomatis kalau QR diangkat dari frame.
  - [ ] QR catch lebih cepat / lebih sering daripada v1.0.10.
- [ ] **Coba Code-128 yang biasa** — pastikan tidak regress dari v1.0.10.
- [ ] **Coba dark-mode** — flip HP ke dark mode (background hitam, QR putih) lalu test. v1.0.10 selalu miss; v1.0.11 harusnya catch via jsQR fallback.
- [ ] **Stocktake → Buka Kamera** — confirm tracking overlay juga muncul di sini, scan eksemplar masih jalan.
- [ ] **OPAC KTA scan** — confirm overlay tracking muncul + scan KTA tetap jalan.
- [ ] **Tutup penutup lensa kamera** — confirm tidak ada error noise di console (dark-frame guard fires).

### Notes

- `MANUAL_RETRY_VARIANTS` 3 → 7 berarti tombol "Scan Sekarang" pada kasus terburuk ~7 × 50 ms = 350 ms (was ~150 ms). Trade-off untuk catch-rate yang jauh lebih tinggi pada kondisi pencahayaan yang sulit. Bisa diturunkan kalau ada keluhan latensi.
- `DecodedResult.location` adalah array di **koordinat ROI** (bukan koordinat video penuh). Overlay component re-maps ke CSS via SVG `viewBox`. Full-frame fallback path melakukan `clamp` agar lokasi yang dihasilkan tetap di dalam kotak ROI untuk konsistensi visual.
- Tidak ada perubahan Rust backend / DB schema / migrasi.
- `qrcode` library hanya devDependency baru (sudah ada sebelumnya untuk export PDF KTA). Tidak menambah ukuran bundle production.
- Setelah PR merged, push tag `v1.0.11` akan trigger `release-v2` workflow seperti biasa untuk publish installer Windows ke GitHub Releases.
