### PR TITLE
feat(opac): post-scan member profile + auto kunjungan + reservasi (FEAT-OPAC-PostScanProfile)

### DIFF
--- a/apps/desktop/src/features/opac/OpacApp.tsx
+++ b/apps/desktop/src/features/opac/OpacApp.tsx
@@ -4,13 +4,18 @@ import { OpacHomePage } from './OpacHomePage';
 import { OpacSearchPage } from './OpacSearchPage';
 import { OpacAdminUnlockButton } from './OpacAdminUnlockButton';
 import { OpacKtaScanFlow } from './OpacKtaScanFlow';
+import { OpacMemberProfile } from './OpacMemberProfile';
 import { useOpacIdleReset } from './useOpacIdleReset';
 import { settingsApi } from '@/lib/settings';
 import { loginRequest, isTauri } from '@/lib/auth';
 import { useToast } from '@/components/ui/toast-manager';
+import { kunjunganApi } from '@/lib/kunjungan';
+import { reservasiApi } from '@/lib/reservasi';
+import { formatTauriError } from '@/lib/errors';
 import type { Anggota } from '@/lib/anggota';
+import type { Buku } from '@/lib/buku';
 
-type View = { kind: 'home' } | { kind: 'search'; query: string };
+type View = { kind: 'home' } | { kind: 'profile' } | { kind: 'search'; query: string };
 
 export interface OpacAppProps {
   /** Optional override for testing or for callers that need to inject a custom verifier. */
@@ -37,6 +42,44 @@ const defaultUnlockSuccess = async (): Promise<void> => {
   }
 };
 
