### PR TITLE
fix(pengembalian): dedupe denda quick-button presets (BUG-Pengembalian-DendaDup)

### DIFF
--- a/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
+++ b/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
@@ -10,15 +10,7 @@ import { useToast } from '@/components/ui/toast-manager';
 import { calculateDenda, peminjamanApi, type PeminjamanDetail, type PeminjamanRow } from '@/lib/peminjaman';
 import { formatTauriError } from '@/lib/errors';
 import { DEFAULT_LOAN_RULES, settingsApi, type LoanRules } from '@/lib/settings';
-
-/**
- * Multipliers for the denda quick-input buttons (FEAT-08 in the v1.0.7
- * batch). The label and value derive from the live `dendaPerHari`
- * setting, so changing Aturan Peminjaman to e.g. 1500 turns the buttons
- * into "Rp 1.500 / Rp 3.000 / Rp 4.500" automatically.
- */
-const DENDA_QUICK_MULTIPLIERS: readonly number[] = [1, 2, 3];
-const DENDA_FIXED_PRESETS: readonly number[] = [5000, 10000, 15000];
+import { dendaQuickPresets } from '@/lib/dendaPresets';
 
 function formatRupiah(value: number): string {
   return value.toLocaleString('id-ID');
@@ -112,6 +104,11 @@ export function PengembalianPage() {
       loanRules.dendaPerHari,
     );
   }, [detail, loanRules.dendaPerHari]);
