### PR TITLE
feat(laporan): one-click executive monthly PDF (C1-LaporanEksekutifPDF)

### DIFF
--- a/apps/desktop/src/features/laporan/EksekutifSubPage.tsx
+++ b/apps/desktop/src/features/laporan/EksekutifSubPage.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FileBarChart, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { DateRangePicker } from '@/components/ui/date-range-picker';
+import { useToast } from '@/components/ui/toast-manager';
+import { presetRangeMonth } from './RangeToolbar';
+import { dashboardApi, type TopBuku, type TopPeminjam } from '@/lib/dashboard';
+import { peminjamanApi, type PeminjamanRow } from '@/lib/peminjaman';
+import { reservasiApi, type ReservasiRow } from '@/lib/reservasi';
+import { settingsApi } from '@/lib/settings';
+import {
+  generateLaporanEksekutifPdf,
+  type LaporanEksekutifAnggotaDenda,
+  type LaporanEksekutifBukuReservasiZeroStock,
+  type LaporanEksekutifData,
+  type LaporanEksekutifIdentitas,
+  type LaporanEksekutifWeekly,
+} from '@/lib/pdf/laporanEksekutif';
+import { formatTauriError } from '@/lib/errors';
+
+function isoWeekLabel(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return iso;
+  // Approximate week-of-month: 1 + floor((day-1)/7).
+  const week = Math.floor((d.getDate() - 1) / 7) + 1;
+  const month = d.toLocaleDateString('id-ID', { month: 'short' });
+  return `M${week} ${month}`;
+}
+
+function bucketWeekly(rows: PeminjamanRow[]): LaporanEksekutifWeekly[] {
+  const buckets = new Map<string, number>();
+  for (const r of rows) {
+    const label = isoWeekLabel(r.tanggalPinjam);
+    buckets.set(label, (buckets.get(label) ?? 0) + 1);
+  }
+  return Array.from(buckets.entries()).map(([bucket, count]) => ({ bucket, count }));
+}
+
+function aggregateDendaTinggi(rows: PeminjamanRow[]): LaporanEksekutifAnggotaDenda[] {
+  const acc = new Map<number, LaporanEksekutifAnggotaDenda>();
+  for (const r of rows) {
+    const outstanding = Math.max(0, (r.totalDenda ?? 0) - (r.totalBayar ?? 0));
+    if (outstanding <= 0) continue;
+    const existing = acc.get(r.anggotaId);
+    if (existing) {
+      existing.outstanding += outstanding;
+    } else {
+      acc.set(r.anggotaId, { nama: r.anggotaNama, outstanding });
+    }
+  }
+  return Array.from(acc.values())
+    .filter((a) => a.outstanding > 50_000)
+    .sort((a, b) => b.outstanding - a.outstanding);
+}
+
+function aggregateBukuTanpaStok(reservasi: ReservasiRow[]): LaporanEksekutifBukuReservasiZeroStock[] {
+  // We can't query stok directly from this thin slice — but rows that flip to
+  // siap_diambil already have a slot, so any active reservasi still in
+  // "menunggu" status implies zero stok at the moment the queue formed. We
+  // surface those.
+  const acc = new Map<number, LaporanEksekutifBukuReservasiZeroStock>();
+  for (const r of reservasi) {
+    if (r.status !== 'menunggu') continue;
+    const existing = acc.get(r.bukuId);
+    if (existing) {
+      existing.reservasiCount += 1;
+    } else {
+      acc.set(r.bukuId, { judul: r.bukuJudul, reservasiCount: 1 });
+    }
+  }
+  return Array.from(acc.values())
+    .filter((b) => b.reservasiCount > 0)
+    .sort((a, b) => b.reservasiCount - a.reservasiCount);
+}
+
+async function fetchAllPeminjaman(from: string, to: string): Promise<PeminjamanRow[]> {
+  const limit = 500;
+  let offset = 0;
+  const all: PeminjamanRow[] = [];
+  for (;;) {
+    const page = await peminjamanApi.list({ from, to, limit, offset });
+    all.push(...page.items);
+    offset += page.items.length;
+    if (page.items.length < limit || all.length >= page.total) break;
+    if (offset > 5000) break; // hard safety cap
+  }
+  return all;
+}
+
+export function LaporanEksekutif() {
+  const { t } = useTranslation(['laporan', 'common']);
+  const { showToast } = useToast();
+  const [range, setRange] = useState(presetRangeMonth);
+  const [busy, setBusy] = useState(false);
+
+  const handlePrint = useCallback(async () => {
+    setBusy(true);
+    try {
+      const [identity, kpi, topBuku, topPeminjam, peminjamanRows, reservasi] = await Promise.all([
+        settingsApi.getIdentity(),
+        dashboardApi.kpi(),
+        dashboardApi.topBuku(5),
+        dashboardApi.topPeminjam(5),
+        fetchAllPeminjaman(range.from, range.to),
+        reservasiApi.listActive().catch(() => []),
+      ]);
+
+      const dendaOutstanding = peminjamanRows.reduce(
+        (acc, r) => acc + Math.max(0, (r.totalDenda ?? 0) - (r.totalBayar ?? 0)),
+        0,
+      );
+
+      const data: LaporanEksekutifData = {
+        kpi: {
+          totalAnggotaAktif: kpi.totalAnggota,
+          totalBuku: kpi.totalBuku,
+          peminjamanPeriode: peminjamanRows.length,
+          dendaOutstanding,
+        },
+        weeklyLoans: bucketWeekly(peminjamanRows),
+        topBuku: (topBuku as TopBuku[]).map((b) => ({ judul: b.judul, count: b.jumlah })),
+        topAnggota: (topPeminjam as TopPeminjam[]).map((a) => ({
+          nama: a.nama,
+          kelas: a.kelas,
+          count: a.jumlah,
+        })),
+        anggotaDendaTinggi: aggregateDendaTinggi(peminjamanRows),
+        bukuReservasiTanpaStok: aggregateBukuTanpaStok(reservasi),
+      };
+
+      const identitas: LaporanEksekutifIdentitas = {
+        nama: identity.nama,
+        alamat: identity.alamat,
+        kepala: identity.kepala,
+        npsn: identity.npsn,
+        tahunAjaran: identity.tahunAjaran,
+        logoSrc: identity.logoPath || undefined,
+      };
+
+      generateLaporanEksekutifPdf({
+        period: { startIso: range.from, endIso: range.to },
+        identitas,
+        data,
+      });
+
+      showToast({
+        title: t('laporan:eksekutif.toastTitle', { defaultValue: 'Laporan disiapkan' }),
+        description: t('laporan:eksekutif.toastDesc', {
+          defaultValue: 'Jendela cetak akan terbuka.',
+        }),
+      });
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('laporan:error.load', { defaultValue: 'Gagal memuat data' }),
+        description: formatTauriError(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [range, showToast, t]);
+
+  useEffect(() => {
+    // Pre-warm settings cache so first click feels snappier.
+    void settingsApi.getIdentity();
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="laporan-eksekutif">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <FileBarChart className="h-5 w-5 text-primary" aria-hidden="true" />
+            <div>
+              <CardTitle>
+                {t('laporan:eksekutif.title', { defaultValue: 'Laporan Eksekutif' })}
+              </CardTitle>
+              <CardDescription>
+                {t('laporan:eksekutif.subtitle', {
+                  defaultValue:
+                    'PDF satu-klik untuk rapat bulanan kepala sekolah: KPI, tren, dan action items.',
+                })}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <DateRangePicker value={range} onChange={setRange} />
+          <Button
+            onClick={handlePrint}
+            disabled={busy}
+            className="w-fit"
+            data-testid="laporan-eksekutif-cetak"
+          >
+            {busy ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {t('laporan:eksekutif.preparing', { defaultValue: 'Menyiapkan…' })}
+              </>
+            ) : (
+              t('laporan:eksekutif.cetak', { defaultValue: 'Cetak PDF' })
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/laporan/LaporanLayout.tsx
+++ b/apps/desktop/src/features/laporan/LaporanLayout.tsx
@@ -1,6 +1,6 @@
 import { Link, Outlet } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
-import { BarChart3, Database, LineChart, ReceiptText, Users } from 'lucide-react';
+import { BarChart3, Database, FileBarChart, LineChart, ReceiptText, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -12,6 +12,7 @@ interface NavItem {
 
 const NAV: NavItem[] = [
   { to: '/laporan/grafik', labelKey: 'laporan:nav.grafik', defaultLabel: 'Grafik', Icon: LineChart },
+  { to: '/laporan/eksekutif', labelKey: 'laporan:nav.eksekutif', defaultLabel: 'Eksekutif', Icon: FileBarChart },
   { to: '/laporan/top-peminjam', labelKey: 'laporan:nav.topPeminjam', defaultLabel: 'Top Peminjam', Icon: Users },
   { to: '/laporan/top-buku', labelKey: 'laporan:nav.topBuku', defaultLabel: 'Top Buku', Icon: BarChart3 },
   { to: '/laporan/kas', labelKey: 'laporan:nav.kas', defaultLabel: 'Kas', Icon: ReceiptText },

--- a/apps/desktop/src/i18n/en/laporan.json
+++ b/apps/desktop/src/i18n/en/laporan.json
@@ -4,10 +4,19 @@
   "empty": "No data in this range",
   "nav": {
     "grafik": "Charts",
+    "eksekutif": "Executive",
     "topPeminjam": "Top Borrowers",
     "topBuku": "Top Books",
     "kas": "Cash",
     "backup": "Backup"
+  },
+  "eksekutif": {
+    "title": "Executive Report",
+    "subtitle": "One-click PDF for the principal\u2019s monthly meeting: KPIs, trends, and action items.",
+    "cetak": "Print PDF",
+    "preparing": "Preparing\u2026",
+    "toastTitle": "Report prepared",
+    "toastDesc": "The print window will open shortly."
   },
   "error": {
     "load": "Failed to load data"

--- a/apps/desktop/src/i18n/id/laporan.json
+++ b/apps/desktop/src/i18n/id/laporan.json
@@ -4,10 +4,19 @@
   "empty": "Belum ada data pada rentang ini",
   "nav": {
     "grafik": "Grafik",
+    "eksekutif": "Eksekutif",
     "topPeminjam": "Top Peminjam",
     "topBuku": "Top Buku",
     "kas": "Kas",
     "backup": "Backup"
+  },
+  "eksekutif": {
+    "title": "Laporan Eksekutif",
+    "subtitle": "PDF satu-klik untuk rapat bulanan kepala sekolah: KPI, tren, dan action items.",
+    "cetak": "Cetak PDF",
+    "preparing": "Menyiapkan\u2026",
+    "toastTitle": "Laporan disiapkan",
+    "toastDesc": "Jendela cetak akan terbuka."
   },
   "error": {
     "load": "Gagal memuat data"

--- a/apps/desktop/src/lib/pdf/laporanEksekutif.ts
+++ b/apps/desktop/src/lib/pdf/laporanEksekutif.ts
@@ -1,0 +1,357 @@
+/**
+ * Generate the "Laporan Eksekutif" — monthly executive report for the
+ * kepala sekolah meeting (C1-LaporanEksekutifPDF, v1.1.0).
+ *
+ * Renders an HTML document with:
+ *  - Page 1 cover: school identity + period KPIs.
+ *  - Page 2 trends: weekly loans line chart, top-5 books bar chart,
+ *    top-5 borrowers bar chart (all inline SVG so print quality stays
+ *    crisp).
+ *  - Page 3 action items: auto-generated suggestions (members with
+ *    outstanding fine > Rp 50.000, books with reservasi queue but
+ *    zero stock) + signature blocks.
+ *
+ * Stays consistent with the existing HTML/`window.print()` PDF stack
+ * (`apps/desktop/src/lib/pdf/nota.ts`) — no new runtime deps. The pure
+ * HTML builder is exported so unit tests can assert content without
+ * needing a browser context.
+ */
+
+export interface LaporanEksekutifPeriod {
+  /** Inclusive ISO start date `YYYY-MM-DD`. */
+  startIso: string;
+  /** Inclusive ISO end date `YYYY-MM-DD`. */
+  endIso: string;
+}
+
+export interface LaporanEksekutifIdentitas {
+  nama?: string;
+  alamat?: string;
+  kepala?: string;
+  npsn?: string;
+  tahunAjaran?: string;
+  /** Optional logo (data: URI or absolute URL); skipped if missing. */
+  logoSrc?: string;
+}
+
+export interface LaporanEksekutifKpi {
+  totalAnggotaAktif: number;
+  totalBuku: number;
+  peminjamanPeriode: number;
+  dendaOutstanding: number;
+}
+
+export interface LaporanEksekutifWeekly {
+  /** Bucket label e.g. `M1` or `2026-W18`. */
+  bucket: string;
+  count: number;
+}
+
+export interface LaporanEksekutifTopBuku {
+  judul: string;
+  count: number;
+}
+
+export interface LaporanEksekutifTopAnggota {
+  nama: string;
+  kelas?: string | null;
+  count: number;
+}
+
+export interface LaporanEksekutifAnggotaDenda {
+  nama: string;
+  kelas?: string | null;
+  outstanding: number;
+}
+
+export interface LaporanEksekutifBukuReservasiZeroStock {
+  judul: string;
+  reservasiCount: number;
+}
+
+export interface LaporanEksekutifData {
+  kpi: LaporanEksekutifKpi;
+  weeklyLoans: LaporanEksekutifWeekly[];
+  topBuku: LaporanEksekutifTopBuku[];
+  topAnggota: LaporanEksekutifTopAnggota[];
+  anggotaDendaTinggi: LaporanEksekutifAnggotaDenda[];
+  bukuReservasiTanpaStok: LaporanEksekutifBukuReservasiZeroStock[];
+}
+
+export interface LaporanEksekutifInput {
+  period: LaporanEksekutifPeriod;
+  identitas?: LaporanEksekutifIdentitas;
+  data: LaporanEksekutifData;
+  /** Override the print/generate timestamp; defaults to `new Date()`. */
+  generatedAt?: Date;
+}
+
+const DENDA_THRESHOLD = 50_000;
+
+function escape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function fmtRupiah(n: number): string {
+  return `Rp ${Math.max(0, Math.round(n)).toLocaleString('id-ID')}`;
+}
+
+function fmtDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('id-ID', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function fmtDateTime(d: Date): string {
+  return d.toLocaleString('id-ID', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function lineChartSvg(buckets: LaporanEksekutifWeekly[]): string {
+  if (buckets.length === 0) return '';
+  const w = 520;
+  const h = 160;
+  const padX = 30;
+  const padY = 20;
+  const innerW = w - padX * 2;
+  const innerH = h - padY * 2;
+  const max = Math.max(1, ...buckets.map((b) => b.count));
+  const stepX = buckets.length > 1 ? innerW / (buckets.length - 1) : 0;
+  const points = buckets
+    .map((b, i) => {
+      const x = padX + stepX * i;
+      const y = padY + innerH - (b.count / max) * innerH;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  const labels = buckets
+    .map((b, i) => {
+      const x = padX + stepX * i;
+      return `<text x="${x.toFixed(1)}" y="${(h - 4).toFixed(1)}" font-size="9" text-anchor="middle" fill="#555">${escape(b.bucket)}</text>`;
+    })
+    .join('');
+  const yAxis = `<line x1="${padX}" y1="${padY}" x2="${padX}" y2="${padY + innerH}" stroke="#ccc" stroke-width="1"/>`;
+  const xAxis = `<line x1="${padX}" y1="${padY + innerH}" x2="${padX + innerW}" y2="${padY + innerH}" stroke="#ccc" stroke-width="1"/>`;
+  const dots = buckets
+    .map((b, i) => {
+      const x = padX + stepX * i;
+      const y = padY + innerH - (b.count / max) * innerH;
+      return `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.5" fill="#1d4ed8"/>`;
+    })
+    .join('');
+  return `<svg viewBox="0 0 ${w} ${h}" width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg">
+    ${yAxis}${xAxis}
+    <polyline fill="none" stroke="#1d4ed8" stroke-width="2" points="${points}"/>
+    ${dots}
+    ${labels}
+  </svg>`;
+}
+
+function barChartSvg(rows: ReadonlyArray<{ label: string; count: number }>): string {
+  if (rows.length === 0) return '';
+  const barH = 18;
+  const gap = 6;
+  const labelW = 200;
+  const max = Math.max(1, ...rows.map((r) => r.count));
+  const w = 520;
+  const h = rows.length * (barH + gap) + 8;
+  const valueW = w - labelW - 30;
+  const items = rows
+    .map((r, i) => {
+      const y = i * (barH + gap) + 4;
+      const barLen = (r.count / max) * valueW;
+      return `
+        <text x="0" y="${y + barH * 0.7}" font-size="11" fill="#222">${escape(r.label.slice(0, 36))}</text>
+        <rect x="${labelW}" y="${y}" width="${barLen.toFixed(1)}" height="${barH}" fill="#1d4ed8" rx="2"/>
+        <text x="${labelW + barLen + 4}" y="${y + barH * 0.7}" font-size="11" fill="#222">${r.count}</text>
+      `;
+    })
+    .join('');
+  return `<svg viewBox="0 0 ${w} ${h}" width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg">${items}</svg>`;
+}
+
+function actionItems(data: LaporanEksekutifData): string[] {
+  const items: string[] = [];
+  for (const a of data.anggotaDendaTinggi) {
+    if (a.outstanding > DENDA_THRESHOLD) {
+      const kelas = a.kelas ? ` (${escape(a.kelas)})` : '';
+      items.push(
+        `Anggota <strong>${escape(a.nama)}</strong>${kelas} memiliki denda ${fmtRupiah(a.outstanding)} — kirim surat penagihan.`,
+      );
+    }
+  }
+  for (const b of data.bukuReservasiTanpaStok) {
+    if (b.reservasiCount > 0) {
+      items.push(
+        `Buku <strong>${escape(b.judul)}</strong> memiliki ${b.reservasiCount} reservasi dengan stok 0 — pertimbangkan pengadaan tambahan.`,
+      );
+    }
+  }
+  return items;
+}
+
+export function buildLaporanEksekutifHtml(input: LaporanEksekutifInput): string {
+  const namaSekolah = input.identitas?.nama || 'Perpustakaan';
+  const alamat = input.identitas?.alamat || '';
+  const npsn = input.identitas?.npsn || '';
+  const tahunAjaran = input.identitas?.tahunAjaran || '';
+  const kepala = input.identitas?.kepala || '';
+  const logoTag = input.identitas?.logoSrc
+    ? `<img src="${escape(input.identitas.logoSrc)}" alt="logo" style="height:64px;object-fit:contain"/>`
+    : '';
+  const periodLabel = `${fmtDate(input.period.startIso)} – ${fmtDate(input.period.endIso)}`;
+  const generatedAt = fmtDateTime(input.generatedAt ?? new Date());
+
+  const { kpi, weeklyLoans, topBuku, topAnggota } = input.data;
+  const noLoans = (kpi.peminjamanPeriode ?? 0) === 0;
+  const items = actionItems(input.data);
+
+  const lineChart = noLoans ? '' : lineChartSvg(weeklyLoans);
+  const topBukuChart = barChartSvg(
+    topBuku.map((b) => ({ label: b.judul, count: b.count })),
+  );
+  const topAnggotaChart = barChartSvg(
+    topAnggota.map((a) => ({
+      label: a.kelas ? `${a.nama} — ${a.kelas}` : a.nama,
+      count: a.count,
+    })),
+  );
+
+  return `<!DOCTYPE html>
+<html lang="id">
+<head>
+<meta charset="utf-8" />
+<title>Laporan Eksekutif Perpustakaan — ${escape(namaSekolah)}</title>
+<style>
+  @page { size: A4; margin: 18mm; }
+  body { font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; color: #111; font-size: 12px; margin: 0; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 16px; margin: 16px 0 8px; border-bottom: 1px solid #e5e7eb; padding-bottom: 4px; }
+  h3 { font-size: 13px; margin: 12px 0 4px; color: #1d4ed8; }
+  .cover-header { display: flex; align-items: center; gap: 16px; }
+  .cover-header .school-meta { flex: 1; }
+  .meta-line { font-size: 11px; color: #555; }
+  .period { font-size: 14px; font-weight: 600; margin: 12px 0; }
+  .kpi-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-top: 16px; }
+  .kpi-cell { border: 1px solid #e5e7eb; border-radius: 6px; padding: 10px 12px; }
+  .kpi-cell .label { font-size: 11px; color: #666; }
+  .kpi-cell .value { font-size: 20px; font-weight: 700; color: #1d4ed8; }
+  .page { page-break-after: always; padding-bottom: 12px; }
+  .page:last-child { page-break-after: auto; }
+  ul.action-items { margin: 0; padding-left: 18px; }
+  ul.action-items li { margin-bottom: 6px; }
+  .signature-row { display: flex; justify-content: space-between; gap: 20px; margin-top: 36px; }
+  .sig { flex: 1; border-top: 1px solid #aaa; padding-top: 4px; text-align: center; font-size: 11px; color: #555; }
+  .sig strong { display: block; font-size: 12px; color: #111; margin-top: 36px; }
+  .footer { font-size: 10px; color: #777; text-align: center; margin-top: 12px; }
+  .empty-note { font-style: italic; color: #777; margin: 12px 0; }
+</style>
+</head>
+<body>
+  <section class="page">
+    <div class="cover-header">
+      ${logoTag}
+      <div class="school-meta">
+        <h1>${escape(namaSekolah)}</h1>
+        <div class="meta-line">${escape(alamat)}</div>
+        <div class="meta-line">${npsn ? 'NPSN: ' + escape(npsn) : ''}${npsn && tahunAjaran ? ' · ' : ''}${tahunAjaran ? 'TA: ' + escape(tahunAjaran) : ''}</div>
+      </div>
+    </div>
+    <h2 style="text-align:center;border:none;margin-top:32px">Laporan Eksekutif Perpustakaan</h2>
+    <p class="period" style="text-align:center">${escape(periodLabel)}</p>
+
+    <div class="kpi-grid">
+      <div class="kpi-cell">
+        <div class="label">Total Anggota Aktif</div>
+        <div class="value">${kpi.totalAnggotaAktif.toLocaleString('id-ID')}</div>
+      </div>
+      <div class="kpi-cell">
+        <div class="label">Total Judul Buku</div>
+        <div class="value">${kpi.totalBuku.toLocaleString('id-ID')}</div>
+      </div>
+      <div class="kpi-cell">
+        <div class="label">Peminjaman Periode</div>
+        <div class="value">${kpi.peminjamanPeriode.toLocaleString('id-ID')}</div>
+      </div>
+      <div class="kpi-cell">
+        <div class="label">Denda Outstanding</div>
+        <div class="value">${fmtRupiah(kpi.dendaOutstanding)}</div>
+      </div>
+    </div>
+    <p class="footer">Dicetak: ${escape(generatedAt)}</p>
+  </section>
+
+  <section class="page">
+    <h2>Tren &amp; Performa</h2>
+    ${
+      noLoans
+        ? '<p class="empty-note">Tidak ada peminjaman dalam periode ini.</p>'
+        : `<h3>Peminjaman per minggu</h3>${lineChart}`
+    }
+    <h3>Top 5 Buku</h3>
+    ${topBuku.length === 0 ? '<p class="empty-note">Belum ada data.</p>' : topBukuChart}
+    <h3>Top 5 Anggota Peminjam</h3>
+    ${topAnggota.length === 0 ? '<p class="empty-note">Belum ada data.</p>' : topAnggotaChart}
+  </section>
+
+  <section class="page">
+    <h2>Action Items</h2>
+    ${
+      items.length === 0
+        ? '<p class="empty-note">Tidak ada item tindak lanjut otomatis.</p>'
+        : `<ul class="action-items">${items.map((it) => `<li>${it}</li>`).join('')}</ul>`
+    }
+
+    <div class="signature-row">
+      <div class="sig">
+        Pustakawan
+        <strong>(__________________)</strong>
+      </div>
+      <div class="sig">
+        Kepala Sekolah
+        <strong>${escape(kepala || '(__________________)')}</strong>
+      </div>
+    </div>
+    <p class="footer">Dicetak: ${escape(generatedAt)} · ${escape(namaSekolah)}</p>
+  </section>
+</body>
+</html>`;
+}
+
+/**
+ * Open a print window with the executive report. Returns a `Blob` of the
+ * generated HTML so callers can also export-to-file if desired.
+ */
+export function generateLaporanEksekutifPdf(input: LaporanEksekutifInput): Blob {
+  const html = buildLaporanEksekutifHtml(input);
+  const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
+  if (typeof window !== 'undefined') {
+    const win = window.open('', '_blank', 'width=820,height=1100');
+    if (!win) {
+      throw new Error('Popup diblokir browser. Izinkan popup untuk mencetak laporan.');
+    }
+    win.document.open();
+    win.document.write(html);
+    win.document.close();
+    setTimeout(() => {
+      try {
+        win.focus();
+        win.print();
+      } catch {
+        // ignore — user can print manually
+      }
+    }, 250);
+  }
+  return blob;
+}

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -47,6 +47,7 @@ import { Route as AuthedLaporanTopPeminjamRouteImport } from './routes/_authed/l
 import { Route as AuthedLaporanTopBukuRouteImport } from './routes/_authed/laporan/top-buku'
 import { Route as AuthedLaporanKasRouteImport } from './routes/_authed/laporan/kas'
 import { Route as AuthedLaporanGrafikRouteImport } from './routes/_authed/laporan/grafik'
+import { Route as AuthedLaporanEksekutifRouteImport } from './routes/_authed/laporan/eksekutif'
 import { Route as AuthedLaporanBackupRouteImport } from './routes/_authed/laporan/backup'
 import { Route as AuthedBukuNewRouteImport } from './routes/_authed/buku/new'
 import { Route as AuthedBukuCetakLabelRouteImport } from './routes/_authed/buku/cetak-label'
@@ -248,6 +249,11 @@ const AuthedLaporanGrafikRoute = AuthedLaporanGrafikRouteImport.update({
   path: '/grafik',
   getParentRoute: () => AuthedLaporanRoute,
 } as any)
+const AuthedLaporanEksekutifRoute = AuthedLaporanEksekutifRouteImport.update({
+  id: '/eksekutif',
+  path: '/eksekutif',
+  getParentRoute: () => AuthedLaporanRoute,
+} as any)
 const AuthedLaporanBackupRoute = AuthedLaporanBackupRouteImport.update({
   id: '/backup',
   path: '/backup',
@@ -300,6 +306,7 @@ export interface FileRoutesByFullPath {
   '/buku/cetak-label': typeof AuthedBukuCetakLabelRoute
   '/buku/new': typeof AuthedBukuNewRoute
   '/laporan/backup': typeof AuthedLaporanBackupRoute
+  '/laporan/eksekutif': typeof AuthedLaporanEksekutifRoute
   '/laporan/grafik': typeof AuthedLaporanGrafikRoute
   '/laporan/kas': typeof AuthedLaporanKasRoute
   '/laporan/top-buku': typeof AuthedLaporanTopBukuRoute
@@ -344,6 +351,7 @@ export interface FileRoutesByTo {
   '/buku/cetak-label': typeof AuthedBukuCetakLabelRoute
   '/buku/new': typeof AuthedBukuNewRoute
   '/laporan/backup': typeof AuthedLaporanBackupRoute
+  '/laporan/eksekutif': typeof AuthedLaporanEksekutifRoute
   '/laporan/grafik': typeof AuthedLaporanGrafikRoute
   '/laporan/kas': typeof AuthedLaporanKasRoute
   '/laporan/top-buku': typeof AuthedLaporanTopBukuRoute
@@ -392,6 +400,7 @@ export interface FileRoutesById {
   '/_authed/buku/cetak-label': typeof AuthedBukuCetakLabelRoute
   '/_authed/buku/new': typeof AuthedBukuNewRoute
   '/_authed/laporan/backup': typeof AuthedLaporanBackupRoute
+  '/_authed/laporan/eksekutif': typeof AuthedLaporanEksekutifRoute
   '/_authed/laporan/grafik': typeof AuthedLaporanGrafikRoute
   '/_authed/laporan/kas': typeof AuthedLaporanKasRoute
   '/_authed/laporan/top-buku': typeof AuthedLaporanTopBukuRoute
@@ -440,6 +449,7 @@ export interface FileRouteTypes {
     | '/buku/cetak-label'
     | '/buku/new'
     | '/laporan/backup'
+    | '/laporan/eksekutif'
     | '/laporan/grafik'
     | '/laporan/kas'
     | '/laporan/top-buku'
@@ -484,6 +494,7 @@ export interface FileRouteTypes {
     | '/buku/cetak-label'
     | '/buku/new'
     | '/laporan/backup'
+    | '/laporan/eksekutif'
     | '/laporan/grafik'
     | '/laporan/kas'
     | '/laporan/top-buku'
@@ -531,6 +542,7 @@ export interface FileRouteTypes {
     | '/_authed/buku/cetak-label'
     | '/_authed/buku/new'
     | '/_authed/laporan/backup'
+    | '/_authed/laporan/eksekutif'
     | '/_authed/laporan/grafik'
     | '/_authed/laporan/kas'
     | '/_authed/laporan/top-buku'
@@ -836,6 +848,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedLaporanGrafikRouteImport
       parentRoute: typeof AuthedLaporanRoute
     }
+    '/_authed/laporan/eksekutif': {
+      id: '/_authed/laporan/eksekutif'
+      path: '/eksekutif'
+      fullPath: '/laporan/eksekutif'
+      preLoaderRoute: typeof AuthedLaporanEksekutifRouteImport
+      parentRoute: typeof AuthedLaporanRoute
+    }
     '/_authed/laporan/backup': {
       id: '/_authed/laporan/backup'
       path: '/backup'
@@ -890,6 +909,7 @@ declare module '@tanstack/react-router' {
 
 interface AuthedLaporanRouteChildren {
   AuthedLaporanBackupRoute: typeof AuthedLaporanBackupRoute
+  AuthedLaporanEksekutifRoute: typeof AuthedLaporanEksekutifRoute
   AuthedLaporanGrafikRoute: typeof AuthedLaporanGrafikRoute
   AuthedLaporanKasRoute: typeof AuthedLaporanKasRoute
   AuthedLaporanTopBukuRoute: typeof AuthedLaporanTopBukuRoute
@@ -899,6 +919,7 @@ interface AuthedLaporanRouteChildren {
 
 const AuthedLaporanRouteChildren: AuthedLaporanRouteChildren = {
   AuthedLaporanBackupRoute: AuthedLaporanBackupRoute,
+  AuthedLaporanEksekutifRoute: AuthedLaporanEksekutifRoute,
   AuthedLaporanGrafikRoute: AuthedLaporanGrafikRoute,
   AuthedLaporanKasRoute: AuthedLaporanKasRoute,
   AuthedLaporanTopBukuRoute: AuthedLaporanTopBukuRoute,

--- a/apps/desktop/src/routes/_authed/laporan/eksekutif.tsx
+++ b/apps/desktop/src/routes/_authed/laporan/eksekutif.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { LaporanEksekutif } from '@/features/laporan/EksekutifSubPage';
+
+export const Route = createFileRoute('/_authed/laporan/eksekutif')({
+  component: LaporanEksekutif,
+});

--- a/apps/desktop/tests/unit/laporanEksekutifPdf.test.ts
+++ b/apps/desktop/tests/unit/laporanEksekutifPdf.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLaporanEksekutifHtml,
+  generateLaporanEksekutifPdf,
+  type LaporanEksekutifData,
+  type LaporanEksekutifInput,
+} from '@/lib/pdf/laporanEksekutif';
+
+const PERIOD = { startIso: '2026-05-01', endIso: '2026-05-31' };
+const FIXED_AT = new Date('2026-05-31T08:00:00Z');
+
+const IDENTITAS = {
+  nama: 'SMA Negeri 1 Demo',
+  alamat: 'Jl. Pendidikan 1',
+  kepala: 'Drs. Budi <Demo>',
+  npsn: '20100001',
+  tahunAjaran: '2025/2026',
+};
+
+function buildData(overrides: Partial<LaporanEksekutifData> = {}): LaporanEksekutifData {
+  return {
+    kpi: {
+      totalAnggotaAktif: 120,
+      totalBuku: 540,
+      peminjamanPeriode: 33,
+      dendaOutstanding: 87_500,
+    },
+    weeklyLoans: [
+      { bucket: 'M1 Mei', count: 6 },
+      { bucket: 'M2 Mei', count: 12 },
+      { bucket: 'M3 Mei', count: 9 },
+      { bucket: 'M4 Mei', count: 6 },
+    ],
+    topBuku: [
+      { judul: 'Bumi Manusia', count: 8 },
+      { judul: 'Laut Bercerita', count: 5 },
+    ],
+    topAnggota: [
+      { nama: 'Siti', kelas: 'X-IPA-1', count: 7 },
+      { nama: 'Rudi', kelas: 'X-IPS-2', count: 5 },
+    ],
+    anggotaDendaTinggi: [
+      { nama: 'Andi', kelas: 'XI-IPA-3', outstanding: 75_000 },
+      { nama: 'Below threshold', outstanding: 30_000 },
+    ],
+    bukuReservasiTanpaStok: [
+      { judul: 'Atomic Habits', reservasiCount: 3 },
+    ],
+    ...overrides,
+  };
+}
+
+function build(overrides: Partial<LaporanEksekutifInput> = {}): string {
+  return buildLaporanEksekutifHtml({
+    period: PERIOD,
+    identitas: IDENTITAS,
+    data: buildData(),
+    generatedAt: FIXED_AT,
+    ...overrides,
+  });
+}
+
+describe('buildLaporanEksekutifHtml (C1-LaporanEksekutifPDF)', () => {
+  it('renders identitas, period, all KPI numbers, and all three chart sections', () => {
+    const html = build();
+    expect(html).toContain('SMA Negeri 1 Demo');
+    expect(html).toContain('NPSN: 20100001');
+    expect(html).toContain('TA: 2025/2026');
+    // Period rendered in id-ID long form
+    expect(html).toMatch(/01 Mei 2026.*31 Mei 2026/);
+    // KPI numbers (id-ID locale uses '.' as thousands sep)
+    expect(html).toContain('120');
+    expect(html).toContain('540');
+    expect(html).toContain('33');
+    expect(html).toMatch(/Rp\s?87\.500/);
+    // Three sub-sections
+    expect(html).toContain('Peminjaman per minggu');
+    expect(html).toContain('Top 5 Buku');
+    expect(html).toContain('Top 5 Anggota Peminjam');
+  });
+
+  it('escapes HTML in identitas to prevent injection', () => {
+    const html = build();
+    expect(html).toContain('Drs. Budi &lt;Demo&gt;');
+    expect(html).not.toContain('Drs. Budi <Demo>');
+  });
+
+  it('renders the empty-state note when no peminjaman in period', () => {
+    const data = buildData({
+      kpi: {
+        totalAnggotaAktif: 120,
+        totalBuku: 540,
+        peminjamanPeriode: 0,
+        dendaOutstanding: 0,
+      },
+      weeklyLoans: [],
+    });
+    const html = buildLaporanEksekutifHtml({ period: PERIOD, data, generatedAt: FIXED_AT });
+    expect(html).toContain('Tidak ada peminjaman dalam periode ini');
+    expect(html).not.toContain('Peminjaman per minggu');
+  });
+
+  it('includes action items only for anggota whose denda is above threshold (Rp 50.000)', () => {
+    const html = build();
+    expect(html).toContain('Andi');
+    expect(html).toMatch(/denda Rp\s?75\.000/);
+    expect(html).not.toContain('Below threshold');
+  });
+
+  it('includes book-reservasi action items when stok is exhausted', () => {
+    const html = build();
+    expect(html).toContain('Atomic Habits');
+    expect(html).toContain('3 reservasi');
+    expect(html).toContain('pertimbangkan pengadaan');
+  });
+
+  it('falls back to placeholder action-item note when none triggered', () => {
+    const data = buildData({
+      anggotaDendaTinggi: [],
+      bukuReservasiTanpaStok: [],
+    });
+    const html = buildLaporanEksekutifHtml({ period: PERIOD, data, generatedAt: FIXED_AT });
+    expect(html).toContain('Tidak ada item tindak lanjut otomatis');
+  });
+
+  it('uses fallback library name when identitas is omitted', () => {
+    const data = buildData();
+    const html = buildLaporanEksekutifHtml({ period: PERIOD, data, generatedAt: FIXED_AT });
+    expect(html).toContain('Perpustakaan');
+  });
+
+  it('renders a kepala-sekolah signature placeholder when name missing', () => {
+    const data = buildData();
+    const html = buildLaporanEksekutifHtml({
+      period: PERIOD,
+      identitas: { nama: 'Demo' },
+      data,
+      generatedAt: FIXED_AT,
+    });
+    expect(html).toContain('(__________________)');
+  });
+});
+
+describe('generateLaporanEksekutifPdf', () => {
+  it('returns a non-empty Blob with HTML content type', () => {
+    // jsdom returns null from window.open by default; stub a minimal popup so
+    // the print path completes without throwing.
+    const fakeWin = {
+      document: { open() {}, write() {}, close() {} },
+      focus() {},
+      print() {},
+    } as unknown as Window;
+    const original = window.open;
+    window.open = (() => fakeWin) as typeof window.open;
+    try {
+      const blob = generateLaporanEksekutifPdf({
+        period: PERIOD,
+        identitas: IDENTITAS,
+        data: buildData(),
+        generatedAt: FIXED_AT,
+      });
+      expect(blob).toBeInstanceOf(Blob);
+      expect(blob.size).toBeGreaterThan(500);
+      expect(blob.type).toContain('text/html');
+    } finally {
+      window.open = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **Laporan Eksekutif** sub-page under `/laporan/eksekutif` so the pustakawan can print a one-click monthly report (cover + KPIs, trend charts, action items + signature blocks) for the kepala-sekolah meeting. Implements **C1-LaporanEksekutifPDF** from the v1.1.0 batch (`.devin/handoff/v1.1.0/BUGS.md` lines 803–874).

## What changed

- **`apps/desktop/src/lib/pdf/laporanEksekutif.ts`** (new) — pure-HTML builder + print helper. Uses the existing `nota.ts` HTML+`window.print()` stack (the spec hints at `pdf-lib` / `kasPdf.ts`, but neither exists in this repo — `nota.ts` is the only PDF module). Returns a `Blob` so callers could also export-to-file. Charts are inline SVG so print quality stays vector-crisp without canvas.
- **`apps/desktop/src/features/laporan/EksekutifSubPage.tsx`** (new) — date-range picker (defaults to current month) + "Cetak PDF" button. Loads identitas + KPI + top-5 buku + top-5 peminjam + period peminjaman + active reservasi in parallel, derives weekly buckets / denda action items / zero-stock reservasi action items, then opens the print window.
- **`apps/desktop/src/routes/_authed/laporan/eksekutif.tsx`** + **`routeTree.gen.ts`** — new route, regenerated tree.
- **`apps/desktop/src/features/laporan/LaporanLayout.tsx`** — adds nav entry between *Grafik* and *Top Peminjam*.
- **`apps/desktop/src/i18n/{id,en}/laporan.json`** — adds `nav.eksekutif` + `eksekutif.{title,subtitle,cetak,preparing,toastTitle,toastDesc}` (parity verified by `pnpm i18n:lint`).
- **`apps/desktop/tests/unit/laporanEksekutifPdf.test.ts`** (new, 9 tests) — covers identitas HTML escaping, period rendering, all four KPIs, weekly chart presence, empty-state note when zero loans, denda > Rp 50k action items, reservasi-zero-stok action items, fallback library name, signature placeholder, and Blob return.

## PDF content (matches spec)

- **Page 1 cover** — logo (if set) + nama/alamat/NPSN/TA, "Laporan Eksekutif Perpustakaan" title, period range, 4-up KPI grid (Total Anggota Aktif, Total Buku, Peminjaman Periode, Denda Outstanding).
- **Page 2 trends** — weekly-loans line chart, top-5 buku bar chart, top-5 anggota bar chart. Empty-state notes when data missing.
- **Page 3 action items** — auto-generated bullets for members with outstanding fine > Rp 50.000 and books with reservasi queue but zero stock. Signature blocks for Pustakawan + Kepala Sekolah at the bottom.

## Acceptance criteria

- [x] Button opens a small dialog (range picker + Cetak button).
- [x] Cetak triggers `generateLaporanEksekutifPdf` and opens the print window.
- [x] PDF contains school name + logo (if set), correct KPI numbers, all three charts on page 2, and the action-item list.
- [x] Operates entirely offline (HTML inline; no external font/asset fetches).
- [x] Tests cover non-empty Blob, empty-data graceful state, and denda > 50k threshold.

## Gates (all green locally)

- `pnpm typecheck` — OK
- `pnpm lint --max-warnings=0` — OK
- `pnpm i18n:lint` — OK
- `pnpm test` — 65 files / 569 tests pass (9 new)
- `pnpm build` — OK

## Notes / risks

- **No new dependencies.** Reuses `nota.ts` HTML+`window.print()` pattern (spec mentions `pdf-lib`, but it isn't a project dep — `nota.ts` is the only existing PDF module).
- **Reservasi action items** are derived from `reservasiApi.listActive()`: any row still in `menunggu` (i.e. queued, not yet promoted to `siap_diambil`) implies stok was 0 when the request landed. This avoids needing a new RPC.
- **Indonesian locale** uses `Intl.NumberFormat`/`toLocaleDateString('id-ID', …)` so currency thousand-separators and date format are correct without extra fonts.
