### PR TITLE
feat(loading): replace spinners with skeleton placeholders (A2-SkeletonScreens)

### DIFF
--- a/apps/desktop/src/components/shared/CardSkeleton.tsx
+++ b/apps/desktop/src/components/shared/CardSkeleton.tsx
@@ -1,0 +1,56 @@
+/**
+ * Card-grid skeleton loader (A2-SkeletonScreens, v1.1.0).
+ *
+ * Renders a responsive grid of card-shaped placeholders matching the OPAC
+ * book grid layout. Honors `prefers-reduced-motion` by suppressing the
+ * pulse animation when the OS asks us to.
+ */
+import * as React from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+export interface CardSkeletonProps {
+  /** Number of placeholder cards to render. Defaults to 12. */
+  count?: number;
+  /** Optional Tailwind classes for the grid container. Override layout. */
+  gridClassName?: string;
+  /** Optional Tailwind classes for each card. */
+  cardClassName?: string;
+  /** Override the test id. */
+  'data-testid'?: string;
+}
+
+const DEFAULT_GRID =
+  'grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6';
+
+export function CardSkeleton({
+  count = 12,
+  gridClassName,
+  cardClassName,
+  'data-testid': testId = 'card-skeleton',
+}: CardSkeletonProps): React.ReactElement {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      data-testid={testId}
+      className={cn(gridClassName ?? DEFAULT_GRID)}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          data-testid="card-skeleton-item"
+          className={cn(
+            'flex flex-col gap-2 rounded-md border border-border/60 bg-card p-3 shadow-sm',
+            cardClassName,
+          )}
+        >
+          <Skeleton className="aspect-[3/4] w-full motion-reduce:animate-none" />
+          <Skeleton className="h-4 w-3/4 motion-reduce:animate-none" />
+          <Skeleton className="h-3 w-1/2 motion-reduce:animate-none" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/shared/DataTable.tsx
+++ b/apps/desktop/src/components/shared/DataTable.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ArrowDownAZ, ArrowUpAZ, ChevronsUpDown } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   Table,
   TableBody,
