### PR TITLE
feat(palette): in-app routes + quick actions in GlobalSearchDialog (A1-CommandPalette)

### DIFF
--- a/apps/desktop/src/components/layout/GlobalSearchDialog.tsx
+++ b/apps/desktop/src/components/layout/GlobalSearchDialog.tsx
@@ -13,12 +13,23 @@ import {
   CommandSeparator,
 } from '@/components/ui/command';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { useToast } from '@/components/ui/toast-manager';
+import { fuzzyScore } from '@/lib/fuzzy';
 import { anggotaApi, type Anggota } from '@/lib/anggota';
 import { bukuApi, type Buku } from '@/lib/buku';
 import { peminjamanApi, type PeminjamanRow } from '@/lib/peminjaman';
+import {
+  COMMAND_PALETTE_DEFAULT_ROUTE_LIMIT,
+  COMMAND_PALETTE_ROUTES,
+  getCommandPaletteActions,
+  type CommandPaletteActionEntry,
+  type CommandPaletteRouteEntry,
+} from '@/components/layout/commandPaletteRegistry';
 
 const PER_GROUP_LIMIT = 5;
 const DEBOUNCE_MS = 200;
+const ROUTE_ACTION_THRESHOLD = 0.3;
+const PER_PALETTE_GROUP_LIMIT = 8;
 
 export interface GlobalSearchHit {
   /** Stable key — `anggota:42`, `buku:7`, `peminjaman:13`. */
@@ -91,9 +102,17 @@ export interface GlobalSearchDialogProps {
   onOpenChange: (next: boolean) => void;
 }
 
+/** Score a route/action against a query using its translated label + description. */
+function scoreEntry(label: string, description: string | undefined, query: string): number {
+  const labelScore = fuzzyScore(label, query);
+  const descScore = description ? fuzzyScore(description, query) * 0.6 : 0;
+  return Math.max(labelScore, descScore);
+}
+
 export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogProps): JSX.Element {
   const { t } = useTranslation(['common']);
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [raw, setRaw] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [results, setResults] = useState<SearchResults>(EMPTY_RESULTS);
@@ -143,15 +162,102 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
     });
   }, [debouncedQuery, open]);
 
-  const totalHits = useMemo(
+  const totalDataHits = useMemo(
     () => results.anggota.length + results.buku.length + results.peminjaman.length,
     [results],
   );
+
+  const trimmed = raw.trim();
+  const hasQuery = trimmed.length > 0;
+  const hasDataQuery = trimmed.length >= 2;
+
+  const visibleRoutes = useMemo<CommandPaletteRouteEntry[]>(() => {
+    if (!hasQuery) {
+      return COMMAND_PALETTE_ROUTES.slice(0, COMMAND_PALETTE_DEFAULT_ROUTE_LIMIT) as CommandPaletteRouteEntry[];
+    }
+    const scored = COMMAND_PALETTE_ROUTES.map((entry) => {
+      const label = t(`commandPalette.route.${entry.key}.label`, {
+        defaultValue: entry.key,
+      });
+      const description = t(`commandPalette.route.${entry.key}.description`, {
+        defaultValue: '',
+      });
+      const score = scoreEntry(label, description || undefined, trimmed);
+      return { entry, score };
+    })
+      .filter((s) => s.score >= ROUTE_ACTION_THRESHOLD)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, PER_PALETTE_GROUP_LIMIT)
+      .map((s) => s.entry);
+    return scored;
+  }, [hasQuery, trimmed, t]);
+
+  const allActions = useMemo(() => getCommandPaletteActions(), []);
+
+  const visibleActions = useMemo<CommandPaletteActionEntry[]>(() => {
+    if (!hasQuery) {
+      return [...allActions];
+    }
+    const scored = allActions
+      .map((entry) => {
+        const label = t(`commandPalette.action.${entry.key}.label`, {
+          defaultValue: entry.key,
+        });
+        const description = t(`commandPalette.action.${entry.key}.description`, {
+          defaultValue: '',
+        });
+        const score = scoreEntry(label, description || undefined, trimmed);
+        return { entry, score };
+      })
+      .filter((s) => s.score >= ROUTE_ACTION_THRESHOLD)
+      .sort((a, b) => b.score - a.score)
+      .map((s) => s.entry);
+    return scored;
+  }, [hasQuery, trimmed, allActions, t]);
 
   const handleActivate = (hit: GlobalSearchHit): void => {
     onOpenChange(false);
     void navigate({ to: hit.to });
   };
