### PR TITLE
feat(dashboard): 2-min quote rotation + manual next button (FEAT-Dashboard-Quotes-2min)

### DIFF
--- a/apps/desktop/src/features/dashboard/DashboardPage.tsx
+++ b/apps/desktop/src/features/dashboard/DashboardPage.tsx
@@ -9,6 +9,7 @@ import {
   UserPlus,
   Sparkles,
   Quote,
+  ChevronRight,
   TrendingUp,
   Trophy,
   Timer,
@@ -24,7 +25,8 @@ import { ChartLine } from '@/components/shared/ChartLine';
 import { Heatmap } from '@/components/shared/Heatmap';
 import { LiveClock } from '@/components/shared/LiveClock';
 import { OverduePanel } from '@/features/dashboard/OverduePanel';
-import { getQuoteByIndex, pickNextQuoteIndex, quoteIndexForDate } from '@/lib/dailyQuote';
+import { getQuoteByIndex } from '@/lib/dailyQuote';
+import { useQuoteRotation } from '@/features/dashboard/useQuoteRotation';
 import { formatTauriError } from '@/lib/errors';
 import { cn } from '@/lib/utils';
 import {
@@ -57,19 +59,6 @@ interface DashboardData {
   heatmap: HeatCell[];
   insights: DashboardInsights;
 }
-
-/**
- * How long the dashboard quote-of-the-day stays on screen before rotating
- * to a new pick (FEAT-11). 5 minutes is short enough to feel alive but long
- * enough that users reading the screen aren't distracted.
- */
-const QUOTE_ROTATE_MS = 5 * 60 * 1000;
-
-/**
- * Duration of the leave (fade-out + slide-up) phase. Matches the duration
- * of the corresponding `slide-up` keyframe so leave/enter feel symmetric.
- */
-const QUOTE_LEAVE_MS = 300;
 
 export function DashboardPage() {
   const { t } = useTranslation(['dashboard', 'common']);
@@ -144,32 +133,12 @@ export function DashboardPage() {
     data.kpi.totalBuku === 0 &&
     data.kpi.bukuDipinjam === 0;
 
-  // Quote-of-the-day rotation (FEAT-11). Initial index is deterministic per
-  // calendar day (matches the pre-rotation behavior so reload-day-1 always
-  // shows the same first quote). Every QUOTE_ROTATE_MS we trigger a leave
-  // animation, swap the index, then mount the new quote with the
-  // `slide-up` keyframe via `key={quoteIndex}`.
-  const [quoteIndex, setQuoteIndex] = useState(() => quoteIndexForDate(new Date()));
-  const [quoteLeaving, setQuoteLeaving] = useState(false);
-
-  useEffect(() => {
-    let leaveTimer: ReturnType<typeof setTimeout> | null = null;
-    const rotateTimer = setInterval(() => {
-      setQuoteLeaving(true);
-      leaveTimer = setTimeout(() => {
-        // setState updater form is required: the interval closure captures
-        // the original quoteIndex but we want to rotate from whichever
-        // index is current right now.
-        setQuoteIndex((prev) => pickNextQuoteIndex(prev));
-        setQuoteLeaving(false);
-      }, QUOTE_LEAVE_MS);
-    }, QUOTE_ROTATE_MS);
-    return () => {
-      clearInterval(rotateTimer);
-      if (leaveTimer !== null) clearTimeout(leaveTimer);
-    };
-  }, []);
-
+  // Quote-of-the-day rotation (FEAT-Dashboard-Quotes-2min). Initial index
+  // is deterministic per calendar day so reload-day-1 always shows the
+  // same first quote. The hook auto-advances every QUOTE_ROTATE_MS via a
+  // slide-up leave animation, and exposes `advance` so the manual
+  // "next" button runs through the same animation phases.
+  const { quoteIndex, quoteLeaving, advance: advanceQuote } = useQuoteRotation();
   const dailyQuote = getQuoteByIndex(quoteIndex);
 
   // Trend datapoints rendered into the line chart. Daily windows show "DD/MM"
@@ -262,7 +231,7 @@ export function DashboardPage() {
           <div
             key={quoteIndex}
             className={cn(
-              'flex flex-col gap-1',
+              'flex min-w-0 flex-1 flex-col gap-1',
               quoteLeaving
                 ? '-translate-y-2 opacity-0 transition-all duration-300 ease-out'
                 : 'motion-safe:animate-slide-up',
@@ -275,6 +244,17 @@ export function DashboardPage() {
             </p>
             <p className="text-xs text-muted-foreground">— {dailyQuote.author}</p>
           </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="ml-auto h-7 w-7 flex-shrink-0"
+            onClick={advanceQuote}
+            data-testid="daily-quote-next"
+            aria-label={t('dashboard:quote.next', { defaultValue: 'Quote selanjutnya' })}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
         </CardContent>
       </Card>
 

--- a/apps/desktop/src/features/dashboard/useQuoteRotation.ts
+++ b/apps/desktop/src/features/dashboard/useQuoteRotation.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { pickNextQuoteIndex, quoteIndexForDate } from '@/lib/dailyQuote';
+
+/**
+ * How long the dashboard quote-of-the-day stays on screen before rotating
+ * to a new pick (FEAT-Dashboard-Quotes-2min). 2 minutes is short enough
+ * that operators see new quotes during a single counter session, but long
+ * enough that the screen does not feel restless.
+ *
+ * Lowered from the original 5 minutes per user feedback ("interval 2 menit
+ * langsung slide up atau animasi lain").
+ */
+export const QUOTE_ROTATE_MS = 2 * 60 * 1000;
+
+/**
+ * Duration of the slide-up + fade-out exit animation before the new quote
+ * mounts. Must stay in sync with the Tailwind transition classes on the
+ * leaving element (`transition-all duration-300`).
+ */
+export const QUOTE_LEAVE_MS = 300;
+
+export interface QuoteRotationState {
+  /** Current quote index into the QUOTES array. */
+  quoteIndex: number;
+  /** Whether the current quote is in its leave-animation phase. */
+  quoteLeaving: boolean;
+  /**
+   * Manually advance to the next quote with the same animation flow used
+   * by the auto-rotate timer. Re-entrant calls during the leave phase are
+   * ignored so the animation never glitches.
+   */
+  advance: () => void;
+}
+
+/**
+ * Self-contained quote rotation state for the dashboard "Daily Quote"
+ * card. Owns:
+ *
+ * - the deterministic per-day initial index (so the first quote of a
+ *   given calendar day is the same across reloads / timezones),
+ * - a `setInterval` that advances the quote every `QUOTE_ROTATE_MS`,
+ * - a `setTimeout` chain that flips `quoteLeaving=true`, swaps the
+ *   index after `QUOTE_LEAVE_MS`, then clears the leave flag so the
+ *   new mount plays the slide-up enter animation.
+ *
+ * The returned `advance` lets the UI expose a "next quote" button that
+ * runs through the same animation phases as the auto-timer.
+ */
+export function useQuoteRotation(now: Date = new Date()): QuoteRotationState {
+  const [quoteIndex, setQuoteIndex] = useState(() => quoteIndexForDate(now));
+  const [quoteLeaving, setQuoteLeaving] = useState(false);
+  const leaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const advance = useCallback((): void => {
+    // Re-entrant guard: while the leave animation is mid-flight, ignore
+    // additional triggers so a fast double-click on the manual next
+    // button (or a timer firing during a click) cannot stack timeouts.
+    if (leaveTimerRef.current !== null) return;
+    setQuoteLeaving(true);
+    leaveTimerRef.current = setTimeout(() => {
+      setQuoteIndex((prev) => pickNextQuoteIndex(prev));
+      setQuoteLeaving(false);
+      leaveTimerRef.current = null;
+    }, QUOTE_LEAVE_MS);
+  }, []);
+
+  useEffect(() => {
+    const rotateTimer = setInterval(advance, QUOTE_ROTATE_MS);
+    return () => {
+      clearInterval(rotateTimer);
+      if (leaveTimerRef.current !== null) {
+        clearTimeout(leaveTimerRef.current);
+        leaveTimerRef.current = null;
+      }
+    };
+  }, [advance]);
+
+  return { quoteIndex, quoteLeaving, advance };
+}

--- a/apps/desktop/src/i18n/en/dashboard.json
+++ b/apps/desktop/src/i18n/en/dashboard.json
@@ -66,6 +66,9 @@
     "subtitle": "Loans per hour (last 6 weeks)",
     "tooltip": "{{day}} · {{hour}}:00 — {{count}} loans"
   },
+  "quote": {
+    "next": "Next quote"
+  },
   "insights": {
     "topBuku": "Top book this month",
     "topBukuSubline": "{{count}}× borrowed",

--- a/apps/desktop/src/i18n/id/dashboard.json
+++ b/apps/desktop/src/i18n/id/dashboard.json
@@ -66,6 +66,9 @@
     "subtitle": "Aktivitas pinjam per jam (6 minggu terakhir)",
     "tooltip": "{{day}} · {{hour}}:00 — {{count}} pinjam"
   },
+  "quote": {
+    "next": "Quote selanjutnya"
+  },
   "insights": {
     "topBuku": "Buku terlaris bulan ini",
     "topBukuSubline": "{{count}}× dipinjam",

--- a/apps/desktop/tests/unit/useQuoteRotation.test.tsx
+++ b/apps/desktop/tests/unit/useQuoteRotation.test.tsx
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  QUOTE_LEAVE_MS,
+  QUOTE_ROTATE_MS,
+  useQuoteRotation,
+} from '@/features/dashboard/useQuoteRotation';
+import { quoteIndexForDate } from '@/lib/dailyQuote';
+
+describe('useQuoteRotation (FEAT-Dashboard-Quotes-2min)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('exposes the 2-minute rotation interval and 300 ms leave duration', () => {
+    expect(QUOTE_ROTATE_MS).toBe(2 * 60 * 1000);
+    expect(QUOTE_LEAVE_MS).toBe(300);
+  });
+
+  it('initializes with the deterministic per-day index', () => {
+    const fixedDate = new Date(2026, 4, 6); // arbitrary fixed day
+    const { result } = renderHook(() => useQuoteRotation(fixedDate));
+    expect(result.current.quoteIndex).toBe(quoteIndexForDate(fixedDate));
+    expect(result.current.quoteLeaving).toBe(false);
+  });
+
+  it('auto-advances after QUOTE_ROTATE_MS via the leave-then-swap animation', () => {
+    const fixedDate = new Date(2026, 4, 6);
+    const { result } = renderHook(() => useQuoteRotation(fixedDate));
+    const initialIndex = result.current.quoteIndex;
+
+    // Just before the rotate timer fires the quote is still showing.
+    act(() => {
+      vi.advanceTimersByTime(QUOTE_ROTATE_MS - 1);
+    });
+    expect(result.current.quoteIndex).toBe(initialIndex);
+    expect(result.current.quoteLeaving).toBe(false);
+
+    // Rotate timer fires → leave phase begins, index unchanged yet.
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.quoteLeaving).toBe(true);
+    expect(result.current.quoteIndex).toBe(initialIndex);
+
+    // After the leave-duration the index swaps and leaving flag resets.
+    act(() => {
+      vi.advanceTimersByTime(QUOTE_LEAVE_MS);
+    });
+    expect(result.current.quoteLeaving).toBe(false);
+    expect(result.current.quoteIndex).not.toBe(initialIndex);
+  });
+
+  it('manual advance() runs the same leave-then-swap animation', () => {
+    const fixedDate = new Date(2026, 4, 6);
+    const { result } = renderHook(() => useQuoteRotation(fixedDate));
+    const initialIndex = result.current.quoteIndex;
+
+    act(() => {
+      result.current.advance();
+    });
+    expect(result.current.quoteLeaving).toBe(true);
+    expect(result.current.quoteIndex).toBe(initialIndex);
+
+    act(() => {
+      vi.advanceTimersByTime(QUOTE_LEAVE_MS);
+    });
+    expect(result.current.quoteLeaving).toBe(false);
+    expect(result.current.quoteIndex).not.toBe(initialIndex);
+  });
+
+  it('ignores re-entrant advance() calls during an in-flight leave animation', () => {
+    const fixedDate = new Date(2026, 4, 6);
+    const { result } = renderHook(() => useQuoteRotation(fixedDate));
+
+    act(() => {
+      result.current.advance();
+      // Second click within the leave window must NOT stack timeouts —
+      // otherwise the index would jump twice for a single user gesture.
+      result.current.advance();
+      result.current.advance();
+    });
+    expect(result.current.quoteLeaving).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(QUOTE_LEAVE_MS);
+    });
+    expect(result.current.quoteLeaving).toBe(false);
+    // Only one swap happened.
+    const afterFirst = result.current.quoteIndex;
+
+    // No further timers pending → advancing the clock does not change state.
+    act(() => {
+      vi.advanceTimersByTime(QUOTE_LEAVE_MS);
+    });
+    expect(result.current.quoteIndex).toBe(afterFirst);
+    expect(result.current.quoteLeaving).toBe(false);
+  });
+
+  it('clears pending timers on unmount so no leaks survive route changes', () => {
+    const fixedDate = new Date(2026, 4, 6);
+    const { result, unmount } = renderHook(() => useQuoteRotation(fixedDate));
+    act(() => {
+      result.current.advance();
+    });
+    expect(result.current.quoteLeaving).toBe(true);
+    unmount();
+    // Vitest will report unhandled timers on test teardown if cleanup
+    // missed them; advancing the clock should be a no-op.
+    expect(() => {
+      vi.advanceTimersByTime(QUOTE_LEAVE_MS + QUOTE_ROTATE_MS);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **FEAT-Dashboard-Quotes-2min** from the v1.1.0 batch.

Quote-of-the-day on the dashboard now rotates every **2 minutes** (down from 5) and gains a manual `ChevronRight` next-button so the operator doesn't have to wait for the timer.

User feedback: *"quotes ini interval 2 menit langsung slide up atau animasi lain"*.

## Implementation

- Extracted the rotation state machine into a dedicated `useQuoteRotation` hook at `apps/desktop/src/features/dashboard/useQuoteRotation.ts`. The hook owns the deterministic per-day initial index, the rotate `setInterval`, the leave-timeout chain, and a re-entrant-safe `advance()` function. `QUOTE_ROTATE_MS` and `QUOTE_LEAVE_MS` are exported from the hook module so tests assert their values without reaching into `DashboardPage`.
- `DashboardPage` now consumes the hook in a single line and renders a small ghost icon-button next to the quote text. The button calls `advance()` which triggers the same leave-then-swap animation the timer uses, so manual + auto rotations look identical.
- Added i18n key `dashboard:quote.next` (id + en).

## Bug-resistance

- The leave-phase ref guard means a fast double-click on the next button cannot stack timeouts — only one swap fires per gesture.
- Cleanup clears both the interval and the in-flight leave timeout on unmount so navigating away mid-animation does not leak timers.

## Test coverage

`apps/desktop/tests/unit/useQuoteRotation.test.tsx` (6 tests):
- `QUOTE_ROTATE_MS === 2 min`, `QUOTE_LEAVE_MS === 300 ms` (regression guard so a future copy-paste cannot silently widen the interval).
- Initial index matches `quoteIndexForDate` for a fixed seed date.
- Auto-rotation: just before `QUOTE_ROTATE_MS` no change, at the tick the leaving flag flips, after `QUOTE_LEAVE_MS` the index swaps.
- Manual `advance()` runs the same leave-then-swap phases.
- Re-entrant `advance()` within the leave window is a no-op (single swap per gesture).
- Cleanup on unmount: `clearInterval` + `clearTimeout` both fire so advancing fake timers post-unmount does not throw.

## Local gates

```
pnpm typecheck   ✓
pnpm lint        ✓ (--max-warnings=0)
pnpm i18n:lint   ✓
pnpm test        ✓ 58 files / 529 tests (+6 new)
pnpm build       ✓
```

## Review & Testing Checklist for Human

- [ ] Open Dashboard. Note the current quote.
- [ ] Wait 2 minutes (or temporarily lower `QUOTE_ROTATE_MS` for the demo). The quote should fade up and out, then a new one fades in from below.
- [ ] Click the right-arrow button next to the quote. Confirm the same fade-up animation runs and a new quote appears.
- [ ] Click the button rapidly 3-4 times in a row. Confirm only one swap happens per gesture (no flicker / double swap).
- [ ] Refresh the dashboard on day X. Note the first quote. Refresh again on the same day — same first quote (deterministic per-day initial).
- [ ] Tab to the next-button with the keyboard. Press Enter. Same animation runs.
- [ ] Set OS-level "reduce motion" on. Click the next-button. Quote swaps without the slide animation (instant).

This is a draft PR per the v1.1.0 continuous-automation protocol — flipping to ready-for-review once CI is green, then squash-merging via the alviarts PAT.
