### PR TITLE
feat(dashboard): clickable KPI + InsightCards (FEAT-Dashboard-Clickable-KPI)

### DIFF
--- a/apps/desktop/src/components/shared/KpiCard.tsx
+++ b/apps/desktop/src/components/shared/KpiCard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from '@tanstack/react-router';
 import { ArrowDown, ArrowUp, Minus } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
@@ -17,6 +18,14 @@ export interface KpiCardProps {
    * Total Buku card). Hidden while `loading=true`.
    */
   subline?: string;
+  /**
+   * Optional TanStack Router target. When provided AND `loading` is false,
+   * the entire card becomes a clickable link (FEAT-Dashboard-Clickable-KPI).
+   * The card retains its visual chrome and gains a hover ring + pointer
+   * cursor so it reads as interactive. While `loading` is true the link
+   * is suppressed so the skeleton state never navigates.
+   */
+  href?: string;
 }
 
 const TONE: Record<NonNullable<KpiCardProps['tone']>, string> = {
@@ -40,6 +49,7 @@ export function KpiCard({
   loading = false,
   hint,
   subline,
+  href,
 }: KpiCardProps): React.ReactElement {
   const showDelta = typeof delta === 'number' && Number.isFinite(delta);
   const trendUp = showDelta && delta > 0.5;
@@ -51,8 +61,18 @@ export function KpiCard({
       ? 'text-rose-600 dark:text-rose-400'
       : 'text-muted-foreground';
 
-  return (
-    <Card className="flex flex-col gap-3 p-4" data-testid="kpi-card">
+  const interactive = typeof href === 'string' && !loading;
+  const cardClassName = cn(
+    'flex flex-col gap-3 p-4',
+    interactive &&
+      'cursor-pointer transition-shadow hover:ring-1 hover:ring-primary/40 focus-visible:ring-2 focus-visible:ring-primary',
+  );
+  const inner = (
+    <Card
+      className={cardClassName}
+      data-testid="kpi-card"
+      data-interactive={interactive ? 'true' : undefined}
+    >
       <div className="flex items-start justify-between">
         <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
           {label}
@@ -91,4 +111,18 @@ export function KpiCard({
       </div>
     </Card>
   );
+
+  if (interactive) {
+    return (
+      <Link
+        to={href}
+        aria-label={label}
+        className="block rounded-xl no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        data-testid="kpi-card-link"
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
 }

--- a/apps/desktop/src/features/dashboard/DashboardPage.tsx
+++ b/apps/desktop/src/features/dashboard/DashboardPage.tsx
@@ -298,6 +298,7 @@ export function DashboardPage() {
               Icon={Users}
               tone="primary"
               loading={loading}
+              href="/anggota"
             />
             <KpiCard
               label={t('dashboard:kpi.buku', { defaultValue: 'Total Buku' })}
@@ -315,6 +316,7 @@ export function DashboardPage() {
               Icon={BookOpen}
               tone="emerald"
               loading={loading}
+              href="/buku"
             />
             <KpiCard
               label={t('dashboard:kpi.dipinjam', { defaultValue: 'Buku Dipinjam' })}
@@ -323,6 +325,7 @@ export function DashboardPage() {
               Icon={ArrowLeftRight}
               tone="amber"
               loading={loading}
+              href="/peminjaman"
             />
           </section>
 
@@ -349,6 +352,11 @@ export function DashboardPage() {
                     })
                   : t('dashboard:insights.empty', { defaultValue: 'Belum ada data' })
               }
+              href={
+                data?.insights.topBukuThisMonth
+                  ? `/buku/${data.insights.topBukuThisMonth.bukuId}`
+                  : undefined
+              }
             />
             <InsightCard
               loading={loading}
@@ -366,6 +374,11 @@ export function DashboardPage() {
                         : ''
                     }`
                   : t('dashboard:insights.empty', { defaultValue: 'Belum ada data' })
+              }
+              href={
+                data?.insights.topPeminjamThisMonth
+                  ? `/anggota/${data.insights.topPeminjamThisMonth.anggotaId}`
+                  : undefined
               }
             />
             <InsightCard
@@ -641,17 +654,40 @@ interface InsightCardProps {
   label: string;
   primary: string;
   secondary?: string;
+  /**
+   * Optional TanStack Router target. When provided AND `loading` is false,
+   * the card becomes clickable (FEAT-Dashboard-Clickable-KPI). The skeleton
+   * state is intentionally non-navigable so callers can pass a derived href
+   * such as `/buku/${data?.insights.topBukuThisMonth?.id}` without guarding.
+   */
+  href?: string;
 }
 
-function InsightCard({ loading, Icon, tone, label, primary, secondary }: InsightCardProps) {
+function InsightCard({
+  loading,
+  Icon,
+  tone,
+  label,
+  primary,
+  secondary,
+  href,
+}: InsightCardProps) {
   const toneClass =
     tone === 'amber'
       ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
       : tone === 'emerald'
         ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300'
         : 'bg-primary/10 text-primary';
-  return (
-    <Card data-testid="insight-card">
+  const interactive = typeof href === 'string' && !loading;
+  const inner = (
+    <Card
+      data-testid="insight-card"
+      data-interactive={interactive ? 'true' : undefined}
+      className={cn(
+        interactive &&
+          'cursor-pointer transition-shadow hover:ring-1 hover:ring-primary/40 focus-visible:ring-2 focus-visible:ring-primary',
+      )}
+    >
       <CardContent className="flex items-start gap-3 p-4">
         <div className={cn('rounded-md p-2', toneClass)}>
           <Icon className="h-5 w-5" />
@@ -672,6 +708,19 @@ function InsightCard({ loading, Icon, tone, label, primary, secondary }: Insight
       </CardContent>
     </Card>
   );
+  if (interactive) {
+    return (
+      <Link
+        to={href}
+        aria-label={label}
+        className="block rounded-xl no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        data-testid="insight-card-link"
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
 }
 
 interface FeaturedRowProps {

--- a/apps/desktop/tests/unit/kpiCard.test.tsx
+++ b/apps/desktop/tests/unit/kpiCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Users } from 'lucide-react';
+
+vi.mock('@tanstack/react-router', () => ({
+  // KpiCard / InsightCard render `<Link to={href}>...</Link>`; in tests we
+  // don't have a router context so swap the Link for a plain anchor that
+  // still exposes `href` and `aria-label` to the rendered DOM.
+  Link: ({
+    to,
+    children,
+    className,
+    'aria-label': ariaLabel,
+    'data-testid': testId,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    className?: string;
+    'aria-label'?: string;
+    'data-testid'?: string;
+  }) => (
+    <a href={to} className={className} aria-label={ariaLabel} data-testid={testId}>
+      {children}
+    </a>
+  ),
+}));
+
+import { KpiCard } from '@/components/shared/KpiCard';
+
+describe('KpiCard with href (FEAT-Dashboard-Clickable-KPI)', () => {
+  it('wraps the card in a navigable Link when href is provided and not loading', () => {
+    render(<KpiCard label="Total Anggota" value={42} Icon={Users} href="/anggota" />);
+    const link = screen.getByTestId('kpi-card-link');
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/anggota');
+    expect(link).toHaveAttribute('aria-label', 'Total Anggota');
+    // Card should still render inside the link with the interactive flag set.
+    const card = screen.getByTestId('kpi-card');
+    expect(card).toHaveAttribute('data-interactive', 'true');
+  });
+
+  it('does NOT render the link wrapper while loading=true (skeleton stays inert)', () => {
+    render(
+      <KpiCard label="Total Buku" value="—" Icon={Users} loading href="/buku" />,
+    );
+    expect(screen.queryByTestId('kpi-card-link')).not.toBeInTheDocument();
+    const card = screen.getByTestId('kpi-card');
+    expect(card).not.toHaveAttribute('data-interactive');
+  });
+
+  it('does NOT render the link wrapper when href is omitted', () => {
+    render(<KpiCard label="Rata-rata" value="3.4" Icon={Users} />);
+    expect(screen.queryByTestId('kpi-card-link')).not.toBeInTheDocument();
+    const card = screen.getByTestId('kpi-card');
+    expect(card).not.toHaveAttribute('data-interactive');
+  });
+
+  it('uses the label as the aria-label so the link is accessible', () => {
+    render(
+      <KpiCard label="Buku Dipinjam" value={7} Icon={Users} href="/peminjaman" />,
+    );
+    const link = screen.getByLabelText('Buku Dipinjam');
+    expect(link).toHaveAttribute('href', '/peminjaman');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **FEAT-Dashboard-Clickable-KPI** from the v1.1.0 batch.

Dashboard cards now navigate to relevant pages on click. The user wants the dashboard to feel like a launchpad: tap a metric, land on the page that owns it.

Wired routes:
- **Total Anggota** → `/anggota`
- **Total Buku** → `/buku`
- **Buku Dipinjam** → `/peminjaman`
- **Buku terlaris bulan ini** → `/buku/{topBukuThisMonth.bukuId}`
- **Peminjam teraktif** → `/anggota/{topPeminjamThisMonth.anggotaId}`

The two static metrics (`Rata-rata pinjam / anggota` and `Rata-rata durasi pinjam`) intentionally retain their non-clickable presentation because there's no obvious deep-link target.

## Implementation

- `KpiCard` accepts an optional `href`. When provided AND `loading=false`, the card is wrapped in `<Link to={href} aria-label={label}>`; the card itself gains a `cursor-pointer` + hover-ring affordance and a `data-interactive="true"` hook for tests / styling. Loading-state skeletons are intentionally non-navigable so the placeholder is never a click target.
- The inline `InsightCard` in `DashboardPage` gets the same `href` prop with the same loading-guard. Insights with null upstream data (e.g. `topBukuThisMonth = null` on a brand-new install) pass `href` undefined and fall back to the read-only card.
- Both wrappers use TanStack Router's `Link` so navigation participates in the SPA history stack and middle-click / cmd-click / right-click → open-in-new-window all work.

### Note on the spec's `?status=aktif` suggestion

The original spec line 188 suggests `Buku Dipinjam → /peminjaman?status=aktif`. The current `/peminjaman` route does not validate search params and `PeminjamanList` keeps its filter in local state defaulting to `'all'`. Wiring URL-driven status filtering would require adding `validateSearch` to the route + reading `useSearch()` in the list component — a worthwhile polish but outside the scope of "clickable cards". This PR links to plain `/peminjaman` and tracks the URL-filter wiring as a separate follow-up.

## Test coverage

- New `apps/desktop/tests/unit/kpiCard.test.tsx` mocks the TanStack `Link` to a plain anchor (the unit test runs outside `RouterProvider`) and asserts:
  - link wraps the card when `href` + `!loading`
  - link is suppressed during `loading`
  - `href` omission renders the original static card
  - `aria-label = label` so screen readers announce the navigation target

## Local gates

```
pnpm typecheck   ✓
pnpm lint        ✓ (--max-warnings=0)
pnpm i18n:lint   ✓
pnpm test        ✓ 57 files / 523 tests (+4 new for KpiCard)
pnpm build       ✓
```

## Review & Testing Checklist for Human

- [ ] Open Dashboard. Hover over each of the three KPI cards (Total Anggota / Total Buku / Buku Dipinjam). Confirm cursor changes to pointer + hover ring appears.
- [ ] Click "Total Anggota" → lands on `/anggota`.
- [ ] Click "Total Buku" → lands on `/buku`.
- [ ] Click "Buku Dipinjam" → lands on `/peminjaman`.
- [ ] On a fresh install (no loans this month), confirm "Buku terlaris bulan ini" and "Peminjam teraktif" cards render normally without the hover/pointer affordance (they have null deep-link targets).
- [ ] On a populated install, click "Buku terlaris bulan ini" → lands on `/buku/{id}` of the top buku. Click "Peminjam teraktif" → lands on `/anggota/{id}` of the top peminjam.
- [ ] Confirm "Rata-rata pinjam / anggota" and "Rata-rata durasi pinjam" remain visually static (no pointer cursor, no link).
- [ ] Reload the dashboard while on a slow connection. While the skeleton is shown, the cards must NOT be clickable / wrapped in a link.
- [ ] Tab through the dashboard with the keyboard. Each clickable card receives focus with a visible ring; pressing Enter activates the link.

This is a draft PR per the v1.1.0 continuous-automation protocol — flipping to ready-for-review once CI is green, then squash-merging via the alviarts PAT.