+
+  const dendaQuickButtons = useMemo(
+    () => dendaQuickPresets(loanRules.dendaPerHari),
+    [loanRules.dendaPerHari],
+  );
 
   function toggle(itemId: number): void {
     const next = new Set(selected);
@@ -310,38 +307,28 @@ export function PengembalianPage() {
                           className="mt-2 flex flex-wrap gap-1.5"
                           data-testid="pengembalian-bayar-quick"
                         >
-                          {DENDA_QUICK_MULTIPLIERS.map((mult) => {
-                            const value = loanRules.dendaPerHari * mult;
+                          {dendaQuickButtons.map((preset) => {
+                            const testid =
+                              preset.kind === 'mult'
+                                ? `pengembalian-bayar-quick-${preset.mult}x`
+                                : `pengembalian-bayar-quick-fixed-${preset.value}`;
                             return (
                               <Button
-                                key={mult}
+                                key={testid}
                                 type="button"
                                 variant="outline"
                                 size="sm"
                                 className="h-7 px-2 text-xs"
-                                onClick={() => setBayar(String(value))}
-                                data-testid={`pengembalian-bayar-quick-${mult}x`}
+                                onClick={() => setBayar(String(preset.value))}
+                                data-testid={testid}
                               >
                                 {t('peminjaman:pengembalian.bayarQuick', {
                                   defaultValue: 'Rp {{value}}',
-                                  value: formatRupiah(value),
+                                  value: formatRupiah(preset.value),
                                 })}
                               </Button>
                             );
                           })}
-                          {DENDA_FIXED_PRESETS.map((value) => (
-                            <Button
-                              key={`preset-${value}`}
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              className="h-7 px-2 text-xs"
-                              onClick={() => setBayar(String(value))}
-                              data-testid={`pengembalian-bayar-preset-${value}`}
-                            >
-                              Rp {formatRupiah(value)}
-                            </Button>
-                          ))}
                         </div>
                       </div>
                       <div className="flex items-end">

--- a/apps/desktop/src/lib/dendaPresets.ts
+++ b/apps/desktop/src/lib/dendaPresets.ts
@@ -1,0 +1,54 @@
+/**
+ * Quick-pick "Bayar Denda" preset buttons shared between Pengembalian
+ * (full-return flow) and Peminjaman detail (partial inline payment).
+ *
+ * Two preset sources are merged:
+ *
+ * 1. Multipliers of the configurable `dendaPerHari` setting (e.g. with
+ *    `dendaPerHari = 1500` and multipliers `[1, 2, 3]` the buttons show
+ *    `Rp 1.500 / Rp 3.000 / Rp 4.500`).
+ * 2. Fixed-rupiah presets (`Rp 5.000 / Rp 10.000 / Rp 15.000`).
+ *
+ * Without deduplication, the common case `dendaPerHari = 5000` renders
+ * the same three values twice (BUG-Pengembalian-DendaDup). This helper
+ * collapses overlap and skips zero/negative values so callers can render
+ * the result with a single map.
+ */
+
+export const DEFAULT_DENDA_QUICK_MULTIPLIERS: readonly number[] = [1, 2, 3];
+export const DEFAULT_DENDA_FIXED_PRESETS: readonly number[] = [5000, 10000, 15000];
+
+export type DendaQuickPreset =
+  | { kind: 'mult'; mult: number; value: number }
+  | { kind: 'fixed'; value: number };
+
+/**
+ * Build the deduplicated list of denda quick-pick buttons in render order.
+ *
+ * - Multiplier buttons come first, in input order; each contributes
+ *   `dendaPerHari × multiplier` and is dropped if the value is `<= 0`
+ *   (e.g. when `dendaPerHari = 0` because denda is disabled in settings)
+ *   or already produced by an earlier multiplier.
+ * - Fixed-preset buttons come after; each is dropped if its value is
+ *   already covered by a multiplier (or another fixed preset).
+ */
+export function dendaQuickPresets(
+  dendaPerHari: number,
+  multipliers: readonly number[] = DEFAULT_DENDA_QUICK_MULTIPLIERS,
+  fixed: readonly number[] = DEFAULT_DENDA_FIXED_PRESETS,
+): DendaQuickPreset[] {
+  const seen = new Set<number>();
+  const out: DendaQuickPreset[] = [];
+  for (const mult of multipliers) {
+    const value = dendaPerHari * mult;
+    if (value <= 0 || seen.has(value)) continue;
+    seen.add(value);
+    out.push({ kind: 'mult', mult, value });
+  }
+  for (const value of fixed) {
+    if (value <= 0 || seen.has(value)) continue;
+    seen.add(value);
+    out.push({ kind: 'fixed', value });
+  }
+  return out;
+}

--- a/apps/desktop/tests/unit/dendaPresets.test.ts
+++ b/apps/desktop/tests/unit/dendaPresets.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DENDA_FIXED_PRESETS,
+  DEFAULT_DENDA_QUICK_MULTIPLIERS,
+  dendaQuickPresets,
+} from '../../src/lib/dendaPresets';
+
+describe('dendaQuickPresets', () => {
+  it('collapses overlap when multipliers fully shadow fixed presets', () => {
+    // dendaPerHari = 5000, multipliers [1,2,3] → [5000, 10000, 15000]
+    // Fixed presets [5000, 10000, 15000] are fully shadowed.
+    const buttons = dendaQuickPresets(5000);
+    expect(buttons).toHaveLength(3);
+    expect(buttons.map((b) => b.value)).toEqual([5000, 10000, 15000]);
+    expect(buttons.every((b) => b.kind === 'mult')).toBe(true);
+  });
+
+  it('renders all six unique buttons when multipliers and fixed presets do not collide', () => {
+    // dendaPerHari = 2000, multipliers [1,2,3] → [2000, 4000, 6000]
+    // Fixed [5000, 10000, 15000] all unique; expect 6 buttons.
+    const buttons = dendaQuickPresets(2000);
+    expect(buttons).toHaveLength(6);
+    expect(buttons.map((b) => b.value)).toEqual([
+      2000,
+      4000,
+      6000,
+      5000,
+      10000,
+      15000,
+    ]);
+    expect(buttons.slice(0, 3).every((b) => b.kind === 'mult')).toBe(true);
+    expect(buttons.slice(3).every((b) => b.kind === 'fixed')).toBe(true);
+  });
+
+  it('hides multiplier section entirely when dendaPerHari is 0', () => {
+    // Denda disabled in settings → only fixed presets render.
+    const buttons = dendaQuickPresets(0);
+    expect(buttons).toHaveLength(3);
+    expect(buttons.every((b) => b.kind === 'fixed')).toBe(true);
+    expect(buttons.map((b) => b.value)).toEqual([5000, 10000, 15000]);
+  });
+
+  it('handles partial overlap (some multipliers collide with fixed presets)', () => {
+    // dendaPerHari = 2500, multipliers [1,2,3] → [2500, 5000, 7500]
+    // 5000 is shared with fixed presets; expect [2500, 5000, 7500, 10000, 15000].
+    const buttons = dendaQuickPresets(2500);
+    expect(buttons.map((b) => b.value)).toEqual([2500, 5000, 7500, 10000, 15000]);
+    expect(buttons.filter((b) => b.kind === 'mult')).toHaveLength(3);
+    expect(buttons.filter((b) => b.kind === 'fixed')).toHaveLength(2);
+  });
+
+  it('drops zero/negative multiplier values without leaking fixed presets', () => {
+    // dendaPerHari = -100 (defensive). All multiplier values are negative,
+    // so they're dropped; the fixed presets fill in.
+    const buttons = dendaQuickPresets(-100);
+    expect(buttons).toHaveLength(3);
+    expect(buttons.every((b) => b.kind === 'fixed')).toBe(true);
+  });
+
+  it('respects custom multiplier and fixed-preset arguments', () => {
+    const buttons = dendaQuickPresets(1000, [1, 5, 10], [1000, 5000]);
+    expect(buttons.map((b) => b.value)).toEqual([1000, 5000, 10000]);
+    expect(buttons.map((b) => b.kind)).toEqual(['mult', 'mult', 'mult']);
+  });
+
+  it('exposes the documented default constants', () => {
+    expect(DEFAULT_DENDA_QUICK_MULTIPLIERS).toEqual([1, 2, 3]);
+    expect(DEFAULT_DENDA_FIXED_PRESETS).toEqual([5000, 10000, 15000]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **BUG-Pengembalian-DendaDup** from the v1.1.0 batch. The Detail Pengembalian card built two parallel preset arrays and rendered them in two loops:

- `DENDA_QUICK_MULTIPLIERS = [1, 2, 3]` × `dendaPerHari` — when `dendaPerHari = 5000` (the most common setting) this produces `[Rp 5.000, Rp 10.000, Rp 15.000]`.
- `DENDA_FIXED_PRESETS = [5000, 10000, 15000]` — rendered raw.

So the page showed six buttons in two rows with three visually-duplicated rupiah values, which the user flagged as "kenapa ada 2x data sama".

Changes:

- New shared helper at `apps/desktop/src/lib/dendaPresets.ts` that returns a deduplicated `Array<{ kind: 'mult' | 'fixed'; value: number }>`. Multiplier values come first, in input order; fixed presets are appended only if the value is not already covered. Zero/negative values are dropped (so `dendaPerHari = 0` hides the multiplier section entirely). The helper is intentionally generic so **FEAT-Peminjaman-DendaInline** (next item in the batch) can render the same UI from one source.
- `PengembalianPage` calls the helper from `useMemo` and renders one mapped list. Visual layout (`flex flex-wrap gap-1.5` inside `data-testid="pengembalian-bayar-quick"`) is unchanged.
- Fixed-preset `data-testid` renamed from `pengembalian-bayar-preset-{value}` to `pengembalian-bayar-quick-fixed-{value}` to match the multiplier-button namespace per BUGS.md spec. Grep confirmed no test or component referenced the old testid outside the page itself.
- Unit tests added at `apps/desktop/tests/unit/dendaPresets.test.ts` cover the spec's three required cases (5000 / 2000 / 0) plus partial overlap (2500), defensive negative input, and custom multiplier/fixed arguments.

Local gates all green:

```
pnpm typecheck   ✓
pnpm lint        ✓ (--max-warnings=0)
pnpm i18n:lint   ✓ (id ↔ en parity)
pnpm test        ✓ 55 files / 512 tests (incl. 7 new dendaPresets tests)
pnpm build       ✓
```

## Review & Testing Checklist for Human

This is a small, self-contained refactor (one helper + one render path + new tests). Risk is yellow because the testid rename touches a UI selector even though no test currently uses it.

- [ ] Open the Pengembalian page with default settings (`dendaPerHari = 5000`) and confirm only **3** quick buttons render (`Rp 5.000 / 10.000 / 15.000`), no duplicates.
- [ ] In Pengaturan → Aturan Peminjaman, change `dendaPerHari` to `2000`, return to Pengembalian, and confirm exactly **6** unique buttons render: `Rp 2.000 / 4.000 / 6.000 / 5.000 / 10.000 / 15.000`.
- [ ] Set `dendaPerHari = 0` and confirm the multiplier section disappears entirely; only the **3** fixed presets (`Rp 5.000 / 10.000 / 15.000`) remain.
- [ ] Click any quick button and confirm the Bayar Denda input populates with the right rupiah value and Kembalikan still submits successfully.

### Notes

- The helper is exported with the default constants (`DEFAULT_DENDA_QUICK_MULTIPLIERS`, `DEFAULT_DENDA_FIXED_PRESETS`) so callers can override for tests or future variants without re-declaring the magic numbers.
- This is a draft PR per the v1.1.0 continuous-automation protocol — flipping to ready-for-review once the alviarts CI suite reports green.
- Sister item **FEAT-Peminjaman-DendaInline** will import this helper and render the same row inside `PeminjamanDetail`'s "Daftar Buku" panel.
