### PR TITLE
feat(opac): intercept Scan KTA when another member is signed in (FEAT-OPAC-Scan-Locked)

### DIFF
--- a/apps/desktop/src/features/opac/OpacApp.tsx
+++ b/apps/desktop/src/features/opac/OpacApp.tsx
@@ -5,6 +5,7 @@ import { OpacSearchPage } from './OpacSearchPage';
 import { OpacAdminUnlockButton } from './OpacAdminUnlockButton';
 import { OpacKtaScanFlow } from './OpacKtaScanFlow';
 import { OpacMemberProfile } from './OpacMemberProfile';
+import { OpacScanLockedDialog } from './OpacScanLockedDialog';
 import { useOpacIdleReset } from './useOpacIdleReset';
 import { settingsApi } from '@/lib/settings';
 import { loginRequest, isTauri } from '@/lib/auth';
@@ -89,6 +90,7 @@ export function OpacApp({
   const { showToast } = useToast();
   const [view, setView] = useState<View>({ kind: 'home' });
   const [scanOpen, setScanOpen] = useState(false);
+  const [scanLockedOpen, setScanLockedOpen] = useState(false);
   const [member, setMember] = useState<Anggota | null>(null);
 
   const goHome = useCallback(() => {
@@ -97,9 +99,25 @@ export function OpacApp({
 
   useOpacIdleReset(() => {
     setScanOpen(false);
+    setScanLockedOpen(false);
     setMember(null);
     setView({ kind: 'home' });
   });
+
+  const handleScanKtaRequest = useCallback((): void => {
+    if (member) {
+      setScanLockedOpen(true);
+    } else {
+      setScanOpen(true);
+    }
+  }, [member]);
+
+  const handleLogoutAndScan = useCallback((): void => {
+    setMember(null);
+    setView({ kind: 'home' });
+    setScanLockedOpen(false);
+    setScanOpen(true);
+  }, []);
 
   useEffect(() => {
     if (!isTauri() || typeof window === 'undefined') return undefined;
@@ -218,6 +236,7 @@ export function OpacApp({
           member={member}
           onLogout={handleLogout}
           onSearchBooks={() => setView({ kind: 'search', query: '' })}
+          onScanKta={handleScanKtaRequest}
         />
       ) : view.kind === 'search' ? (
         <OpacSearchPage
@@ -232,7 +251,7 @@ export function OpacApp({
         <OpacHomePage
           libraryName={libraryName}
           onSearch={(q) => setView({ kind: 'search', query: q })}
-          onScanKta={() => setScanOpen(true)}
+          onScanKta={handleScanKtaRequest}
           member={member}
           onReserve={(b) => {
             void handleReserveBook(b);
@@ -243,6 +262,12 @@ export function OpacApp({
         open={scanOpen}
         onOpenChange={setScanOpen}
         onMemberAuthenticated={handleMemberAuthenticated}
+      />
+      <OpacScanLockedDialog
+        open={scanLockedOpen}
+        onOpenChange={setScanLockedOpen}
+        memberName={member?.nama ?? ''}
+        onLogoutAndScan={handleLogoutAndScan}
       />
       <OpacAdminUnlockButton
         onVerify={verifyAdmin}

--- a/apps/desktop/src/features/opac/OpacMemberProfile.tsx
+++ b/apps/desktop/src/features/opac/OpacMemberProfile.tsx
@@ -29,6 +29,7 @@ import {
   CircleDollarSign,
   History,
   LogOut,
+  ScanLine,
   Search,
   User as UserIcon,
   X,
@@ -51,6 +52,14 @@ export interface OpacMemberProfileProps {
   member: Anggota;
   onLogout: () => void;
   onSearchBooks: () => void;
+  /**
+   * Optional handler for the "Scan KTA Lain" button that lets a different
+   * student request a fresh scan even when the current member is still
+   * signed in. The parent is expected to intercept via
+   * `OpacScanLockedDialog` (FEAT-OPAC-Scan-Locked) before opening the
+   * camera flow.
+   */
+  onScanKta?: () => void;
 }
 
 const ACTIVE_STATUSES = new Set<AnggotaLoanHistoryRow['status']>([
@@ -123,6 +132,7 @@ export function OpacMemberProfile({
   member,
   onLogout,
   onSearchBooks,
+  onScanKta,
 }: OpacMemberProfileProps): JSX.Element {
   const { t } = useTranslation('opac');
   const { showToast } = useToast();
@@ -236,6 +246,17 @@ export function OpacMemberProfile({
               <Search className="mr-1.5 h-4 w-4" />
               {t('profile.searchBooks')}
             </Button>
+            {onScanKta ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onScanKta}
+                data-testid="opac-profile-scan-other"
+              >
+                <ScanLine className="mr-1.5 h-4 w-4" />
+                {t('profile.scanOtherKta')}
+              </Button>
+            ) : null}
             <Button
               variant="ghost"
               size="sm"

--- a/apps/desktop/src/features/opac/OpacScanLockedDialog.tsx
+++ b/apps/desktop/src/features/opac/OpacScanLockedDialog.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export interface OpacScanLockedDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Name of the member currently signed in. Shown in title + description. */
+  memberName: string;
+  /** Logout the active member then open the scan flow. */
+  onLogoutAndScan: () => void;
+}
+
+export function OpacScanLockedDialog({
+  open,
+  onOpenChange,
+  memberName,
+  onLogoutAndScan,
+}: OpacScanLockedDialogProps): JSX.Element {
+  const { t } = useTranslation('opac');
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-md"
+        data-testid="opac-scan-locked-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle>{t('scanLocked.title', { nama: memberName })}</DialogTitle>
+          <DialogDescription>{t('scanLocked.description')}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            data-testid="opac-scan-locked-cancel"
+          >
+            {t('scanLocked.cancel')}
+          </Button>
+          <Button
+            type="button"
+            onClick={onLogoutAndScan}
+            data-testid="opac-scan-locked-logout"
+          >
+            {t('scanLocked.logoutAndScan')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/i18n/en/opac.json
+++ b/apps/desktop/src/i18n/en/opac.json
@@ -95,6 +95,12 @@
     "fullscreenError": "Could not enter fullscreen automatically. Press F11 if not in fullscreen.",
     "limitations": "Note: Ctrl+Alt+Del / Task Manager cannot be disabled from the app."
   },
+  "scanLocked": {
+    "title": "Another member is still signed in: {{nama}}",
+    "description": "Click Sign out & Scan to switch members, or Cancel to keep the current session.",
+    "logoutAndScan": "Sign out & Scan",
+    "cancel": "Cancel"
+  },
   "footer": {
     "poweredBy": "Perpustakaan Nusantara",
     "version": "v{{version}}"
@@ -103,6 +109,7 @@
     "kelas": "Class",
     "jurusan": "Major",
     "searchBooks": "Search Books",
+    "scanOtherKta": "Scan Another KTA",
     "loadError": "Failed to load member data",
     "denda": {
       "title": "Unpaid Fines",

--- a/apps/desktop/src/i18n/id/opac.json
+++ b/apps/desktop/src/i18n/id/opac.json
@@ -95,6 +95,12 @@
     "fullscreenError": "Tidak dapat masuk fullscreen otomatis. Tekan F11 jika belum fullscreen.",
     "limitations": "Catatan: Ctrl+Alt+Del / Task Manager tidak dapat dinonaktifkan dari aplikasi."
   },
+  "scanLocked": {
+    "title": "Anggota lain masih login: {{nama}}",
+    "description": "Klik tombol Logout & Scan untuk pindah anggota, atau Batal untuk tetap di sesi saat ini.",
+    "logoutAndScan": "Logout & Scan",
+    "cancel": "Batal"
+  },
   "footer": {
     "poweredBy": "Perpustakaan Nusantara",
     "version": "v{{version}}"
@@ -103,6 +109,7 @@
     "kelas": "Kelas",
     "jurusan": "Jurusan",
     "searchBooks": "Cari Buku",
+    "scanOtherKta": "Scan KTA Lain",
     "loadError": "Gagal memuat data anggota",
     "denda": {
       "title": "Denda Belum Dibayar",

--- a/apps/desktop/tests/unit/opacScanLockedDialog.test.tsx
+++ b/apps/desktop/tests/unit/opacScanLockedDialog.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
+import { OpacScanLockedDialog } from '@/features/opac/OpacScanLockedDialog';
+
+function Wrap({ children }: { children: React.ReactNode }): JSX.Element {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}
+
+describe('OpacScanLockedDialog (FEAT-OPAC-Scan-Locked)', () => {
+  it('renders the current member name in the title when open', () => {
+    render(
+      <Wrap>
+        <OpacScanLockedDialog
+          open
+          onOpenChange={() => {}}
+          memberName="Budi Santoso"
+          onLogoutAndScan={() => {}}
+        />
+      </Wrap>,
+    );
+    expect(
+      screen.getByText(/Anggota lain masih login: Budi Santoso|Another member is still signed in: Budi Santoso/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Logout & Scan|Sign out & Scan/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^Batal$|^Cancel$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <Wrap>
+        <OpacScanLockedDialog
+          open={false}
+          onOpenChange={() => {}}
+          memberName="Budi Santoso"
+          onLogoutAndScan={() => {}}
+        />
+      </Wrap>,
+    );
+    expect(screen.queryByTestId('opac-scan-locked-dialog')).not.toBeInTheDocument();
+  });
+
+  it('invokes onLogoutAndScan when Logout & Scan is clicked', () => {
+    const onLogoutAndScan = vi.fn();
+    render(
+      <Wrap>
+        <OpacScanLockedDialog
+          open
+          onOpenChange={() => {}}
+          memberName="Siti Aisyah"
+          onLogoutAndScan={onLogoutAndScan}
+        />
+      </Wrap>,
+    );
+    fireEvent.click(screen.getByTestId('opac-scan-locked-logout'));
+    expect(onLogoutAndScan).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onOpenChange(false) when Batal is clicked and does not call onLogoutAndScan', () => {
+    const onOpenChange = vi.fn();
+    const onLogoutAndScan = vi.fn();
+    render(
+      <Wrap>
+        <OpacScanLockedDialog
+          open
+          onOpenChange={onOpenChange}
+          memberName="Siti Aisyah"
+          onLogoutAndScan={onLogoutAndScan}
+        />
+      </Wrap>,
+    );
+    fireEvent.click(screen.getByTestId('opac-scan-locked-cancel'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onLogoutAndScan).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the v1.1.0 batch item 8 (`FEAT-OPAC-Scan-Locked`). When the OPAC kiosk has a member session active and a different student walks up wanting to scan their own KTA, the app now intercepts the scan trigger with a confirmation dialog instead of silently opening the camera and overwriting the session.

The intercept lives at the `OpacApp` level so every scan-trigger surface gets it for free:

- `OpacHomePage` "Scan KTA Saya" button (the original trigger).
- `OpacMemberProfile` gains an optional `Scan KTA Lain` button so a different student can request a fresh scan from inside the previous member's profile view (the realistic real-world scenario described by the user — previous member forgot to logout).

`OpacScanLockedDialog` is a small `Dialog` that surfaces the active member's name and offers two actions:

- **Logout & Scan** — clears `member`, resets the view to home, closes the locked dialog, opens `OpacKtaScanFlow`.
- **Batal** — closes the dialog without touching session state.

The existing `useOpacIdleReset` continues to clear `scanOpen`, `scanLockedOpen`, `member`, and view on idle timeout, so a forgotten dialog doesn't pin the kiosk indefinitely.

### Files changed

- `apps/desktop/src/features/opac/OpacScanLockedDialog.tsx` (new)
- `apps/desktop/src/features/opac/OpacApp.tsx` — adds `scanLockedOpen` state, `handleScanKtaRequest`, `handleLogoutAndScan`, mounts the dialog, threads `onScanKta` into the profile view.
- `apps/desktop/src/features/opac/OpacMemberProfile.tsx` — optional `onScanKta` prop renders the `Scan KTA Lain` button next to `Cari Buku` / `Logout`.
- `apps/desktop/src/i18n/{id,en}/opac.json` — adds `scanLocked.{title,description,logoutAndScan,cancel}` and `profile.scanOtherKta`. `pnpm i18n:lint` passes parity.
- `apps/desktop/tests/unit/opacScanLockedDialog.test.tsx` (new) — 4 unit tests covering the acceptance criteria.

### Local gates

| Gate | Result |
|---|---|
| `pnpm i18n:lint` | OK across all namespaces |
| `pnpm typecheck` (desktop) | OK |
| `pnpm lint` (desktop, `--max-warnings=0`) | OK |
| `pnpm test` (desktop, vitest) | 546 pass / 546 (4 new) |
| `pnpm build` (desktop, vite) | OK |

## Review & Testing Checklist for Human

Risk level: yellow — touches the OPAC public-mode flow that runs on the school kiosk. Single-screen change, no schema work, deterministic state machine.

- [ ] Verify the camera scan flow still opens immediately when no member is signed in (`Scan KTA Saya` on the home page → camera dialog).
- [ ] Trigger a member session (scan a KTA), open the profile view, click `Scan KTA Lain`. The locked dialog must show the active member's name. `Batal` must close the dialog with the session intact; `Logout & Scan` must clear the session, return to home, and open the camera dialog.
- [ ] Confirm the locked dialog auto-clears on idle timeout (~2 minutes of no input) — `useOpacIdleReset` should reset `scanLockedOpen`, `scanOpen`, `member`, and view back to home.
- [ ] Run the kiosk in EN locale and re-check the dialog copy ("Another member is still signed in: …", "Sign out & Scan", "Cancel").

### Notes

- v1.1.0 batch progress: items 1–7 + this item 8 done. Items A1, A2, C1, D1, D5, E1, RELEASE still OPEN per `.devin/handoff/v1.1.0/PROGRESS.md`.
- The `Scan KTA Lain` button on the profile view is the design decision that turns the spec's "defensive guard" into a feature the user can actually trigger from the profile screen — the original `Scan KTA Saya` on the home view is unreachable while a member is signed in because `goHome` redirects to the profile.