+
+  const handleRoute = (entry: CommandPaletteRouteEntry): void => {
+    onOpenChange(false);
+    void navigate({ to: entry.to });
+  };
+
+  const handleAction = (entry: CommandPaletteActionEntry): void => {
+    onOpenChange(false);
+    // Defer execution so the dialog finishes closing before the action runs.
+    // Otherwise toasts/confirms triggered by the action lose focus to the dialog.
+    setTimeout(() => {
+      void Promise.resolve(
+        entry.execute({
+          navigate: (path) => {
+            void navigate({ to: path });
+          },
+          showToast,
+          t,
+        }),
+      ).catch((err) => {
+        showToast({
+          variant: 'destructive',
+          title: t('commandPalette.executeFail', {
+            defaultValue: 'Tidak dapat menjalankan perintah',
+          }),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, 0);
+  };
+
+  const showHint = !hasQuery && visibleActions.length === 0 && visibleRoutes.length === 0;
+  const showBusy = hasDataQuery && busy;
+  const showEmpty =
+    hasQuery &&
+    !showBusy &&
+    totalDataHits === 0 &&
+    visibleRoutes.length === 0 &&
+    visibleActions.length === 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -167,12 +273,12 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
             value={raw}
             onValueChange={setRaw}
             placeholder={t('common:globalSearch.placeholder', {
-              defaultValue: 'Cari anggota, buku, peminjaman…',
+              defaultValue: 'Cari anggota, buku, peminjaman, halaman, perintah…',
             })}
             data-testid="global-search-input"
           />
           <CommandList>
-            {raw.trim().length < 2 ? (
+            {showHint ? (
               <div
                 className="text-muted-foreground px-4 py-6 text-center text-sm"
                 data-testid="global-search-hint"
@@ -181,7 +287,8 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
                   defaultValue: 'Ketik minimal 2 huruf untuk mencari…',
                 })}
               </div>
-            ) : busy ? (
+            ) : null}
+            {showBusy ? (
               <div
                 className="text-muted-foreground flex items-center justify-center gap-2 px-4 py-6 text-sm"
                 data-testid="global-search-busy"
@@ -189,100 +296,176 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
                 <Loader2 className="h-4 w-4 animate-spin" />
                 {t('common:globalSearch.busy', { defaultValue: 'Mencari…' })}
               </div>
-            ) : totalHits === 0 ? (
+            ) : null}
+            {showEmpty ? (
               <CommandEmpty data-testid="global-search-empty">
                 {t('common:globalSearch.empty', {
                   defaultValue: 'Tidak ada hasil yang cocok.',
                 })}
               </CommandEmpty>
-            ) : (
-              <>
-                {results.anggota.length > 0 && (
-                  <CommandGroup
-                    heading={t('common:globalSearch.groupAnggota', {
-                      defaultValue: 'Anggota',
-                    })}
+            ) : null}
+            {hasDataQuery && results.anggota.length > 0 && (
+              <CommandGroup
+                heading={t('common:globalSearch.groupAnggota', {
+                  defaultValue: 'Anggota',
+                })}
+              >
+                {results.anggota.map((hit) => (
+                  <CommandItem
+                    key={hit.key}
+                    value={hit.key}
+                    onSelect={() => handleActivate(hit)}
+                    data-testid={`global-search-item-${hit.key}`}
                   >
-                    {results.anggota.map((hit) => (
+                    <UserIcon className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate">{hit.primary}</span>
+                      {hit.secondary && (
+                        <span className="text-muted-foreground truncate text-xs">
+                          {hit.secondary}
+                        </span>
+                      )}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {hasDataQuery && results.buku.length > 0 && (
+              <>
+                {results.anggota.length > 0 && <CommandSeparator />}
+                <CommandGroup
+                  heading={t('common:globalSearch.groupBuku', {
+                    defaultValue: 'Buku',
+                  })}
+                >
+                  {results.buku.map((hit) => (
+                    <CommandItem
+                      key={hit.key}
+                      value={hit.key}
+                      onSelect={() => handleActivate(hit)}
+                      data-testid={`global-search-item-${hit.key}`}
+                    >
+                      <BookOpen className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate">{hit.primary}</span>
+                        {hit.secondary && (
+                          <span className="text-muted-foreground truncate text-xs">
+                            {hit.secondary}
+                          </span>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+            {hasDataQuery && results.peminjaman.length > 0 && (
+              <>
+                {(results.anggota.length > 0 || results.buku.length > 0) && (
+                  <CommandSeparator />
+                )}
+                <CommandGroup
+                  heading={t('common:globalSearch.groupPeminjaman', {
+                    defaultValue: 'Peminjaman',
+                  })}
+                >
+                  {results.peminjaman.map((hit) => (
+                    <CommandItem
+                      key={hit.key}
+                      value={hit.key}
+                      onSelect={() => handleActivate(hit)}
+                      data-testid={`global-search-item-${hit.key}`}
+                    >
+                      <Calendar className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate">{hit.primary}</span>
+                        {hit.secondary && (
+                          <span className="text-muted-foreground truncate text-xs">
+                            {hit.secondary}
+                          </span>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+            {visibleRoutes.length > 0 && (
+              <>
+                {hasDataQuery && totalDataHits > 0 && <CommandSeparator />}
+                <CommandGroup
+                  heading={t('common:globalSearch.groupRoutes', {
+                    defaultValue: 'Halaman',
+                  })}
+                >
+                  {visibleRoutes.map((entry) => {
+                    const Icon = entry.icon;
+                    const label = t(`commandPalette.route.${entry.key}.label`, {
+                      defaultValue: entry.key,
+                    });
+                    const description = t(`commandPalette.route.${entry.key}.description`, {
+                      defaultValue: '',
+                    });
+                    return (
                       <CommandItem
-                        key={hit.key}
-                        value={hit.key}
-                        onSelect={() => handleActivate(hit)}
-                        data-testid={`global-search-item-${hit.key}`}
+                        key={`route:${entry.key}`}
+                        value={`route:${entry.key}`}
+                        onSelect={() => handleRoute(entry)}
+                        data-testid={`global-search-route-${entry.key}`}
                       >
-                        <UserIcon className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+                        <Icon className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
                         <div className="flex min-w-0 flex-col">
-                          <span className="truncate">{hit.primary}</span>
-                          {hit.secondary && (
+                          <span className="truncate">{label}</span>
+                          {description && (
                             <span className="text-muted-foreground truncate text-xs">
-                              {hit.secondary}
+                              {description}
                             </span>
                           )}
                         </div>
                       </CommandItem>
-                    ))}
-                  </CommandGroup>
+                    );
+                  })}
+                </CommandGroup>
+              </>
+            )}
+            {visibleActions.length > 0 && (
+              <>
+                {(visibleRoutes.length > 0 || (hasDataQuery && totalDataHits > 0)) && (
+                  <CommandSeparator />
                 )}
-                {results.buku.length > 0 && (
-                  <>
-                    {results.anggota.length > 0 && <CommandSeparator />}
-                    <CommandGroup
-                      heading={t('common:globalSearch.groupBuku', {
-                        defaultValue: 'Buku',
-                      })}
-                    >
-                      {results.buku.map((hit) => (
-                        <CommandItem
-                          key={hit.key}
-                          value={hit.key}
-                          onSelect={() => handleActivate(hit)}
-                          data-testid={`global-search-item-${hit.key}`}
-                        >
-                          <BookOpen className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
-                          <div className="flex min-w-0 flex-col">
-                            <span className="truncate">{hit.primary}</span>
-                            {hit.secondary && (
-                              <span className="text-muted-foreground truncate text-xs">
-                                {hit.secondary}
-                              </span>
-                            )}
-                          </div>
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </>
-                )}
-                {results.peminjaman.length > 0 && (
-                  <>
-                    {(results.anggota.length > 0 || results.buku.length > 0) && (
-                      <CommandSeparator />
-                    )}
-                    <CommandGroup
-                      heading={t('common:globalSearch.groupPeminjaman', {
-                        defaultValue: 'Peminjaman',
-                      })}
-                    >
-                      {results.peminjaman.map((hit) => (
-                        <CommandItem
-                          key={hit.key}
-                          value={hit.key}
-                          onSelect={() => handleActivate(hit)}
-                          data-testid={`global-search-item-${hit.key}`}
-                        >
-                          <Calendar className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
-                          <div className="flex min-w-0 flex-col">
-                            <span className="truncate">{hit.primary}</span>
-                            {hit.secondary && (
-                              <span className="text-muted-foreground truncate text-xs">
-                                {hit.secondary}
-                              </span>
-                            )}
-                          </div>
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </>
-                )}
+                <CommandGroup
+                  heading={t('common:globalSearch.groupActions', {
+                    defaultValue: 'Aksi Cepat',
+                  })}
+                >
+                  {visibleActions.map((entry) => {
+                    const Icon = entry.icon;
+                    const label = t(`commandPalette.action.${entry.key}.label`, {
+                      defaultValue: entry.key,
+                    });
+                    const description = t(`commandPalette.action.${entry.key}.description`, {
+                      defaultValue: '',
+                    });
+                    return (
+                      <CommandItem
+                        key={`action:${entry.key}`}
+                        value={`action:${entry.key}`}
+                        onSelect={() => handleAction(entry)}
+                        data-testid={`global-search-action-${entry.key}`}
+                      >
+                        <Icon className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+                        <div className="flex min-w-0 flex-col">
+                          <span className="truncate">{label}</span>
+                          {description && (
+                            <span className="text-muted-foreground truncate text-xs">
+                              {description}
+                            </span>
+                          )}
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
               </>
             )}
           </CommandList>

--- a/apps/desktop/src/components/layout/commandPaletteRegistry.ts
+++ b/apps/desktop/src/components/layout/commandPaletteRegistry.ts
@@ -1,0 +1,223 @@
+/**
+ * Command palette registry (A1-CommandPalette, v1.1.0).
+ *
+ * Static lists of in-app routes and quick actions surfaced through the
+ * `GlobalSearchDialog` command palette. Other features can reference these
+ * lists to keep their own static UI (sidebar, settings menu, etc.) in sync,
+ * or extend the registry with `addCommandPaletteAction` to register
+ * feature-specific actions (e.g. FEAT-Sirkulasi-Search → "Mulai Sirkulasi",
+ * D5-SandboxDemoMode → "Toggle Mode Demo").
+ *
+ * The registry intentionally avoids importing React components (icons are
+ * passed in as React types) so feature modules can register entries lazily
+ * without pulling the renderer into their bundle.
+ */
+import type { ComponentType } from 'react';
+import type { TFunction } from 'i18next';
+import {
+  ArrowLeftRight,
+  BarChart3,
+  BookOpen,
+  BookMarked,
+  CalendarCheck,
+  ClipboardList,
+  Database,
+  FileBarChart,
+  FilePlus,
+  HardDriveDownload,
+  Heart,
+  History,
+  IdCard,
+  LayoutDashboard,
+  LogOut,
+  Moon,
+  Monitor,
+  ScanLine,
+  Settings,
+  Undo2,
+  UserPlus,
+  Users,
+} from 'lucide-react';
+
+import { useThemeStore } from '@/stores/themeStore';
+import { settingsApi } from '@/lib/settings';
+import { logoutRequest } from '@/lib/auth';
+import { useAuthStore } from '@/stores/authStore';
+
+export type CommandPaletteIcon = ComponentType<{ className?: string }>;
+
+export interface CommandPaletteRouteEntry {
+  /** Stable identifier — also used as the i18n key suffix and registry key. */
+  key: string;
+  /** Path passed to `navigate({ to })`. */
+  to: string;
+  /** Lucide icon shown next to the label. */
+  icon: CommandPaletteIcon;
+}
+
+export interface CommandPaletteActionContext {
+  /** Type kept loose so feature modules don't need to import the router. */
+  navigate: (path: string) => void;
+  showToast: (input: { title: string; description?: string; variant?: 'default' | 'destructive' }) => void;
+  t: TFunction;
+}
+
+export interface CommandPaletteActionEntry {
+  /** Stable identifier — also used as the i18n key suffix and registry key. */
+  key: string;
+  /** Lucide icon shown next to the label. */
+  icon: CommandPaletteIcon;
+  /**
+   * Invoked AFTER the dialog closes. Implementations may be async; callers
+   * should not await — long-running work should be fired-and-forgotten and
+   * surface progress via toasts.
+   */
+  execute: (ctx: CommandPaletteActionContext) => void | Promise<void>;
+}
+
+/**
+ * Default routes surfaced when the user opens the palette. Order is the
+ * default rendering order; the first 6 entries are surfaced when the query
+ * is empty (the "Halaman" group).
+ */
+export const COMMAND_PALETTE_ROUTES: readonly CommandPaletteRouteEntry[] = [
+  { key: 'dashboard', to: '/dashboard', icon: LayoutDashboard },
+  { key: 'anggota', to: '/anggota', icon: Users },
+  { key: 'buku', to: '/buku', icon: BookOpen },
+  { key: 'peminjaman', to: '/peminjaman', icon: ArrowLeftRight },
+  { key: 'sirkulasi', to: '/sirkulasi', icon: ScanLine },
+  { key: 'laporan', to: '/laporan', icon: BarChart3 },
+  { key: 'pengembalian', to: '/pengembalian', icon: Undo2 },
+  { key: 'reservasi', to: '/reservasi', icon: BookMarked },
+  { key: 'wishlist', to: '/wishlist', icon: Heart },
+  { key: 'stocktake', to: '/stocktake', icon: ClipboardList },
+  { key: 'kunjungan', to: '/kunjungan', icon: CalendarCheck },
+  { key: 'settings', to: '/settings', icon: Settings },
+  { key: 'backup', to: '/laporan/backup', icon: HardDriveDownload },
+  { key: 'auditLog', to: '/settings/audit-log', icon: History },
+  { key: 'kta', to: '/settings/kta', icon: IdCard },
+  { key: 'manual', to: '/settings/manual', icon: BookOpen },
+  { key: 'tentang', to: '/settings/tentang', icon: Database },
+] as const;
+
+/** Number of entries from `COMMAND_PALETTE_ROUTES` shown when query is empty. */
+export const COMMAND_PALETTE_DEFAULT_ROUTE_LIMIT = 6;
+
+/**
+ * Built-in quick actions. Order is the default rendering order. Feature
+ * modules can append their own via `addCommandPaletteAction(entry)` —
+ * registrations are processed lazily so call sites don't need to ship
+ * anything at import time.
+ */
+const BUILTIN_ACTIONS: CommandPaletteActionEntry[] = [
+  {
+    key: 'backupSekarang',
+    icon: HardDriveDownload,
+    execute: ({ navigate, showToast, t }) => {
+      navigate('/laporan/backup');
+      showToast({
+        title: t('commandPalette.action.backupSekarang.toast'),
+      });
+    },
+  },
+  {
+    key: 'cetakLaporanBulanan',
+    icon: FileBarChart,
+    execute: ({ navigate }) => {
+      navigate('/laporan');
+    },
+  },
+  {
+    key: 'tambahAnggota',
+    icon: UserPlus,
+    execute: ({ navigate }) => {
+      navigate('/anggota/new');
+    },
+  },
+  {
+    key: 'tambahBuku',
+    icon: FilePlus,
+    execute: ({ navigate }) => {
+      navigate('/buku/new');
+    },
+  },
+  {
+    key: 'tambahPeminjaman',
+    icon: ArrowLeftRight,
+    execute: ({ navigate }) => {
+      navigate('/peminjaman/new');
+    },
+  },
+  {
+    key: 'toggleTheme',
+    icon: Moon,
+    execute: ({ showToast, t }) => {
+      const state = useThemeStore.getState();
+      const next = state.resolved === 'dark' ? 'light' : 'dark';
+      state.setTheme(next);
+      showToast({
+        title: t(`commandPalette.action.toggleTheme.toast.${next}`),
+      });
+    },
+  },
+  {
+    key: 'bukaOpac',
+    icon: Monitor,
+    execute: async ({ showToast, t }) => {
+      try {
+        await settingsApi.saveAppMode('public');
+        if (typeof window !== 'undefined') {
+          window.location.reload();
+        }
+      } catch (err) {
+        showToast({
+          variant: 'destructive',
+          title: t('commandPalette.action.bukaOpac.fail'),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  },
+  {
+    key: 'logout',
+    icon: LogOut,
+    execute: async ({ showToast, t }) => {
+      try {
+        await logoutRequest();
+        useAuthStore.getState().logout();
+      } catch (err) {
+        showToast({
+          variant: 'destructive',
+          title: t('commandPalette.action.logout.fail'),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  },
+];
+
+const extraActions: CommandPaletteActionEntry[] = [];
+
+/**
+ * Append a feature-owned action to the registry. Subsequent reads of
+ * `getCommandPaletteActions()` will include the registered entry. Calling
+ * with the same `key` replaces any previous registration.
+ */
+export function addCommandPaletteAction(entry: CommandPaletteActionEntry): void {
+  const existing = extraActions.findIndex((a) => a.key === entry.key);
+  if (existing >= 0) {
+    extraActions.splice(existing, 1, entry);
+  } else {
+    extraActions.push(entry);
+  }
+}
+
+/** Return the union of built-in + feature-registered actions in declared order. */
+export function getCommandPaletteActions(): readonly CommandPaletteActionEntry[] {
+  return [...BUILTIN_ACTIONS, ...extraActions];
+}
+
+/** Test helper — wipes runtime registrations without affecting built-ins. */
+export function _clearExtraCommandPaletteActions(): void {
+  extraActions.length = 0;
+}

--- a/apps/desktop/src/i18n/en/common.json
+++ b/apps/desktop/src/i18n/en/common.json
@@ -34,7 +34,9 @@
     "groupAnggota": "Members",
     "groupBuku": "Books",
     "groupPeminjaman": "Loans",
-    "footerHint": "Enter to open • ↑↓ to navigate • Esc to close"
+    "footerHint": "Enter to open • ↑↓ to navigate • Esc to close",
+    "groupRoutes": "Pages",
+    "groupActions": "Quick Actions"
   },
   "states": {
     "loading": "Loading…",
@@ -154,5 +156,119 @@
   "scanner": {
     "handScannerDetected": "USB hand-scanner detected",
     "handScannerHint": "USB hand-scanner is ready — focus the scan field and pull the trigger."
+  },
+  "commandPalette": {
+    "executeFail": "Failed to execute command",
+    "route": {
+      "dashboard": {
+        "label": "Dashboard",
+        "description": "KPI summary and recent activity"
+      },
+      "anggota": {
+        "label": "Members",
+        "description": "Manage member records"
+      },
+      "buku": {
+        "label": "Books",
+        "description": "Manage book catalog"
+      },
+      "peminjaman": {
+        "label": "Loans",
+        "description": "Active loans and history"
+      },
+      "sirkulasi": {
+        "label": "Circulation (Webcam)",
+        "description": "Scan KTA/books via camera"
+      },
+      "laporan": {
+        "label": "Reports",
+        "description": "Stats, top borrowers, cashbook, charts"
+      },
+      "pengembalian": {
+        "label": "Returns",
+        "description": "Record returns and overdue fines"
+      },
+      "reservasi": {
+        "label": "Reservations",
+        "description": "Book hold queue"
+      },
+      "wishlist": {
+        "label": "Wishlist",
+        "description": "Member title requests"
+      },
+      "stocktake": {
+        "label": "Stocktake",
+        "description": "Physical inventory check"
+      },
+      "kunjungan": {
+        "label": "Visits",
+        "description": "Record daily visits"
+      },
+      "settings": {
+        "label": "Settings",
+        "description": "Application configuration"
+      },
+      "backup": {
+        "label": "Backup",
+        "description": "Backup and restore database"
+      },
+      "auditLog": {
+        "label": "Audit Log",
+        "description": "System activity"
+      },
+      "kta": {
+        "label": "Member Card",
+        "description": "Print member ID cards"
+      },
+      "manual": {
+        "label": "Manual",
+        "description": "User guide"
+      },
+      "tentang": {
+        "label": "About",
+        "description": "Application version and license"
+      }
+    },
+    "action": {
+      "backupSekarang": {
+        "label": "Backup Now",
+        "description": "Open backup page",
+        "toast": "Opening backup page…"
+      },
+      "cetakLaporanBulanan": {
+        "label": "Print Monthly Report",
+        "description": "Open the reports hub"
+      },
+      "tambahAnggota": {
+        "label": "Add Member",
+        "description": "Open the new-member form"
+      },
+      "tambahBuku": {
+        "label": "Add Book",
+        "description": "Open the new-book form"
+      },
+      "tambahPeminjaman": {
+        "label": "Add Loan",
+        "description": "Start a new loan transaction"
+      },
+      "toggleTheme": {
+        "label": "Toggle Theme",
+        "description": "Switch between light and dark",
+        "toast": {
+          "light": "Theme switched to light",
+          "dark": "Theme switched to dark"
+        }
+      },
+      "bukaOpac": {
+        "label": "Open OPAC Mode",
+        "description": "Switch to public catalog (reload required)",
+        "fail": "Failed to open OPAC mode"
+      },
+      "logout": {
+        "label": "Sign Out",
+        "description": "End librarian session",
+        "fail": "Failed to sign out"
+      }
+    }
   }
 }

--- a/apps/desktop/src/i18n/id/common.json
+++ b/apps/desktop/src/i18n/id/common.json
@@ -34,7 +34,9 @@
     "groupAnggota": "Anggota",
     "groupBuku": "Buku",
     "groupPeminjaman": "Peminjaman",
-    "footerHint": "Enter untuk buka • ↑↓ navigasi • Esc tutup"
+    "footerHint": "Enter untuk buka • ↑↓ navigasi • Esc tutup",
+    "groupRoutes": "Halaman",
+    "groupActions": "Aksi Cepat"
   },
   "states": {
     "loading": "Memuat…",
@@ -154,5 +156,119 @@
   "scanner": {
     "handScannerDetected": "Hand-scanner USB terdeteksi",
     "handScannerHint": "Hand-scanner USB siap digunakan — fokuskan ke kolom scan dan pindai barcode."
+  },
+  "commandPalette": {
+    "executeFail": "Tidak dapat menjalankan perintah",
+    "route": {
+      "dashboard": {
+        "label": "Dashboard",
+        "description": "Ringkasan KPI dan aktivitas terkini"
+      },
+      "anggota": {
+        "label": "Anggota",
+        "description": "Kelola data anggota"
+      },
+      "buku": {
+        "label": "Buku",
+        "description": "Kelola katalog buku"
+      },
+      "peminjaman": {
+        "label": "Peminjaman",
+        "description": "Daftar dan transaksi peminjaman"
+      },
+      "sirkulasi": {
+        "label": "Sirkulasi (Webcam)",
+        "description": "Pindai KTA/buku via kamera"
+      },
+      "laporan": {
+        "label": "Laporan",
+        "description": "Statistik, top peminjam, kas, grafik"
+      },
+      "pengembalian": {
+        "label": "Pengembalian",
+        "description": "Catat pengembalian dan denda"
+      },
+      "reservasi": {
+        "label": "Reservasi",
+        "description": "Antrean pemesanan buku"
+      },
+      "wishlist": {
+        "label": "Wishlist",
+        "description": "Usulan judul baru dari anggota"
+      },
+      "stocktake": {
+        "label": "Stocktake",
+        "description": "Inventaris fisik koleksi"
+      },
+      "kunjungan": {
+        "label": "Kunjungan",
+        "description": "Catat kunjungan harian"
+      },
+      "settings": {
+        "label": "Pengaturan",
+        "description": "Konfigurasi aplikasi"
+      },
+      "backup": {
+        "label": "Backup",
+        "description": "Backup dan restore database"
+      },
+      "auditLog": {
+        "label": "Audit Log",
+        "description": "Aktivitas sistem"
+      },
+      "kta": {
+        "label": "KTA",
+        "description": "Cetak kartu tanda anggota"
+      },
+      "manual": {
+        "label": "Manual",
+        "description": "Buku panduan pengguna"
+      },
+      "tentang": {
+        "label": "Tentang",
+        "description": "Versi aplikasi dan lisensi"
+      }
+    },
+    "action": {
+      "backupSekarang": {
+        "label": "Backup Sekarang",
+        "description": "Buka halaman backup",
+        "toast": "Membuka halaman backup…"
+      },
+      "cetakLaporanBulanan": {
+        "label": "Cetak Laporan Bulanan",
+        "description": "Buka pusat laporan"
+      },
+      "tambahAnggota": {
+        "label": "Tambah Anggota",
+        "description": "Buka formulir anggota baru"
+      },
+      "tambahBuku": {
+        "label": "Tambah Buku",
+        "description": "Buka formulir buku baru"
+      },
+      "tambahPeminjaman": {
+        "label": "Tambah Peminjaman",
+        "description": "Buka transaksi peminjaman baru"
+      },
+      "toggleTheme": {
+        "label": "Ganti Tema",
+        "description": "Beralih antara mode terang dan gelap",
+        "toast": {
+          "light": "Tema diubah ke terang",
+          "dark": "Tema diubah ke gelap"
+        }
+      },
+      "bukaOpac": {
+        "label": "Buka Mode OPAC",
+        "description": "Beralih ke katalog publik (memuat ulang)",
+        "fail": "Gagal membuka mode OPAC"
+      },
+      "logout": {
+        "label": "Keluar",
+        "description": "Akhiri sesi pustakawan",
+        "fail": "Gagal keluar"
+      }
+    }
   }
 }

--- a/apps/desktop/tests/unit/commandPalette.test.tsx
+++ b/apps/desktop/tests/unit/commandPalette.test.tsx
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
+
+import { GlobalSearchDialog } from '@/components/layout/GlobalSearchDialog';
+import {
+  COMMAND_PALETTE_ROUTES,
+  addCommandPaletteAction,
+  _clearExtraCommandPaletteActions,
+} from '@/components/layout/commandPaletteRegistry';
+import { ToastManagerProvider } from '@/components/ui/toast-manager';
+
+const navigateMock = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/lib/anggota', () => ({
+  anggotaApi: {
+    list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+  },
+}));
+
+vi.mock('@/lib/buku', () => ({
+  bukuApi: {
+    list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+  },
+}));
+
+vi.mock('@/lib/peminjaman', () => ({
+  peminjamanApi: {
+    list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+  },
+}));
+
+function Wrap({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <ToastManagerProvider>{children}</ToastManagerProvider>
+    </I18nextProvider>
+  );
+}
+
+describe('GlobalSearchDialog command palette (A1-CommandPalette)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+  });
+
+  afterEach(() => {
+    _clearExtraCommandPaletteActions();
+  });
+
+  it('shows Quick Actions and Pages groups when query is empty (no data search)', () => {
+    render(
+      <Wrap>
+        <GlobalSearchDialog open onOpenChange={() => {}} />
+      </Wrap>,
+    );
+    // Default Halaman group surfaces top 6 routes
+    const expectedKeys = COMMAND_PALETTE_ROUTES.slice(0, 6).map((r) => r.key);
+    for (const key of expectedKeys) {
+      expect(
+        screen.getByTestId(`global-search-route-${key}`),
+        `route ${key} should render in default empty state`,
+      ).toBeInTheDocument();
+    }
+    // Aksi Cepat shows >= 8 actions including the 4 we always ship
+    for (const key of [
+      'backupSekarang',
+      'tambahAnggota',
+      'toggleTheme',
+      'logout',
+    ]) {
+      expect(
+        screen.getByTestId(`global-search-action-${key}`),
+        `action ${key} should render in default empty state`,
+      ).toBeInTheDocument();
+    }
+    // Hint must NOT render when registry already provides hits
+    expect(screen.queryByTestId('global-search-hint')).not.toBeInTheDocument();
+  });
+
+  it('matches "back" against the Backup quick action and the Backup route', async () => {
+    render(
+      <Wrap>
+        <GlobalSearchDialog open onOpenChange={() => {}} />
+      </Wrap>,
+    );
+    const input = screen.getByTestId('global-search-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'back' } });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('global-search-action-backupSekarang'),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('global-search-route-backup')).toBeInTheDocument();
+    // Routes that don't match should not render
+    expect(screen.queryByTestId('global-search-route-stocktake')).not.toBeInTheDocument();
+  });
+
+  it('navigates when a route entry is selected', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Wrap>
+        <GlobalSearchDialog open onOpenChange={onOpenChange} />
+      </Wrap>,
+    );
+    fireEvent.click(screen.getByTestId('global-search-route-anggota'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/anggota' });
+  });
+
+  it('runs the registered execute callback when an action is selected', async () => {
+    const onOpenChange = vi.fn();
+    const execute = vi.fn();
+    addCommandPaletteAction({
+      key: 'testAction',
+      icon: () => null as unknown as JSX.Element,
+      execute,
+    });
+    render(
+      <Wrap>
+        <GlobalSearchDialog open onOpenChange={onOpenChange} />
+      </Wrap>,
+    );
+    const item = await screen.findByTestId('global-search-action-testAction');
+    fireEvent.click(item);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    // execute fires after the dialog closes (setTimeout 0)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    const ctx = execute.mock.calls[0]?.[0];
+    expect(ctx).toBeDefined();
+    expect(typeof ctx.navigate).toBe('function');
+    expect(typeof ctx.showToast).toBe('function');
+    expect(typeof ctx.t).toBe('function');
+  });
+
+  it('does not crash when query has no data matches (only routes/actions)', async () => {
+    render(
+      <Wrap>
+        <GlobalSearchDialog open onOpenChange={() => {}} />
+      </Wrap>,
+    );
+    const input = screen.getByTestId('global-search-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'back' } });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('global-search-action-backupSekarang'),
+      ).toBeInTheDocument();
+    });
+    // Empty banner must NOT render because routes/actions are present
+    expect(screen.queryByTestId('global-search-empty')).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/tests/unit/setup.ts
+++ b/apps/desktop/tests/unit/setup.ts
@@ -1,6 +1,26 @@
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 
+// jsdom doesn't ship ResizeObserver — stub it so cmdk (command palette) renders
+if (typeof globalThis !== 'undefined' && !('ResizeObserver' in globalThis)) {
+  class ResizeObserverStub {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub;
+}
+
+// jsdom doesn't ship scrollIntoView — stub on the prototype so cmdk's
+// auto-scroll on selection doesn't blow up.
+if (
+  typeof window !== 'undefined' &&
+  typeof window.HTMLElement !== 'undefined' &&
+  !window.HTMLElement.prototype.scrollIntoView
+) {
+  window.HTMLElement.prototype.scrollIntoView = function scrollIntoViewStub(): void {};
+}
+
 // jsdom doesn't ship matchMedia — stub it for theme store
 if (typeof window !== 'undefined' && !window.matchMedia) {
   Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## Summary

Turn `GlobalSearchDialog` into a true command palette — adds in-app route navigation and quick-action commands on top of the existing anggota/buku/peminjaman data search. Implements **A1-CommandPalette** from the v1.1.0 batch.

Spec: `.devin/handoff/v1.1.0/BUGS.md` lines 672–745.

## What changed

- **`apps/desktop/src/components/layout/commandPaletteRegistry.ts` (new)** — exports `COMMAND_PALETTE_ROUTES` (17 in-app pages) and a built-in action list (8 quick actions: Backup Sekarang, Cetak Laporan Bulanan, Tambah Anggota/Buku/Peminjaman, Toggle Tema, Buka OPAC, Logout). Other features can call `addCommandPaletteAction(entry)` to register feature-owned actions (e.g. D5-DemoMode will register "Toggle Mode Demo" once it ships).
- **`GlobalSearchDialog.tsx`** — fuzzy-matches routes + actions against the query and renders them as additional `CommandGroup`s. Empty-state shows `Halaman` (top 6 routes) + `Aksi Cepat` (all actions); on `≥ 2`-char queries the existing data search runs in parallel and groups render in order: anggota → buku → peminjaman → routes → actions. Action callbacks are deferred via `setTimeout(0)` so dialog close completes before any toast/navigation, preventing focus loss.
- **i18n** — adds `commandPalette.{route,action}.<key>.{label,description}` and `globalSearch.group{Routes,Actions}` keys in both `id/` and `en/` (passes `i18n:lint`).
- **Tests** — `commandPalette.test.tsx` with 5 cases: default groups when query empty, "back" surfaces Backup action + Backup route, route entry navigates, action callback receives navigate/showToast/t context, no crash when only routes/actions match.
- **Test setup** — `tests/unit/setup.ts` gains `ResizeObserver` and `HTMLElement.prototype.scrollIntoView` polyfills so cmdk renders under jsdom.

## Acceptance criteria checklist

- [x] Ctrl/Cmd+K opens dialog (existing behavior unchanged via `Header.tsx` shortcut).
- [x] Empty query shows `Aksi Cepat` (≥8 actions) + `Halaman` (top 6 routes), no data search.
- [x] Typing "back" matches Backup Sekarang action and Backup route.
- [x] Typing "lapor" matches Laporan route + Cetak Laporan Bulanan action.
- [x] Typing "ali" still hits anggota search.
- [x] Group ordering: anggota / buku / peminjaman / routes / actions.
- [x] Keyboard nav (↑/↓/Enter/Esc) preserved by cmdk.
- [x] All labels go through i18n; `pnpm i18n:lint` is green.
- [x] Action `execute` fires AFTER dialog closes (deferred via `setTimeout(0)`).

## Notes

- "Toggle Mode Demo" is intentionally **not** registered yet because **D5-SandboxDemoMode** is still OPEN — D5 will own its registration via `addCommandPaletteAction(...)` so this PR doesn't ship a stub.
- "Backup Sekarang" navigates to `/laporan/backup` rather than firing `backupApi.runNow()` directly because the existing backup helper requires an interactive folder picker; firing it from the palette would dead-end without UI. Left a path for D1/future to swap in a no-prompt backup once one exists.

## Gates (all green locally)

- `pnpm typecheck` — OK
- `pnpm lint --max-warnings=0` — OK
- `pnpm i18n:lint` — OK across all namespaces
- `pnpm test` — 62 files / 551 tests pass (5 new)
- `pnpm build` — OK (warnings are pre-existing dynamic-import / 500kB chunk hints, not from this PR)

## Risks

- `GlobalSearchDialog.tsx` is shared infra; refactor is additive and the existing data-search code path is preserved unchanged. The existing `globalSearchDialog.test.tsx` (12 cases) still passes.
- No changes to the `Ctrl+K` keyboard shortcut wiring in `Header.tsx`.
- New polyfills in `tests/unit/setup.ts` are guarded by `if (!('ResizeObserver' in globalThis))` so they don't override jsdom upgrades.

## Followups for downstream items

- D5-SandboxDemoMode → call `addCommandPaletteAction({ key: 'toggleDemoMode', ... })`.
- C1-LaporanEksekutifPDF → optionally register a "Cetak Laporan Eksekutif PDF" action that runs the report directly (no navigation).
- FEAT-Sirkulasi-Search → optional "Mulai Sirkulasi" action.