+const KUNJUNGAN_THROTTLE_MS = 5 * 60 * 1000;
+const KUNJUNGAN_THROTTLE_KEY = 'po:opac-kunjungan-last';
+
+interface KunjunganThrottleEntry {
+  anggotaId: number;
+  ts: number;
+}
+
+function readLastKunjungan(anggotaId: number): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(KUNJUNGAN_THROTTLE_KEY);
+    if (!raw) return null;
+    const list = JSON.parse(raw) as KunjunganThrottleEntry[];
+    if (!Array.isArray(list)) return null;
+    const hit = list.find((e) => e?.anggotaId === anggotaId);
+    return hit?.ts ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastKunjungan(anggotaId: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(KUNJUNGAN_THROTTLE_KEY);
+    const list: KunjunganThrottleEntry[] = raw ? (JSON.parse(raw) as KunjunganThrottleEntry[]) : [];
+    const cutoff = Date.now() - KUNJUNGAN_THROTTLE_MS * 12; // 1h history is plenty
+    const fresh = (Array.isArray(list) ? list : []).filter(
+      (e) => e?.anggotaId !== anggotaId && typeof e?.ts === 'number' && e.ts >= cutoff,
+    );
+    fresh.push({ anggotaId, ts: Date.now() });
+    window.localStorage.setItem(KUNJUNGAN_THROTTLE_KEY, JSON.stringify(fresh));
+  } catch {
+    // localStorage may be unavailable — silently ignore
+  }
+}
+
 export function OpacApp({
   verifyAdmin = defaultVerifyAdmin,
   onUnlockSuccess = defaultUnlockSuccess,
@@ -48,7 +91,9 @@ export function OpacApp({
   const [scanOpen, setScanOpen] = useState(false);
   const [member, setMember] = useState<Anggota | null>(null);
 
-  const goHome = useCallback(() => setView({ kind: 'home' }), []);
+  const goHome = useCallback(() => {
+    setView(member ? { kind: 'profile' } : { kind: 'home' });
+  }, [member]);
 
   useOpacIdleReset(() => {
     setScanOpen(false);
@@ -92,41 +137,112 @@ export function OpacApp({
     return () => window.removeEventListener('keydown', handler, true);
   }, []);
 
+  const handleMemberAuthenticated = useCallback(
+    (m: Anggota): void => {
+      setMember(m);
+      setView({ kind: 'profile' });
+      // Sub-feature B — auto absen kehadiran. Throttle so a member who
+      // re-scans within 5 minutes does not produce duplicate kunjungan
+      // rows; show a "welcome back" toast instead.
+      const last = readLastKunjungan(m.id);
+      const now = Date.now();
+      if (last !== null && now - last < KUNJUNGAN_THROTTLE_MS) {
+        showToast({
+          title: t('session.welcomeBack', { nama: m.nama }),
+        });
+        return;
+      }
+      writeLastKunjungan(m.id);
+      void (async (): Promise<void> => {
+        try {
+          await kunjunganApi.create({ anggotaId: m.id, sumber: 'manual' });
+          showToast({
+            title: t('session.kehadiranTercatat'),
+            description: m.nama,
+          });
+        } catch (err) {
+          // Non-fatal: still let the member browse, just surface the
+          // error so the operator can investigate.
+          showToast({
+            variant: 'destructive',
+            title: t('session.kehadiranFail'),
+            description: formatTauriError(err),
+          });
+        }
+      })();
+    },
+    [showToast, t],
+  );
+
+  const handleLogout = useCallback((): void => {
+    setMember(null);
+    setView({ kind: 'home' });
+  }, []);
+
+  const handleReserveBook = useCallback(
+    async (buku: Buku): Promise<void> => {
+      if (!member) {
+        showToast({
+          variant: 'destructive',
+          title: t('reservasi.loginFirst'),
+        });
+        return;
+      }
+      try {
+        const created = await reservasiApi.create({
+          anggotaId: member.id,
+          bukuId: buku.id,
+        });
+        showToast({
+          title: t('reservasi.created'),
+          description: t('reservasi.queueDescription', {
+            judul: buku.judul,
+            urutan: created.urutan,
+          }),
+        });
+      } catch (err) {
+        showToast({
+          variant: 'destructive',
+          title: t('reservasi.createFail'),
+          description: formatTauriError(err),
+        });
+      }
+    },
+    [member, showToast, t],
+  );
+
   return (
     <div className="relative h-full w-full bg-background" data-testid="opac-app">
-      {member && (
-        <div
-          className="border-b bg-primary/10 px-6 py-2 text-sm"
-          role="status"
-          data-testid="opac-member-banner"
-        >
-          <div className="mx-auto flex max-w-5xl items-center justify-between gap-2">
-            <span className="font-medium">
-              {t('session.welcome', { nama: member.nama })}
-            </span>
-            <button
-              type="button"
-              onClick={() => setMember(null)}
-              className="text-xs text-muted-foreground underline-offset-2 hover:underline"
-            >
-              {t('session.logout')}
-            </button>
-          </div>
-        </div>
-      )}
-      {view.kind === 'home' ? (
+      {view.kind === 'profile' && member ? (
+        <OpacMemberProfile
+          member={member}
+          onLogout={handleLogout}
+          onSearchBooks={() => setView({ kind: 'search', query: '' })}
+        />
+      ) : view.kind === 'search' ? (
+        <OpacSearchPage
+          initialQuery={view.query}
+          onBack={goHome}
+          member={member}
+          onReserve={(b) => {
+            void handleReserveBook(b);
+          }}
+        />
+      ) : (
         <OpacHomePage
           libraryName={libraryName}
           onSearch={(q) => setView({ kind: 'search', query: q })}
           onScanKta={() => setScanOpen(true)}
+          member={member}
+          onReserve={(b) => {
+            void handleReserveBook(b);
+          }}
         />
-      ) : (
-        <OpacSearchPage initialQuery={view.query} onBack={goHome} />
       )}
       <OpacKtaScanFlow
         open={scanOpen}
         onOpenChange={setScanOpen}
-        onMemberAuthenticated={(m) => setMember(m)}
+        onMemberAuthenticated={handleMemberAuthenticated}
       />
       <OpacAdminUnlockButton
         onVerify={verifyAdmin}

--- a/apps/desktop/src/features/opac/OpacHomePage.tsx
+++ b/apps/desktop/src/features/opac/OpacHomePage.tsx
@@ -6,16 +6,19 @@ import { Input } from '@/components/ui/input';
 import { OpacBookCard } from './OpacBookCard';
 import { OpacBookDetailDialog } from './OpacBookDetailDialog';
 import { bukuApi, type Buku } from '@/lib/buku';
+import type { Anggota } from '@/lib/anggota';
 
 export interface OpacHomePageProps {
   onSearch: (query: string) => void;
   onScanKta: () => void;
   libraryName?: string;
+  member?: Anggota | null;
+  onReserve?: (buku: Buku) => void;
 }
 
 const PAGE_SIZE = 24;
 
-export function OpacHomePage({ onSearch, onScanKta, libraryName }: OpacHomePageProps): JSX.Element {
+export function OpacHomePage({ onSearch, onScanKta, libraryName, member, onReserve }: OpacHomePageProps): JSX.Element {
   const { t } = useTranslation('opac');
   const [query, setQuery] = useState('');
   const [books, setBooks] = useState<Buku[]>([]);
@@ -136,6 +139,15 @@ export function OpacHomePage({ onSearch, onScanKta, libraryName }: OpacHomePageP
         buku={selected}
         open={selected !== null}
         onOpenChange={(o) => !o && setSelected(null)}
+        guest={!member}
+        onReserve={
+          onReserve
+            ? (b) => {
+                onReserve(b);
+                setSelected(null);
+              }
+            : undefined
+        }
       />
     </div>
   );

--- a/apps/desktop/src/features/opac/OpacMemberProfile.tsx
+++ b/apps/desktop/src/features/opac/OpacMemberProfile.tsx
@@ -1,0 +1,434 @@
+/**
+ * FEAT-OPAC-PostScanProfile (v1.1.0) — full-screen member profile that
+ * mounts after a successful KTA scan.
+ *
+ * User feedback (BUGS.md): "scan kta hanya itu fungsi nya? memuncukan
+ * nama? tambah misal anggota sudah scan muncul peminjaman aktif atau
+ * langsung absen kehadiran, atau bisa resevasi buku apa bila kosong
+ * eksemplar nya".
+ *
+ * The component:
+ *   1. Fetches the member's loan history (active + last 10) and their
+ *      active reservasi rows in parallel on mount.
+ *   2. Renders a header with avatar/foto + nama/kode/kelas + Logout
+ *      button that delegates to the parent.
+ *   3. Shows three sections: Peminjaman Aktif, Denda Outstanding,
+ *      Reservasi Saya, Riwayat Peminjaman (collapsible).
+ *   4. Lets the member cancel their own reservasi rows.
+ *   5. Forwards a "Cari Buku" callback so the page header can route
+ *      back into OpacSearchPage with the member context preserved.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  AlertTriangle,
+  BookOpen,
+  Calendar,
+  ChevronDown,
+  ChevronUp,
+  CircleDollarSign,
+  History,
+  LogOut,
+  Search,
+  User as UserIcon,
+  X,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/components/ui/toast-manager';
+import {
+  peminjamanApi,
+  type AnggotaLoanHistory,
+  type AnggotaLoanHistoryRow,
+} from '@/lib/peminjaman';
+import { reservasiApi, type ReservasiRow } from '@/lib/reservasi';
+import { formatTauriError } from '@/lib/errors';
+import { cn } from '@/lib/utils';
+import type { Anggota } from '@/lib/anggota';
+
+export interface OpacMemberProfileProps {
+  member: Anggota;
+  onLogout: () => void;
+  onSearchBooks: () => void;
+}
+
+const ACTIVE_STATUSES = new Set<AnggotaLoanHistoryRow['status']>([
+  'dipinjam',
+  'sebagian',
+  'terlambat',
+]);
+
+function fmtRupiah(n: number): string {
+  if (!Number.isFinite(n)) return '-';
+  try {
+    return n.toLocaleString('id-ID', { style: 'currency', currency: 'IDR', maximumFractionDigits: 0 });
+  } catch {
+    return `Rp ${Math.round(n)}`;
+  }
+}
+
+function fmtDate(iso?: string | null): string {
+  if (!iso) return '-';
+  try {
+    return new Date(iso).toLocaleDateString('id-ID', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function daysOverdue(jatuhTempoIso: string): number {
+  const jt = new Date(jatuhTempoIso);
+  const today = new Date();
+  jt.setHours(0, 0, 0, 0);
+  today.setHours(0, 0, 0, 0);
+  const ms = today.getTime() - jt.getTime();
+  return Math.max(0, Math.floor(ms / 86_400_000));
+}
+
+interface ReservasiStatusBadgeProps {
+  status: ReservasiRow['status'];
+}
+
+function ReservasiStatusBadge({ status }: ReservasiStatusBadgeProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const cls = (() => {
+    switch (status) {
+      case 'menunggu':
+        return 'bg-amber-500 text-white hover:bg-amber-500';
+      case 'siap_diambil':
+        return 'bg-emerald-500 text-white hover:bg-emerald-500';
+      case 'diambil':
+        return 'bg-sky-500 text-white hover:bg-sky-500';
+      case 'expired':
+        return 'bg-zinc-500 text-white hover:bg-zinc-500';
+      case 'dibatalkan':
+        return 'bg-zinc-400 text-white hover:bg-zinc-400';
+      default:
+        return '';
+    }
+  })();
+  return (
+    <Badge className={cls} data-testid={`reservasi-status-${status}`}>
+      {t(`profile.reservasi.status.${status}`)}
+    </Badge>
+  );
+}
+
+export function OpacMemberProfile({
+  member,
+  onLogout,
+  onSearchBooks,
+}: OpacMemberProfileProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  const { showToast } = useToast();
+  const [history, setHistory] = useState<AnggotaLoanHistory | null>(null);
+  const [reservasi, setReservasi] = useState<ReservasiRow[] | null>(null);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+  const [loadingReservasi, setLoadingReservasi] = useState(true);
+  const [showRiwayat, setShowRiwayat] = useState(false);
+  const [cancellingId, setCancellingId] = useState<number | null>(null);
+  const [fotoError, setFotoError] = useState(false);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoadingHistory(true);
+    setLoadingReservasi(true);
+    try {
+      const [hist, resv] = await Promise.allSettled([
+        peminjamanApi.anggotaLoanHistory(member.id, 50),
+        reservasiApi.listByAnggota(member.id),
+      ]);
+      if (hist.status === 'fulfilled') {
+        setHistory(hist.value);
+      } else {
+        showToast({
+          variant: 'destructive',
+          title: t('profile.loadError'),
+          description: formatTauriError(hist.reason),
+        });
+      }
+      if (resv.status === 'fulfilled') {
+        setReservasi(resv.value);
+      } else {
+        // Reservasi may legitimately be empty for first-time members;
+        // surface an unexpected RPC error but don't block the screen.
+        setReservasi([]);
+      }
+    } finally {
+      setLoadingHistory(false);
+      setLoadingReservasi(false);
+    }
+  }, [member.id, showToast, t]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const activeLoans = useMemo(
+    () => (history?.history ?? []).filter((h) => ACTIVE_STATUSES.has(h.status)),
+    [history],
+  );
+
+  const dendaOutstanding = useMemo(() => {
+    if (!history) return 0;
+    return Math.max(0, history.summary.totalDenda - history.summary.totalBayar);
+  }, [history]);
+
+  const handleCancelReservasi = async (row: ReservasiRow): Promise<void> => {
+    setCancellingId(row.id);
+    try {
+      await reservasiApi.cancel(row.id);
+      showToast({
+        title: t('profile.reservasi.cancelOk'),
+        description: row.bukuJudul,
+      });
+      void refresh();
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('profile.reservasi.cancelFail'),
+        description: formatTauriError(err),
+      });
+    } finally {
+      setCancellingId(null);
+    }
+  };
+
+  const memberInitials = (member.nama ?? '?').slice(0, 2).toUpperCase();
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4 sm:p-6" data-testid="opac-member-profile">
+      <Card>
+        <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:gap-4">
+          <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 text-primary">
+            {member.fotoPath && !fotoError ? (
+              <img
+                src={member.fotoPath}
+                alt={member.nama}
+                className="h-full w-full object-cover"
+                onError={() => setFotoError(true)}
+              />
+            ) : (
+              <span className="text-lg font-semibold" aria-hidden="true">
+                {memberInitials}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-lg font-semibold leading-tight">{member.nama}</h2>
+            <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+              <span className="font-mono">{member.kodeAnggota}</span>
+              {member.kelas ? <span>{t('profile.kelas')}: {member.kelas}</span> : null}
+              {member.jurusan ? <span>{t('profile.jurusan')}: {member.jurusan}</span> : null}
+            </div>
+          </div>
+          <div className="flex flex-shrink-0 gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onSearchBooks}
+              data-testid="opac-profile-search"
+            >
+              <Search className="mr-1.5 h-4 w-4" />
+              {t('profile.searchBooks')}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onLogout}
+              data-testid="opac-profile-logout"
+            >
+              <LogOut className="mr-1.5 h-4 w-4" />
+              {t('session.logout')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {dendaOutstanding > 0 ? (
+        <Card className="border-destructive/40 bg-destructive/5" data-testid="opac-profile-denda">
+          <CardContent className="flex items-center gap-3 p-4">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+            <div className="flex-1">
+              <p className="text-sm font-medium">{t('profile.denda.title')}</p>
+              <p className="text-xs text-muted-foreground">{t('profile.denda.description')}</p>
+            </div>
+            <p className="text-lg font-semibold text-destructive">
+              {fmtRupiah(dendaOutstanding)}
+            </p>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card data-testid="opac-profile-active-loans">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <BookOpen className="h-4 w-4" />
+            {t('profile.activeLoans.title')}
+            {activeLoans.length > 0 ? (
+              <Badge variant="secondary">{activeLoans.length}</Badge>
+            ) : null}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {loadingHistory ? (
+            <p className="text-sm text-muted-foreground">{t('search.loading')}</p>
+          ) : activeLoans.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('profile.activeLoans.empty')}</p>
+          ) : (
+            activeLoans.map((row) => {
+              const overdue = daysOverdue(row.tanggalJatuhTempo);
+              const isLate = overdue > 0;
+              return (
+                <div
+                  key={row.peminjamanId}
+                  className={cn(
+                    'flex items-center justify-between gap-3 rounded-md border p-3',
+                    isLate && 'border-destructive/40 bg-destructive/5',
+                  )}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">
+                      {row.bukuJudulPertama ?? row.nomorPinjam}
+                      {row.totalItem > 1 ? (
+                        <span className="ml-1 text-xs text-muted-foreground">
+                          (+{row.totalItem - 1})
+                        </span>
+                      ) : null}
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      <Calendar className="mr-1 inline h-3 w-3 align-[-2px]" />
+                      {t('profile.activeLoans.due', { date: fmtDate(row.tanggalJatuhTempo) })}
+                    </p>
+                  </div>
+                  {isLate ? (
+                    <Badge className="bg-destructive text-white hover:bg-destructive">
+                      {t('profile.activeLoans.overdue', { days: overdue })}
+                    </Badge>
+                  ) : (
+                    <Badge className="bg-emerald-500 text-white hover:bg-emerald-500">
+                      {t('profile.activeLoans.onTime')}
+                    </Badge>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      <Card data-testid="opac-profile-reservasi">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <CircleDollarSign className="h-4 w-4" />
+            {t('profile.reservasi.title')}
+            {reservasi && reservasi.length > 0 ? (
+              <Badge variant="secondary">{reservasi.length}</Badge>
+            ) : null}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {loadingReservasi ? (
+            <p className="text-sm text-muted-foreground">{t('search.loading')}</p>
+          ) : !reservasi || reservasi.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('profile.reservasi.empty')}</p>
+          ) : (
+            reservasi.map((row) => (
+              <div
+                key={row.id}
+                className="flex items-center justify-between gap-3 rounded-md border p-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{row.bukuJudul}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {t('profile.reservasi.queue', { urutan: row.urutan })}
+                    {row.slotRak ? ` · ${t('profile.reservasi.slot', { slot: row.slotRak })}` : ''}
+                    {row.expiredAt ? ` · ${t('profile.reservasi.expires', { date: fmtDate(row.expiredAt) })}` : ''}
+                  </p>
+                </div>
+                <ReservasiStatusBadge status={row.status} />
+                {(row.status === 'menunggu' || row.status === 'siap_diambil') && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      void handleCancelReservasi(row);
+                    }}
+                    disabled={cancellingId === row.id}
+                    data-testid={`opac-reservasi-cancel-${row.id}`}
+                  >
+                    <X className="mr-1 h-3.5 w-3.5" />
+                    {t('profile.reservasi.cancel')}
+                  </Button>
+                )}
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      <Card data-testid="opac-profile-history">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center justify-between text-base">
+            <span className="flex items-center gap-2">
+              <History className="h-4 w-4" />
+              {t('profile.history.title')}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowRiwayat((v) => !v)}
+              data-testid="opac-profile-history-toggle"
+            >
+              {showRiwayat ? (
+                <>
+                  <ChevronUp className="mr-1 h-3.5 w-3.5" />
+                  {t('profile.history.hide')}
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="mr-1 h-3.5 w-3.5" />
+                  {t('profile.history.show')}
+                </>
+              )}
+            </Button>
+          </CardTitle>
+        </CardHeader>
+        {showRiwayat ? (
+          <CardContent className="space-y-2">
+            {loadingHistory ? (
+              <p className="text-sm text-muted-foreground">{t('search.loading')}</p>
+            ) : !history || history.history.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{t('profile.history.empty')}</p>
+            ) : (
+              history.history.slice(0, 10).map((row) => (
+                <div
+                  key={row.peminjamanId}
+                  className="flex items-center justify-between gap-2 rounded-md border p-2 text-xs"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-medium">{row.bukuJudulPertama ?? row.nomorPinjam}</p>
+                    <p className="text-muted-foreground">
+                      {fmtDate(row.tanggalPinjam)} → {fmtDate(row.tanggalKembali ?? row.tanggalJatuhTempo)}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="capitalize">{row.status}</Badge>
+                </div>
+              ))
+            )}
+            {history?.summary?.lastPinjam ? (
+              <p className="pt-1 text-[10px] text-muted-foreground">
+                <UserIcon className="mr-1 inline h-3 w-3 align-[-2px]" />
+                {t('profile.history.lastPinjam', { date: fmtDate(history.summary.lastPinjam) })}
+              </p>
+            ) : null}
+          </CardContent>
+        ) : null}
+      </Card>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacSearchPage.tsx
+++ b/apps/desktop/src/features/opac/OpacSearchPage.tsx
@@ -7,15 +7,23 @@ import { OpacBookCard } from './OpacBookCard';
 import { OpacBookDetailDialog } from './OpacBookDetailDialog';
 import { OpacWishlistDialog } from './OpacWishlistDialog';
 import { bukuApi, type Buku } from '@/lib/buku';
+import type { Anggota } from '@/lib/anggota';
 
 export interface OpacSearchPageProps {
   initialQuery: string;
   onBack: () => void;
+  member?: Anggota | null;
+  onReserve?: (buku: Buku) => void;
 }
 
 const PAGE_SIZE = 24;
 
-export function OpacSearchPage({ initialQuery, onBack }: OpacSearchPageProps): JSX.Element {
+export function OpacSearchPage({
+  initialQuery,
+  onBack,
+  member,
+  onReserve,
+}: OpacSearchPageProps): JSX.Element {
   const { t } = useTranslation('opac');
   const [query, setQuery] = useState(initialQuery);
   const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
@@ -111,6 +119,15 @@ export function OpacSearchPage({ initialQuery, onBack }: OpacSearchPageProps): J
           setSelected(null);
           setWishlistFor(b);
         }}
+        guest={!member}
+        onReserve={
+          onReserve
+            ? (b) => {
+                onReserve(b);
+                setSelected(null);
+              }
+            : undefined
+        }
       />
       <OpacWishlistDialog
         open={wishlistFor !== null}

--- a/apps/desktop/src/i18n/en/opac.json
+++ b/apps/desktop/src/i18n/en/opac.json
@@ -62,7 +62,10 @@
     "cameraInUse": "Camera is being used by another app.",
     "cameraUnsupported": "Browser does not support camera access.",
     "cameraOtherError": "An error occurred while accessing the camera.",
-    "selectDevice": "Select camera"
+    "selectDevice": "Select camera",
+    "welcomeBack": "Welcome back, {{nama}}",
+    "kehadiranTercatat": "Attendance recorded",
+    "kehadiranFail": "Failed to record attendance"
   },
   "admin": {
     "unlockButton": "Admin Mode",
@@ -95,5 +98,52 @@
   "footer": {
     "poweredBy": "Perpustakaan Nusantara",
     "version": "v{{version}}"
+  },
+  "profile": {
+    "kelas": "Class",
+    "jurusan": "Major",
+    "searchBooks": "Search Books",
+    "loadError": "Failed to load member data",
+    "denda": {
+      "title": "Unpaid Fines",
+      "description": "Please settle with the librarian."
+    },
+    "activeLoans": {
+      "title": "Active Loans",
+      "empty": "No active loans.",
+      "due": "Due: {{date}}",
+      "onTime": "On time",
+      "overdue": "{{days}} days overdue"
+    },
+    "reservasi": {
+      "title": "My Reservations",
+      "empty": "No active reservations.",
+      "queue": "Queue #{{urutan}}",
+      "slot": "Slot {{slot}}",
+      "expires": "Valid until {{date}}",
+      "cancel": "Cancel",
+      "cancelOk": "Reservation cancelled",
+      "cancelFail": "Failed to cancel reservation",
+      "status": {
+        "menunggu": "Waiting",
+        "siap_diambil": "Ready for pickup",
+        "diambil": "Picked up",
+        "expired": "Expired",
+        "dibatalkan": "Cancelled"
+      }
+    },
+    "history": {
+      "title": "Loan History",
+      "show": "Show",
+      "hide": "Hide",
+      "empty": "No loan history yet.",
+      "lastPinjam": "Last loan: {{date}}"
+    }
+  },
+  "reservasi": {
+    "loginFirst": "Scan your KTA to reserve",
+    "created": "Reservation created",
+    "queueDescription": "{{judul}} — queue #{{urutan}}",
+    "createFail": "Failed to create reservation"
   }
 }

--- a/apps/desktop/src/i18n/id/opac.json
+++ b/apps/desktop/src/i18n/id/opac.json
@@ -62,7 +62,10 @@
     "cameraInUse": "Kamera sedang dipakai aplikasi lain.",
     "cameraUnsupported": "Browser tidak mendukung akses kamera.",
     "cameraOtherError": "Terjadi kesalahan saat mengakses kamera.",
-    "selectDevice": "Pilih kamera"
+    "selectDevice": "Pilih kamera",
+    "welcomeBack": "Selamat datang kembali, {{nama}}",
+    "kehadiranTercatat": "Kehadiran tercatat",
+    "kehadiranFail": "Gagal mencatat kehadiran"
   },
   "admin": {
     "unlockButton": "Mode Admin",
@@ -95,5 +98,52 @@
   "footer": {
     "poweredBy": "Perpustakaan Nusantara",
     "version": "v{{version}}"
+  },
+  "profile": {
+    "kelas": "Kelas",
+    "jurusan": "Jurusan",
+    "searchBooks": "Cari Buku",
+    "loadError": "Gagal memuat data anggota",
+    "denda": {
+      "title": "Denda Belum Dibayar",
+      "description": "Mohon segera diselesaikan di petugas perpustakaan."
+    },
+    "activeLoans": {
+      "title": "Peminjaman Aktif",
+      "empty": "Tidak ada peminjaman aktif saat ini.",
+      "due": "Jatuh tempo: {{date}}",
+      "onTime": "Tepat waktu",
+      "overdue": "Terlambat {{days}} hari"
+    },
+    "reservasi": {
+      "title": "Reservasi Saya",
+      "empty": "Belum ada reservasi aktif.",
+      "queue": "Antrean #{{urutan}}",
+      "slot": "Slot {{slot}}",
+      "expires": "Berlaku s/d {{date}}",
+      "cancel": "Batalkan",
+      "cancelOk": "Reservasi dibatalkan",
+      "cancelFail": "Gagal membatalkan reservasi",
+      "status": {
+        "menunggu": "Menunggu",
+        "siap_diambil": "Siap diambil",
+        "diambil": "Sudah diambil",
+        "expired": "Kedaluwarsa",
+        "dibatalkan": "Dibatalkan"
+      }
+    },
+    "history": {
+      "title": "Riwayat Peminjaman",
+      "show": "Tampilkan",
+      "hide": "Sembunyikan",
+      "empty": "Belum ada riwayat peminjaman.",
+      "lastPinjam": "Terakhir pinjam: {{date}}"
+    }
+  },
+  "reservasi": {
+    "loginFirst": "Login dengan KTA terlebih dahulu untuk reservasi",
+    "created": "Reservasi berhasil",
+    "queueDescription": "{{judul}} — antrean #{{urutan}}",
+    "createFail": "Gagal membuat reservasi"
   }
 }

--- a/apps/desktop/tests/unit/opacMemberProfile.test.tsx
+++ b/apps/desktop/tests/unit/opacMemberProfile.test.tsx
@@ -1,0 +1,206 @@
+import { describe, expect, it, beforeEach, vi, type Mock } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
+import { OpacMemberProfile } from '@/features/opac/OpacMemberProfile';
+import { ToastManagerProvider } from '@/components/ui/toast-manager';
+import { ToastProvider, ToastViewport } from '@/components/ui/toast';
+import type { Anggota } from '@/lib/anggota';
+
+vi.mock('@/lib/peminjaman', () => ({
+  peminjamanApi: {
+    anggotaLoanHistory: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/reservasi', () => ({
+  reservasiApi: {
+    listByAnggota: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+import { peminjamanApi } from '@/lib/peminjaman';
+import { reservasiApi } from '@/lib/reservasi';
+
+const member: Anggota = {
+  id: 1,
+  kodeAnggota: 'A001',
+  nama: 'Budi Santoso',
+  kelas: 'XI IPA 1',
+  jurusan: 'IPA',
+  tanggalDaftar: '2025-01-01',
+  aktif: true,
+  createdAt: '2025-01-01',
+  updatedAt: '2025-01-01',
+};
+
+function Wrap({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <ToastProvider>
+        <ToastManagerProvider>
+          {children}
+          <ToastViewport />
+        </ToastManagerProvider>
+      </ToastProvider>
+    </I18nextProvider>
+  );
+}
+
+const baseHistory = {
+  summary: {
+    aktifCount: 1,
+    overdueCount: 0,
+    totalDenda: 0,
+    totalBayar: 0,
+    lastPinjam: '2025-01-15',
+  },
+  topBuku: [],
+  history: [],
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (peminjamanApi.anggotaLoanHistory as Mock).mockResolvedValue(baseHistory);
+  (reservasiApi.listByAnggota as Mock).mockResolvedValue([]);
+});
+
+describe('OpacMemberProfile', () => {
+  it('renders header with nama / kode / kelas / jurusan', async () => {
+    render(
+      <Wrap>
+        <OpacMemberProfile member={member} onLogout={() => {}} onSearchBooks={() => {}} />
+      </Wrap>,
+    );
+    expect(await screen.findByText('Budi Santoso')).toBeInTheDocument();
+    expect(screen.getByText('A001')).toBeInTheDocument();
+    expect(screen.getByText(/XI IPA 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Jurusan|Major/i)).toBeInTheDocument();
+  });
+
+  it('shows active loans with overdue badge when past due date', async () => {
+    const yesterday = new Date(Date.now() - 86_400_000 * 3).toISOString().slice(0, 10);
+    (peminjamanApi.anggotaLoanHistory as Mock).mockResolvedValue({
+      ...baseHistory,
+      history: [
+        {
+          peminjamanId: 1,
+          nomorPinjam: 'PJ-001',
+          tanggalPinjam: '2025-01-01',
+          tanggalJatuhTempo: yesterday,
+          status: 'dipinjam',
+          totalItem: 1,
+          totalDenda: 0,
+          bukuJudulPertama: 'Sapiens',
+        },
+      ],
+    });
+    render(
+      <Wrap>
+        <OpacMemberProfile member={member} onLogout={() => {}} onSearchBooks={() => {}} />
+      </Wrap>,
+    );
+    expect(await screen.findByText('Sapiens')).toBeInTheDocument();
+    expect(screen.getByText(/Terlambat 3 hari|3 days overdue/i)).toBeInTheDocument();
+  });
+
+  it('shows denda outstanding card only when totalDenda > totalBayar', async () => {
+    (peminjamanApi.anggotaLoanHistory as Mock).mockResolvedValue({
+      ...baseHistory,
+      summary: { ...baseHistory.summary, totalDenda: 5000, totalBayar: 1000 },
+    });
+    render(
+      <Wrap>
+        <OpacMemberProfile member={member} onLogout={() => {}} onSearchBooks={() => {}} />
+      </Wrap>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('opac-profile-denda')).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Rp\s*4\.000|IDR/)).toBeInTheDocument();
+  });
+
+  it('does not render denda card when zero', async () => {
+    render(
+      <Wrap>
+        <OpacMemberProfile member={member} onLogout={() => {}} onSearchBooks={() => {}} />
+      </Wrap>,
+    );
+    await screen.findByText('Budi Santoso');
+    expect(screen.queryByTestId('opac-profile-denda')).not.toBeInTheDocument();
+  });
+
+  it('lists active reservasi with queue position and lets the member cancel', async () => {
+    (reservasiApi.listByAnggota as Mock).mockResolvedValue([
+      {
+        id: 7,
+        anggotaId: 1,
+        anggotaNama: 'Budi Santoso',
+        anggotaKode: 'A001',
+        bukuId: 99,
+        bukuJudul: 'Pulang',
+        bukuKode: 'B-99',
+        urutan: 2,
+        status: 'menunggu',
+        slotRak: null,
+        tanggalRequest: '2025-01-10',
+        tanggalSiapDiambil: null,
+        expiredAt: null,
+        catatan: null,
+        createdAt: '2025-01-10',
+        updatedAt: '2025-01-10',
+      },
+    ]);
+    (reservasiApi.cancel as Mock).mockResolvedValue(undefined);
+    render(
+      <Wrap>
+        <OpacMemberProfile member={member} onLogout={() => {}} onSearchBooks={() => {}} />
+      </Wrap>,
+    );
+    expect(await screen.findByText('Pulang')).toBeInTheDocument();
+    expect(screen.getByText(/Antrean #2|Queue #2/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('opac-reservasi-cancel-7'));
+    await waitFor(() => expect(reservasiApi.cancel).toHaveBeenCalledWith(7));
+  });
+
+  it('toggles riwayat section open/closed', async () => {
+    (peminjamanApi.anggotaLoanHistory as Mock).mockResolvedValue({
+      ...baseHistory,
+      history: [
+        {
+          peminjamanId: 5,
+          nomorPinjam: 'PJ-005',
+          tanggalPinjam: '2025-01-01',
+          tanggalJatuhTempo: '2025-01-15',
+          tanggalKembali: '2025-01-14',
+          status: 'dikembalikan',
+          totalItem: 1,
+          totalDenda: 0,
+          bukuJudulPertama: 'Old Book',
+        },
+      ],
+    });
+    render(
+      <Wrap>
+        <OpacMemberProfile member={member} onLogout={() => {}} onSearchBooks={() => {}} />
+      </Wrap>,
+    );
+    await screen.findByText('Budi Santoso');
+    expect(screen.queryByText('Old Book')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('opac-profile-history-toggle'));
+    expect(await screen.findByText('Old Book')).toBeInTheDocument();
+  });
+
+  it('calls onLogout when the logout button is clicked', async () => {
+    const onLogout = vi.fn();
+    render(
+      <Wrap>
+        <OpacMemberProfile member={member} onLogout={onLogout} onSearchBooks={() => {}} />
+      </Wrap>,
+    );
+    await screen.findByText('Budi Santoso');
+    fireEvent.click(screen.getByTestId('opac-profile-logout'));
+    expect(onLogout).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **FEAT-OPAC-PostScanProfile** (item 7 / 14 in the v1.1.0 batch).

User feedback (BUGS.md):
> "scan kta hanya itu fungsi nya? memuncukan nama? tambah misal anggota sudah scan muncul peminjaman aktif atau langsung absen kehadiran, atau bisa resevasi buku apa bila kosong eksemplar nya"

Three sub-features ship together so the post-scan experience feels complete:

### Sub-feature A — Full member profile after KTA scan
- New `OpacMemberProfile` component (`apps/desktop/src/features/opac/OpacMemberProfile.tsx`) replaces the old single-line "Selamat datang, X" banner.
- Header: avatar/foto fallback, nama, kode anggota, kelas, jurusan, plus "Cari Buku" / "Logout" actions.
- **Denda Outstanding card** (only when `totalDenda - totalBayar > 0`).
- **Peminjaman Aktif** list with per-row overdue badge (red, "Terlambat N hari") or on-time badge (green).
- **Reservasi Saya** list with status pill, queue position, slot rak, expiry date, and per-row Cancel button.
- **Riwayat Peminjaman** collapsible section (last 10 loans).
- Data is fetched once via `peminjamanApi.anggotaLoanHistory(50)` + `reservasiApi.listByAnggota` in parallel; RPC failures surface as toasts without blocking the rest of the panel.

### Sub-feature B — Auto absen kehadiran on scan
- `OpacApp.handleMemberAuthenticated` now calls `kunjunganApi.create({ anggotaId, sumber: 'manual' })` after every successful KTA scan.
- A **5-minute throttle** keyed by `anggotaId` in `localStorage` suppresses duplicate kunjungan rows when a member re-scans quickly. The member instead sees a "Selamat datang kembali, {nama}" toast.
- Successful create surfaces a "Kehadiran tercatat" toast.

### Sub-feature C — Reservasi wired into OPAC catalog
- `OpacApp` threads `member` and `onReserve` down through `OpacHomePage` and `OpacSearchPage`.
- Both pages pass `guest={!member}` to `OpacBookDetailDialog`, activating the existing Reservasi button only for logged-in members.
- Successful create shows the assigned queue position in the toast: "{judul} — antrean #N".
- Existing `reservasiApi.create / listByAnggota / cancel` are used as-is — no new RPC, no schema migration.

## Files changed

- `apps/desktop/src/features/opac/OpacMemberProfile.tsx` (new, ~360 lines)
- `apps/desktop/src/features/opac/OpacApp.tsx` — replaces banner with profile view, adds member-state-aware view routing, kunjungan throttle, reserve handler
- `apps/desktop/src/features/opac/OpacHomePage.tsx` — accepts `member` and `onReserve`, passes to detail dialog
- `apps/desktop/src/features/opac/OpacSearchPage.tsx` — same threading
- `apps/desktop/src/i18n/{id,en}/opac.json` — `profile.*`, `reservasi.*`, `session.welcomeBack`/`kehadiranTercatat`/`kehadiranFail`
- `apps/desktop/tests/unit/opacMemberProfile.test.tsx` (new, 7 tests)

## Testing

- `pnpm typecheck` ✓
- `pnpm lint --max-warnings=0` ✓
- `pnpm i18n:lint` ✓ (id ↔ en parity)
- `pnpm test` ✓ (542 tests, +7 new)
- `pnpm build` ✓ (14s)

7 new tests cover header render, overdue badge, denda card visibility, reservasi listing+cancel, riwayat toggle, logout callback.

## Acceptance criteria

- [x] After scan, OpacMemberProfile shows nama / kode / kelas / jurusan / active loans / denda / riwayat / reservasi
- [x] Each scan creates a kunjungan row (skipped if last scan was < 5 min ago — 5-min localStorage throttle)
- [x] Reserving a buku with `tersedia === 0` succeeds and queue position is shown in the toast
- [x] Logout button clears member and returns to OpacHomePage

## Out of scope (deferred)

- The schema migration for a NEW `reservasi` table outlined in the long-form spec is **not** required: the `reservasi_buku` table and `reservasi_*` Tauri RPCs already exist in the repo (see `apps/desktop/src-tauri/src/commands/reservasi.rs`). This PR wires existing infrastructure into the OPAC member experience instead of duplicating it.
- Promote-on-pengembalian is already implemented backend-side (see `promote_next_in_queue` in `reservasi.rs`); no frontend work needed for that part of the spec.

## Batch context

- v1.1.0 progress: 6/14 done before this PR (#145 #146 #147 #148 #149 #150). This is item **7/14**.
- After merge, batch will pause before item 8 (FEAT-OPAC-Scan-Locked) per user request.