@@ -9,6 +10,9 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
+
+const SKELETON_WIDTHS = ['w-32', 'w-48', 'w-24', 'w-40', 'w-20'] as const;
+const DEFAULT_SKELETON_ROWS = 8;
 
 export interface DataTableColumn<T> {
   key: string;
@@ -108,11 +112,25 @@ export function DataTable<T>({
         </TableHeader>
         <TableBody>
           {isLoading ? (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="py-10 text-center text-muted-foreground">
-                Memuat…
-              </TableCell>
-            </TableRow>
+            Array.from({ length: DEFAULT_SKELETON_ROWS }).map((_, r) => (
+              <TableRow
+                key={`skeleton-${r}`}
+                aria-busy="true"
+                aria-hidden="true"
+                data-testid="data-table-skeleton-row"
+              >
+                {columns.map((col, ci) => (
+                  <TableCell key={col.key} className={col.cellClassName}>
+                    <Skeleton
+                      className={cn(
+                        'h-4 motion-reduce:animate-none',
+                        SKELETON_WIDTHS[ci % SKELETON_WIDTHS.length],
+                      )}
+                    />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
           ) : rows.length === 0 ? (
             <TableRow>
               <TableCell colSpan={columns.length} className="py-10 text-center text-muted-foreground">

--- a/apps/desktop/src/components/shared/TableSkeleton.tsx
+++ b/apps/desktop/src/components/shared/TableSkeleton.tsx
@@ -1,0 +1,68 @@
+/**
+ * Table-shaped skeleton loader (A2-SkeletonScreens, v1.1.0).
+ *
+ * Renders a `<table>` with the same column/row structure as the eventual
+ * data so the user perceives the page as "loaded" much faster than a
+ * centered spinner. Honors `prefers-reduced-motion` by suppressing the
+ * pulse animation when the OS asks us to.
+ */
+import * as React from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+export interface TableSkeletonProps {
+  /** Number of `<td>` per row. Required so the placeholder shape matches. */
+  columns: number;
+  /** Number of placeholder rows to render. Defaults to 8. */
+  rows?: number;
+  /** Optional Tailwind width hints, one per column (cycled if shorter). */
+  widths?: ReadonlyArray<string>;
+  /** Optional class on the wrapping container. */
+  className?: string;
+  /** Override the test id. */
+  'data-testid'?: string;
+}
+
+const DEFAULT_WIDTHS: readonly string[] = [
+  'w-32',
+  'w-48',
+  'w-24',
+  'w-40',
+  'w-20',
+];
+
+export function TableSkeleton({
+  columns,
+  rows = 8,
+  widths,
+  className,
+  'data-testid': testId = 'table-skeleton',
+}: TableSkeletonProps): React.ReactElement {
+  const widthFor = (col: number): string => {
+    const list = widths && widths.length > 0 ? widths : DEFAULT_WIDTHS;
+    return list[col % list.length] ?? 'w-32';
+  };
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      data-testid={testId}
+      className={cn('w-full', className)}
+    >
+      <table className="w-full border-collapse">
+        <tbody>
+          {Array.from({ length: rows }).map((_, r) => (
+            <tr key={r} className="border-b border-border/40 last:border-b-0">
+              {Array.from({ length: columns }).map((__, c) => (
+                <td key={c} className="px-3 py-3">
+                  <Skeleton className={cn('h-4 motion-reduce:animate-none', widthFor(c))} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/opac/OpacHomePage.tsx
+++ b/apps/desktop/src/features/opac/OpacHomePage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { BookOpen, ChevronLeft, ChevronRight, ScanLine, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { CardSkeleton } from '@/components/shared/CardSkeleton';
 import { OpacBookCard } from './OpacBookCard';
 import { OpacBookDetailDialog } from './OpacBookDetailDialog';
 import { bukuApi, type Buku } from '@/lib/buku';
@@ -123,7 +124,10 @@ export function OpacHomePage({ onSearch, onScanKta, libraryName, member, onReser
           )}
         </div>
         {loading ? (
-          <p className="text-sm text-muted-foreground">{t('search.loading')}</p>
+          <CardSkeleton
+            count={PAGE_SIZE}
+            data-testid="opac-home-card-skeleton"
+          />
         ) : books.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('search.empty')}</p>
         ) : (

--- a/apps/desktop/src/features/opac/OpacSearchPage.tsx
+++ b/apps/desktop/src/features/opac/OpacSearchPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowLeft, Heart, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { CardSkeleton } from '@/components/shared/CardSkeleton';
 import { OpacBookCard } from './OpacBookCard';
 import { OpacBookDetailDialog } from './OpacBookDetailDialog';
 import { OpacWishlistDialog } from './OpacWishlistDialog';
@@ -91,7 +92,11 @@ export function OpacSearchPage({
 
       <main className="flex-1 overflow-auto p-6">
         {loading ? (
-          <p className="text-sm text-muted-foreground">{t('search.loading')}</p>
+          <CardSkeleton
+            count={20}
+            gridClassName="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+            data-testid="opac-search-card-skeleton"
+          />
         ) : error ? (
           <p className="text-sm text-destructive">{error}</p>
         ) : items.length === 0 ? (

--- a/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
+++ b/apps/desktop/src/features/pengembalian/PengembalianPage.tsx
@@ -180,6 +180,25 @@ export function PengembalianPage() {
               )}
             </div>
             <ul className="flex max-h-[420px] flex-col gap-1 overflow-y-auto">
+              {searching && results.length === 0 && (
+                <>
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <li
+                      key={`pengembalian-skeleton-${i}`}
+                      className="flex items-center gap-3 rounded border border-border px-3 py-2"
+                      aria-busy="true"
+                      aria-hidden="true"
+                      data-testid="pengembalian-result-skeleton"
+                    >
+                      <div className="h-9 w-9 rounded-full bg-muted motion-reduce:animate-none animate-pulse" />
+                      <div className="flex min-w-0 flex-1 flex-col gap-1">
+                        <div className="h-3 w-2/3 rounded bg-muted motion-reduce:animate-none animate-pulse" />
+                        <div className="h-3 w-1/2 rounded bg-muted motion-reduce:animate-none animate-pulse" />
+                      </div>
+                    </li>
+                  ))}
+                </>
+              )}
               {results.length === 0 && !searching && (
                 <li className="rounded border border-dashed p-4 text-center text-sm text-muted-foreground">
                   {t('peminjaman:pengembalian.empty', { defaultValue: 'Tidak ada peminjaman aktif' })}

--- a/apps/desktop/tests/unit/cardSkeleton.test.tsx
+++ b/apps/desktop/tests/unit/cardSkeleton.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CardSkeleton } from '@/components/shared/CardSkeleton';
+
+describe('CardSkeleton (A2-SkeletonScreens)', () => {
+  it('renders the requested number of cards', () => {
+    render(<CardSkeleton count={6} />);
+    expect(screen.getAllByTestId('card-skeleton-item')).toHaveLength(6);
+  });
+
+  it('defaults to 12 cards when count omitted', () => {
+    render(<CardSkeleton />);
+    expect(screen.getAllByTestId('card-skeleton-item')).toHaveLength(12);
+  });
+
+  it('marks the container as aria-busy for screen readers', () => {
+    render(<CardSkeleton count={1} />);
+    const container = screen.getByTestId('card-skeleton');
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(container).toHaveAttribute('role', 'status');
+  });
+
+  it('respects an override grid className', () => {
+    render(<CardSkeleton count={1} gridClassName="grid grid-cols-1" />);
+    const container = screen.getByTestId('card-skeleton');
+    expect(container.className).toContain('grid-cols-1');
+  });
+});

--- a/apps/desktop/tests/unit/tableSkeleton.test.tsx
+++ b/apps/desktop/tests/unit/tableSkeleton.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TableSkeleton } from '@/components/shared/TableSkeleton';
+
+describe('TableSkeleton (A2-SkeletonScreens)', () => {
+  it('renders the requested number of rows × columns', () => {
+    render(<TableSkeleton columns={4} rows={3} />);
+    const cells = document.querySelectorAll('td');
+    expect(cells.length).toBe(4 * 3);
+  });
+
+  it('falls back to 8 rows when rows prop is omitted', () => {
+    render(<TableSkeleton columns={2} />);
+    const tds = document.querySelectorAll('td');
+    expect(tds.length).toBe(2 * 8);
+  });
+
+  it('honors per-column width hints', () => {
+    render(<TableSkeleton columns={3} rows={1} widths={['w-12', 'w-24', 'w-48']} />);
+    const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
+    expect(skeletons[0]?.className).toContain('w-12');
+    expect(skeletons[1]?.className).toContain('w-24');
+    expect(skeletons[2]?.className).toContain('w-48');
+  });
+
+  it('marks the container as aria-busy for screen readers', () => {
+    render(<TableSkeleton columns={1} />);
+    const container = screen.getByTestId('table-skeleton');
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(container).toHaveAttribute('role', 'status');
+  });
+
+  it('disables the pulse under prefers-reduced-motion via tailwind utility', () => {
+    render(<TableSkeleton columns={2} rows={1} />);
+    const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
+    for (const s of Array.from(skeletons)) {
+      expect(s.className).toContain('motion-reduce:animate-none');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Replace centered spinners with skeleton placeholders so list pages and OPAC card grids feel snappier. Implements **A2-SkeletonScreens** from the v1.1.0 batch (`.devin/handoff/v1.1.0/BUGS.md` lines 748–802).

## What changed

- **`apps/desktop/src/components/shared/TableSkeleton.tsx`** (new) — `<table>`-shaped placeholder with configurable `columns`, `rows` (default 8), and `widths` (per-column hints). Container is `role="status" aria-busy="true"` for screen readers.
- **`apps/desktop/src/components/shared/CardSkeleton.tsx`** (new) — responsive card-grid placeholder for OPAC book grids. Configurable `count` (default 12) and `gridClassName`. Same a11y semantics.
- **`apps/desktop/src/components/shared/DataTable.tsx`** — loading state now renders 8 skeleton rows that match the column shape instead of a single centered "Memuat…" cell. Used by Anggota / Buku / Peminjaman list pages so all three benefit automatically without per-page changes.
- **`apps/desktop/src/features/opac/OpacHomePage.tsx`** — replaces "Memuat…" text with `<CardSkeleton count={24} />` matching `xl:grid-cols-6` layout.
- **`apps/desktop/src/features/opac/OpacSearchPage.tsx`** — replaces "Memuat…" with `<CardSkeleton count={20} gridClassName="…xl:grid-cols-5" />`.
- **`apps/desktop/src/features/pengembalian/PengembalianPage.tsx`** — search results panel now shows 5 skeleton list-items while the first search runs, instead of leaving the panel empty until results arrive. Inline spinner inside the input is preserved for incremental searches.
- All skeletons include `motion-reduce:animate-none` so users with `prefers-reduced-motion` see static placeholders.
- 9 new unit tests in `tableSkeleton.test.tsx` + `cardSkeleton.test.tsx`.

## Acceptance criteria checklist

- [x] On initial load of the listed list pages, user sees skeleton placeholders matching the table layout (via DataTable loading-branch refactor).
- [x] Skeletons fade out cleanly when data arrives (rows simply replace skeleton-rows on the same `<TableBody>` via the existing isLoading branch swap).
- [x] Filter bar renders immediately; only the table region uses the skeleton (already true — only `DataTable` body is touched).
- [x] Honors `prefers-reduced-motion` via Tailwind `motion-reduce:animate-none` (per-element).
- [x] OPAC home + search pages render `CardSkeleton` instead of "Memuat…" text.
- [x] aria-busy + role="status" set so screen readers announce loading.
- [x] Tests cover rows × columns, defaults, width hints, aria-busy, and motion-reduce class.

## Notes

- We hooked the skeleton into the canonical `DataTable` loading branch instead of changing each list page individually, which means **Stocktake/Audit Log/Kas/Backup/Reservasi/Wishlist/Sirkulasi** also pick up the new look for free wherever they use `DataTable` — net positive surface area beyond the spec.
- `TableSkeleton` is exported as a standalone component so future feature pages that don't use `DataTable` (e.g. custom layouts) can still use it directly.

## Gates (all green locally)

- `pnpm typecheck` — OK
- `pnpm lint --max-warnings=0` — OK
- `pnpm i18n:lint` — OK across all namespaces
- `pnpm test` — 64 files / 560 tests pass (9 new)
- `pnpm build` — OK (vite warnings unchanged from main)

## Risks

- `DataTable.tsx` is shared infra — verified no existing tests look for the old "Memuat…" copy. The loading→loaded transition still happens in the same branch swap, so behavior is identical for callers.
- `Pengembalian` skeletons are inline (not via the new `TableSkeleton`) because the panel uses a `<ul>` of search results, not a `<table>`. Reuses the same `motion-reduce:animate-none animate-pulse` pattern.
