### PR TITLE
feat(sandbox): D5-SandboxDemoMode — toggleable demo database with banner

### DIFF
--- a/apps/desktop/src-tauri/src/commands/backup_runner.rs
+++ b/apps/desktop/src-tauri/src/commands/backup_runner.rs
@@ -238,6 +238,18 @@ pub fn spawn_backup_scheduler(app: &tauri::AppHandle) {
 
 fn tick(app: &tauri::AppHandle) -> AppResult<()> {
     let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    // D5-SandboxDemoMode — never auto-back-up the demo DB. Manual backups
+    // from the Settings page still target the active connection, but the
+    // cron-driven auto-backup short-circuits here so demo data stays out
+    // of the regular cloud target.
+    if state
+        .sandbox_mode
+        .lock()
+        .map(|g| *g)
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
     let backup_dir = resolve_default_backup_dir(app)?;
     let db_src = crate::db::resolve_db_path(app)?;
     let did_run = run_tick_once(&state, &backup_dir, &db_src, Local::now())?;

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod laporan;
 pub mod master_data;
 pub mod peminjaman;
 pub mod reservasi;
+pub mod sandbox;
 pub mod settings;
 pub mod stocktake;
 pub mod surat;

--- a/apps/desktop/src-tauri/src/commands/sandbox.rs
+++ b/apps/desktop/src-tauri/src/commands/sandbox.rs
@@ -1,0 +1,306 @@
+//! D5-SandboxDemoMode — RPC commands that toggle the application between
+//! the production database and a sandboxed `demo.db` copy.
+//!
+//! When sandbox mode is active:
+//!   - `state.db` points at `<app_data>/perpustakaan-v2-demo.db`.
+//!   - `<app_data>/sandbox.flag` exists with the contents `"1"` so the
+//!     mode survives an app restart.
+//!   - The backup scheduler short-circuits each tick (see
+//!     `commands::backup_runner::tick`) so demo data is never written into
+//!     the regular cloud target.
+//!   - `state.sandbox_mode` is `true` and `SandboxBanner.tsx` renders.
+//!
+//! Audit trail of toggles is appended to `sandbox_audit_log` in the
+//! **production** DB (never the demo copy) so history survives wipes.
+
+use rusqlite::Connection;
+use serde::Serialize;
+use tauri::{AppHandle, State};
+
+use crate::commands::auth::SessionUser;
+use crate::db;
+use crate::error::{AppError, AppResult};
+use crate::AppState;
+
+/// Operational snapshot returned by every sandbox RPC. Front-end uses
+/// `active` to drive `SandboxBanner` and the toggle button label, and
+/// `dbPath` for the diagnostic line on `SandboxPage`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxStatus {
+    pub active: bool,
+    pub db_path: String,
+    pub demo_db_path: String,
+    pub prod_db_path: String,
+}
+
+fn build_status(app: &AppHandle, active: bool) -> AppResult<SandboxStatus> {
+    let demo = db::demo_db_path(app)?;
+    let prod = db::prod_db_path(app)?;
+    let db_path = if active { demo.clone() } else { prod.clone() };
+    Ok(SandboxStatus {
+        active,
+        db_path: db_path.to_string_lossy().to_string(),
+        demo_db_path: demo.to_string_lossy().to_string(),
+        prod_db_path: prod.to_string_lossy().to_string(),
+    })
+}
+
+fn current_user_id(state: &AppState) -> Option<i64> {
+    state
+        .current_user
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().map(|u: &SessionUser| u.id))
+}
+
+/// Append a row to `sandbox_audit_log` in the production DB. Always opens
+/// a fresh connection to the prod path so the entry lands on the real
+/// database regardless of which DB is currently mounted on `state.db`.
+fn append_sandbox_audit(
+    app: &AppHandle,
+    action: &str,
+    user_id: Option<i64>,
+    note: Option<&str>,
+) -> AppResult<()> {
+    let prod = db::prod_db_path(app)?;
+    let conn = Connection::open(&prod)?;
+    db::run_migrations(&conn)?; // ensures the table exists on first call
+    conn.execute(
+        "INSERT INTO sandbox_audit_log (action, user_id, note) VALUES (?1, ?2, ?3)",
+        rusqlite::params![action, user_id, note],
+    )?;
+    Ok(())
+}
+
+/// Returns the current sandbox status without mutating state. Used by
+/// `SandboxBanner` and `SandboxPage` to render their initial state.
+#[tauri::command]
+pub fn sandbox_status(app: AppHandle, state: State<'_, AppState>) -> AppResult<SandboxStatus> {
+    let active = state
+        .sandbox_mode
+        .lock()
+        .map(|g| *g)
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    build_status(&app, active)
+}
+
+/// Activate sandbox mode: copies the production DB to `demo.db`, swaps the
+/// connection on `state.db` to point at the demo file, runs migrations on
+/// the demo copy, and persists the flag so the mode survives a restart.
+/// Idempotent — calling it while already active reseeds the demo DB from
+/// production (handy for "reset demo" buttons).
+#[tauri::command]
+pub fn sandbox_enable(app: AppHandle, state: State<'_, AppState>) -> AppResult<SandboxStatus> {
+    let prod = db::prod_db_path(&app)?;
+    let demo = db::demo_db_path(&app)?;
+
+    // Copy production DB onto demo path. Use std::fs::copy which truncates
+    // the destination so subsequent enables always start from a fresh
+    // production snapshot. If prod doesn't exist yet (first-run edge case),
+    // open an empty connection and let migrations create the schema.
+    if prod.exists() {
+        std::fs::copy(&prod, &demo)?;
+    } else if demo.exists() {
+        // Ensure demo file starts clean so the user always lands in a
+        // predictable state.
+        std::fs::remove_file(&demo)?;
+    }
+
+    let new_conn = db::open_connection(&demo)?;
+    db::run_migrations(&new_conn)?;
+    db::seed_default_admin(&new_conn)?;
+
+    {
+        let mut db_guard = state
+            .db
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        *db_guard = new_conn;
+    }
+    {
+        let mut sb_guard = state
+            .sandbox_mode
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        *sb_guard = true;
+    }
+    db::write_sandbox_flag(&app, true)?;
+    append_sandbox_audit(&app, "enable", current_user_id(&state), None)?;
+
+    log::info!("sandbox: enabled — db handle now at {}", demo.display());
+    build_status(&app, true)
+}
+
+/// Deactivate sandbox mode: closes the demo connection, optionally
+/// archives `demo.db` to `<app_data>/demo-archive/<ts>.db`, restores the
+/// production DB handle, clears the persisted flag, and writes the audit
+/// row.
+#[tauri::command]
+pub fn sandbox_disable(app: AppHandle, state: State<'_, AppState>) -> AppResult<SandboxStatus> {
+    let prod = db::prod_db_path(&app)?;
+    let demo = db::demo_db_path(&app)?;
+
+    let new_conn = db::open_connection(&prod)?;
+    db::run_migrations(&new_conn)?;
+    db::seed_default_admin(&new_conn)?;
+
+    {
+        let mut db_guard = state
+            .db
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        *db_guard = new_conn;
+    }
+    {
+        let mut sb_guard = state
+            .sandbox_mode
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        *sb_guard = false;
+    }
+    db::write_sandbox_flag(&app, false)?;
+
+    // Best-effort archive — we don't fail the disable if archiving fails.
+    if demo.exists() {
+        if let Ok(archive_dir) = db::app_data_dir(&app).map(|d| d.join("demo-archive")) {
+            if std::fs::create_dir_all(&archive_dir).is_ok() {
+                let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
+                let archived = archive_dir.join(format!("demo-{ts}.db"));
+                if let Err(err) = std::fs::rename(&demo, &archived) {
+                    log::warn!(
+                        "sandbox: archive failed ({err}); leaving demo file in place at {}",
+                        demo.display()
+                    );
+                } else {
+                    log::info!("sandbox: archived demo DB to {}", archived.display());
+                }
+            }
+        }
+    }
+
+    append_sandbox_audit(&app, "disable", current_user_id(&state), None)?;
+    log::info!("sandbox: disabled — db handle restored to {}", prod.display());
+    build_status(&app, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_with_migrations(path: &std::path::Path) -> Connection {
+        let conn = Connection::open(path).expect("open db");
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .expect("foreign_keys");
+        crate::db::run_migrations(&conn).expect("migrations");
+        conn
+    }
+
+    #[test]
+    fn sandbox_audit_table_is_created_by_migrations() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("prod.db");
+        let conn = open_with_migrations(&path);
+
+        // Table exists.
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sandbox_audit_log'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("query sqlite_master");
+        assert_eq!(count, 1);
+
+        // Insert + readback.
+        conn.execute(
+            "INSERT INTO sandbox_audit_log (action, user_id, note) VALUES ('enable', 1, 'unit-test')",
+            [],
+        )
+        .expect("insert audit");
+        let (action, user_id, note): (String, Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT action, user_id, note FROM sandbox_audit_log ORDER BY id DESC LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("read audit");
+        assert_eq!(action, "enable");
+        assert_eq!(user_id, Some(1));
+        assert_eq!(note.as_deref(), Some("unit-test"));
+    }
+
+    #[test]
+    fn sandbox_audit_check_constraint_rejects_unknown_action() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conn = open_with_migrations(&dir.path().join("prod.db"));
+        let err = conn.execute(
+            "INSERT INTO sandbox_audit_log (action) VALUES ('rogue')",
+            [],
+        );
+        assert!(err.is_err(), "CHECK constraint should reject unknown action");
+    }
+
+    #[test]
+    fn enable_disable_roundtrip_swaps_db_files() {
+        // This covers the file-level half of the toggle (DB copy + archive
+        // moves) without the Tauri AppHandle. We exercise the `enable_sandbox`
+        // / `disable_sandbox` IO contract directly.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prod = dir.path().join("prod.db");
+        let demo = dir.path().join("demo.db");
+        let archive_dir = dir.path().join("demo-archive");
+
+        // Seed prod with a marker row.
+        {
+            let conn = open_with_migrations(&prod);
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES ('sandbox.test.marker', 'prod-only')",
+                [],
+            )
+            .expect("seed prod");
+        }
+
+        // enable: copy prod -> demo, demo should contain the marker.
+        std::fs::copy(&prod, &demo).expect("enable: copy prod->demo");
+        {
+            let demo_conn = open_with_migrations(&demo);
+            let value: String = demo_conn
+                .query_row(
+                    "SELECT value FROM settings WHERE key = 'sandbox.test.marker'",
+                    [],
+                    |r| r.get(0),
+                )
+                .expect("read marker from demo");
+            assert_eq!(value, "prod-only");
+
+            // Mutate demo only — prod should remain untouched after the toggle.
+            demo_conn
+                .execute(
+                    "UPDATE settings SET value = 'demo-only' WHERE key = 'sandbox.test.marker'",
+                    [],
+                )
+                .expect("mutate demo");
+        }
+
+        // Verify prod was not affected by demo writes.
+        {
+            let conn = Connection::open(&prod).expect("open prod after demo write");
+            let value: String = conn
+                .query_row(
+                    "SELECT value FROM settings WHERE key = 'sandbox.test.marker'",
+                    [],
+                    |r| r.get(0),
+                )
+                .expect("read marker from prod");
+            assert_eq!(value, "prod-only", "prod must be untouched while demo is active");
+        }
+
+        // disable: archive demo, prod handle restored.
+        std::fs::create_dir_all(&archive_dir).expect("mkdir archive");
+        let archived = archive_dir.join("demo-test.db");
+        std::fs::rename(&demo, &archived).expect("disable: archive demo");
+        assert!(!demo.exists(), "demo file must be archived away");
+        assert!(archived.exists(), "archive copy must exist");
+    }
+}

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -9,13 +9,68 @@ const SCHEMA_SQL: &str = include_str!("schema.sql");
 const DEFAULT_ADMIN_USERNAME: &str = "admin";
 const DEFAULT_ADMIN_PASSWORD: &str = "admin123";
 
-pub fn resolve_db_path(app: &AppHandle) -> AppResult<PathBuf> {
+pub fn app_data_dir(app: &AppHandle) -> AppResult<PathBuf> {
     let dir = app
         .path()
         .app_data_dir()
         .map_err(|e| AppError::Internal(format!("app_data_dir: {e}")))?;
     std::fs::create_dir_all(&dir)?;
-    Ok(dir.join("perpustakaan-v2.db"))
+    Ok(dir)
+}
+
+/// Production database path. Always returns the real DB file regardless of
+/// whether sandbox mode is currently active — used by the sandbox toggle
+/// (to seed `demo.db`) and by the audit log writer (so toggle history is
+/// preserved across sandbox enables/disables).
+pub fn prod_db_path(app: &AppHandle) -> AppResult<PathBuf> {
+    Ok(app_data_dir(app)?.join("perpustakaan-v2.db"))
+}
+
+/// Sandbox / demo database path (D5-SandboxDemoMode).
+pub fn demo_db_path(app: &AppHandle) -> AppResult<PathBuf> {
+    Ok(app_data_dir(app)?.join("perpustakaan-v2-demo.db"))
+}
+
+/// Path of the persisted sandbox-active flag. The presence of the file
+/// (with content `"1"`) means sandbox mode should be re-enabled on next
+/// startup. We use a separate plain file rather than the `settings` table
+/// so sandbox state is decoupled from whichever DB is currently mounted.
+pub fn sandbox_flag_path(app: &AppHandle) -> AppResult<PathBuf> {
+    Ok(app_data_dir(app)?.join("sandbox.flag"))
+}
+
+/// Read the persisted sandbox flag. Defaults to `false` if the file is
+/// missing or unreadable so a clean install always boots into prod mode.
+pub fn read_sandbox_flag(app: &AppHandle) -> bool {
+    let Ok(path) = sandbox_flag_path(app) else {
+        return false;
+    };
+    matches!(std::fs::read_to_string(&path), Ok(s) if s.trim() == "1")
+}
+
+/// Persist the sandbox flag to disk. Writes `"1"` when on, removes the file
+/// when off so a fresh install never accidentally inherits sandbox mode
+/// from a stale file.
+pub fn write_sandbox_flag(app: &AppHandle, on: bool) -> AppResult<()> {
+    let path = sandbox_flag_path(app)?;
+    if on {
+        std::fs::write(&path, "1")?;
+    } else if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+/// Resolve the DB path to mount at startup. Picks `demo.db` when the
+/// sandbox flag is set, the production DB otherwise. Existing callers
+/// (dashboard system-health, manual backup, scheduler) keep working without
+/// modification.
+pub fn resolve_db_path(app: &AppHandle) -> AppResult<PathBuf> {
+    if read_sandbox_flag(app) {
+        demo_db_path(app)
+    } else {
+        prod_db_path(app)
+    }
 }
 
 pub fn open_connection(path: &Path) -> AppResult<Connection> {
@@ -34,6 +89,7 @@ pub fn run_migrations(conn: &Connection) -> AppResult<()> {
     conn.execute_batch(SURAT_SQL)?;
     conn.execute_batch(WISHLIST_SQL)?;
     conn.execute_batch(SYNC_SQL)?;
+    conn.execute_batch(SANDBOX_AUDIT_SQL)?;
     apply_additive_migrations(conn)?;
     backfill_missing_eksemplar(conn)?;
     seed_master_data(conn)?;
@@ -115,6 +171,19 @@ CREATE TABLE IF NOT EXISTS sync_log (
 CREATE INDEX IF NOT EXISTS idx_sync_log_ts ON sync_log(ts DESC);
 "#;
 
+/// D5-SandboxDemoMode — append-only log of sandbox toggles. Lives in the
+/// production DB (never in the demo copy) so toggle history is preserved
+/// across `enable_sandbox` overwrites of `demo.db`.
+const SANDBOX_AUDIT_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS sandbox_audit_log (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts        TEXT NOT NULL DEFAULT (datetime('now')),
+    action    TEXT NOT NULL CHECK (action IN ('enable','disable')),
+    user_id   INTEGER,
+    note      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sandbox_audit_ts ON sandbox_audit_log(ts DESC);
+"#;
 
 const KTA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS kta_templates (

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,10 @@ pub struct AppState {
     pub db: Mutex<rusqlite::Connection>,
     pub current_user: Mutex<Option<commands::auth::SessionUser>>,
     pub remember_token: Mutex<Option<String>>,
+    /// D5-SandboxDemoMode — `true` when the active `db` connection points
+    /// at `demo.db`. Mirrors the on-disk `sandbox.flag` so RPC handlers
+    /// can branch without re-reading the file on every call.
+    pub sandbox_mode: Mutex<bool>,
 }
 
 const MAIN_WINDOW_LABEL: &str = "main";
@@ -39,8 +43,28 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
-            let db_path = db::resolve_db_path(app.handle())?;
-            log::info!("opening sqlite db at {}", db_path.display());
+            // D5: ensure the production DB is migrated even when we boot
+            // straight into sandbox mode, so the audit log and prod schema
+            // stay current. Sandbox mode persists across restarts via the
+            // `sandbox.flag` file, so on next launch we mount `demo.db` if
+            // the flag is still present.
+            let prod_path = db::prod_db_path(app.handle())?;
+            {
+                let prod_conn = db::open_connection(&prod_path)?;
+                db::run_migrations(&prod_conn)?;
+                db::seed_default_admin(&prod_conn)?;
+            }
+            let sandbox_active = db::read_sandbox_flag(app.handle());
+            let db_path = if sandbox_active {
+                db::demo_db_path(app.handle())?
+            } else {
+                prod_path.clone()
+            };
+            log::info!(
+                "opening sqlite db at {} (sandbox={})",
+                db_path.display(),
+                sandbox_active
+            );
             let conn = db::open_connection(&db_path)?;
             db::run_migrations(&conn)?;
             db::seed_default_admin(&conn)?;
@@ -48,6 +72,7 @@ pub fn run() {
                 db: Mutex::new(conn),
                 current_user: Mutex::new(None),
                 remember_token: Mutex::new(None),
+                sandbox_mode: Mutex::new(sandbox_active),
             });
 
             // BUG-011: build the system tray once at setup. The tray is
@@ -167,6 +192,9 @@ pub fn run() {
             commands::dashboard::dashboard_heatmap,
             commands::dashboard::dashboard_insights,
             commands::dashboard::dashboard_system_health,
+            commands::sandbox::sandbox_status,
+            commands::sandbox::sandbox_enable,
+            commands::sandbox::sandbox_disable,
             commands::laporan::laporan_grafik,
             commands::laporan::laporan_top_peminjam,
             commands::laporan::laporan_top_buku,

--- a/apps/desktop/src/components/layout/AppShell.tsx
+++ b/apps/desktop/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Outlet, useNavigate } from '@tanstack/react-router';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
+import { SandboxBanner } from './SandboxBanner';
 import { useSidebarStore } from '@/stores/sidebarStore';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 
@@ -55,6 +56,7 @@ export function AppShell() {
     <div className="flex h-full min-h-0 min-w-[800px] overflow-hidden bg-background text-foreground">
       <Sidebar />
       <div className="flex min-w-0 flex-1 flex-col">
+        <SandboxBanner />
         <Header />
         <main className="flex-1 overflow-y-auto" data-testid="app-main">
           <Outlet />

--- a/apps/desktop/src/components/layout/SandboxBanner.tsx
+++ b/apps/desktop/src/components/layout/SandboxBanner.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { sandboxApi } from '@/lib/sandbox';
+
+/**
+ * D5-SandboxDemoMode — global yellow banner mounted above the AppShell
+ * Header. Renders only when sandbox mode is active. The "Kembali ke Mode
+ * Asli" button calls `sandbox_disable` and reloads the window so every
+ * React Query cache is rebuilt from the production DB.
+ */
+export function SandboxBanner(): React.ReactElement | null {
+  const { t } = useTranslation(['settings', 'common']);
+  const [active, setActive] = useState<boolean>(false);
+  const [busy, setBusy] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancel = false;
+    sandboxApi
+      .status()
+      .then((s) => {
+        if (!cancel) setActive(s.active);
+      })
+      .catch(() => {
+        if (!cancel) setActive(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, []);
+
+  if (!active) return null;
+
+  const handleDisable = async (): Promise<void> => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await sandboxApi.disable();
+      // Hard reload so React Query, Zustand stores, and route loaders all
+      // re-fetch from the production DB.
+      window.location.reload();
+    } catch {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center justify-between gap-4 border-b border-amber-300/70 bg-amber-100 px-4 py-2 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200"
+      data-testid="sandbox-banner"
+      role="status"
+    >
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4" aria-hidden />
+        <span className="text-sm font-medium">
+          {t('settings:sections.sandbox.bannerMessage', {
+            defaultValue: 'Mode Demo aktif — perubahan tidak menyentuh data asli.',
+          })}
+        </span>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleDisable}
+        disabled={busy}
+        data-testid="sandbox-banner-disable"
+        className="border-amber-400 bg-white/40 text-amber-900 hover:bg-white/70 dark:border-amber-500/50 dark:bg-amber-500/10 dark:text-amber-100"
+      >
+        {t('settings:sections.sandbox.disable', { defaultValue: 'Kembali ke Mode Asli' })}
+      </Button>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/settings/SandboxPage.tsx
+++ b/apps/desktop/src/features/settings/SandboxPage.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { useToast } from '@/components/ui/toast-manager';
+import { sandboxApi, type SandboxStatus } from '@/lib/sandbox';
+import { SettingsSection } from './SettingsSection';
+
+/**
+ * D5-SandboxDemoMode — Settings sub-page that toggles sandbox mode. Both
+ * enable and disable trigger a hard reload after the RPC succeeds so every
+ * cache (React Query, Zustand, route loaders) re-fetches against the new
+ * active connection.
+ */
+export function SandboxPage(): JSX.Element {
+  const { t } = useTranslation(['settings', 'common']);
+  const { showToast } = useToast();
+  const [status, setStatus] = useState<SandboxStatus | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [confirm, setConfirm] = useState<'enable' | 'disable' | null>(null);
+  const [saving, setSaving] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const s = await sandboxApi.status();
+        if (!cancelled) setStatus(s);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onConfirm = async (): Promise<void> => {
+    if (confirm === null) return;
+    setSaving(true);
+    try {
+      const next = confirm === 'enable' ? await sandboxApi.enable() : await sandboxApi.disable();
+      setStatus(next);
+      showToast({
+        title:
+          confirm === 'enable'
+            ? t('settings:sections.sandbox.enabledToast', {
+                defaultValue: 'Mode Demo aktif. Memuat ulang…',
+              })
+            : t('settings:sections.sandbox.disabledToast', {
+                defaultValue: 'Mode Demo dinonaktifkan. Memuat ulang…',
+              }),
+      });
+      if (typeof window !== 'undefined') window.location.reload();
+    } catch (err) {
+      showToast({
+        variant: 'destructive',
+        title: t('settings:sections.sandbox.error', {
+          defaultValue: 'Gagal mengubah Mode Demo',
+        }),
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSaving(false);
+      setConfirm(null);
+    }
+  };
+
+  const active = status?.active ?? false;
+
+  return (
+    <SettingsSection i18nKey="sandbox">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-3 rounded-md border bg-muted/40 p-4">
+          {active ? (
+            <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-600" aria-hidden />
+          ) : (
+            <ShieldCheck className="mt-0.5 h-5 w-5 text-emerald-600" aria-hidden />
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">
+              {active
+                ? t('settings:sections.sandbox.activeTitle', {
+                    defaultValue: 'Mode Demo aktif',
+                  })
+                : t('settings:sections.sandbox.inactiveTitle', {
+                    defaultValue: 'Mode Demo nonaktif',
+                  })}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {active
+                ? t('settings:sections.sandbox.activeDescription', {
+                    defaultValue:
+                      'Aplikasi sedang menyentuh database demo terpisah. Backup otomatis dilewati selama mode demo aktif.',
+                  })
+                : t('settings:sections.sandbox.inactiveDescription', {
+                    defaultValue:
+                      'Mengaktifkan mode demo akan menyalin database asli ke `demo.db` dan memuat ulang aplikasi.',
+                  })}
+            </p>
+          </div>
+        </div>
+
+        <dl className="grid gap-2 rounded-md border p-4 text-sm" data-testid="sandbox-paths">
+          <div className="grid grid-cols-[8rem_1fr] gap-2">
+            <dt className="text-muted-foreground">
+              {t('settings:sections.sandbox.activeDb', { defaultValue: 'DB aktif' })}
+            </dt>
+            <dd className="break-all font-mono text-xs">
+              {loading ? '…' : status?.dbPath ?? '—'}
+            </dd>
+          </div>
+          <div className="grid grid-cols-[8rem_1fr] gap-2">
+            <dt className="text-muted-foreground">
+              {t('settings:sections.sandbox.prodDb', { defaultValue: 'DB asli' })}
+            </dt>
+            <dd className="break-all font-mono text-xs">
+              {loading ? '…' : status?.prodDbPath ?? '—'}
+            </dd>
+          </div>
+          <div className="grid grid-cols-[8rem_1fr] gap-2">
+            <dt className="text-muted-foreground">
+              {t('settings:sections.sandbox.demoDb', { defaultValue: 'DB demo' })}
+            </dt>
+            <dd className="break-all font-mono text-xs">
+              {loading ? '…' : status?.demoDbPath ?? '—'}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="flex flex-wrap gap-2">
+          {!active ? (
+            <Button
+              onClick={() => setConfirm('enable')}
+              disabled={loading || saving}
+              data-testid="sandbox-enable-btn"
+            >
+              {t('settings:sections.sandbox.enable', { defaultValue: 'Aktifkan Mode Demo' })}
+            </Button>
+          ) : (
+            <Button
+              variant="destructive"
+              onClick={() => setConfirm('disable')}
+              disabled={loading || saving}
+              data-testid="sandbox-disable-btn"
+            >
+              {t('settings:sections.sandbox.disable', { defaultValue: 'Kembali ke Mode Asli' })}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={confirm !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+        title={
+          confirm === 'enable'
+            ? t('settings:sections.sandbox.confirmEnableTitle', {
+                defaultValue: 'Aktifkan Mode Demo?',
+              })
+            : t('settings:sections.sandbox.confirmDisableTitle', {
+                defaultValue: 'Nonaktifkan Mode Demo?',
+              })
+        }
+        description={
+          confirm === 'enable'
+            ? t('settings:sections.sandbox.confirmEnableDescription', {
+                defaultValue:
+                  'Database asli akan disalin ke demo.db. Aplikasi akan dimuat ulang dan semua perubahan berikutnya tidak menyentuh data asli.',
+              })
+            : t('settings:sections.sandbox.confirmDisableDescription', {
+                defaultValue:
+                  'Database demo akan diarsipkan dan aplikasi kembali ke data asli setelah memuat ulang.',
+              })
+        }
+        confirmText={
+          confirm === 'enable'
+            ? t('settings:sections.sandbox.enable', { defaultValue: 'Aktifkan Mode Demo' })
+            : t('settings:sections.sandbox.disable', { defaultValue: 'Kembali ke Mode Asli' })
+        }
+        cancelText={t('common:actions.cancel', { defaultValue: 'Batal' })}
+        destructive={confirm === 'disable'}
+        onConfirm={onConfirm}
+      />
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/features/settings/sections.ts
+++ b/apps/desktop/src/features/settings/sections.ts
@@ -13,6 +13,7 @@ import {
   BookText,
   BookOpen,
   Monitor,
+  FlaskConical,
 } from 'lucide-react';
 
 /**
@@ -166,6 +167,22 @@ export const SECTIONS: SectionDef[] = [
     i18nKey: 'aksesMode',
     Icon: Monitor,
     keywords: ['akses mode', 'mode akses', 'opac', 'public', 'kios', 'kiosk', 'admin', 'fullscreen'],
+  },
+  {
+    id: 'sandbox',
+    to: '/settings/sandbox',
+    i18nKey: 'sandbox',
+    Icon: FlaskConical,
+    keywords: [
+      'sandbox',
+      'mode demo',
+      'demo mode',
+      'demo',
+      'training',
+      'pelatihan',
+      'simulasi',
+      'safe mode',
+    ],
   },
 ];
 

--- a/apps/desktop/src/i18n/en/settings.json
+++ b/apps/desktop/src/i18n/en/settings.json
@@ -318,6 +318,27 @@
       "feedback": {
         "saved": "Access mode saved. Reloading…"
       }
+    },
+    "sandbox": {
+      "label": "Demo Mode",
+      "summary": "Run the app against a separate sandbox database — handy for training without touching real data.",
+      "activeTitle": "Demo mode active",
+      "inactiveTitle": "Demo mode inactive",
+      "activeDescription": "The app is currently writing to a separate demo database. Automatic backups are skipped while demo mode is active.",
+      "inactiveDescription": "Turning on demo mode copies the live database to demo.db and reloads the app. Subsequent changes never touch the live data.",
+      "enable": "Enable demo mode",
+      "disable": "Back to live mode",
+      "activeDb": "Active DB",
+      "prodDb": "Live DB",
+      "demoDb": "Demo DB",
+      "bannerMessage": "Demo mode active — changes don't touch the live data.",
+      "confirmEnableTitle": "Enable demo mode?",
+      "confirmEnableDescription": "The live database will be copied to demo.db. The app will reload and subsequent changes will never touch the live data.",
+      "confirmDisableTitle": "Disable demo mode?",
+      "confirmDisableDescription": "The demo database will be archived and the app returns to the live data after reload.",
+      "enabledToast": "Demo mode active. Reloading…",
+      "disabledToast": "Demo mode disabled. Reloading…",
+      "error": "Failed to toggle demo mode"
     }
   }
 }

--- a/apps/desktop/src/i18n/id/settings.json
+++ b/apps/desktop/src/i18n/id/settings.json
@@ -318,6 +318,27 @@
       "feedback": {
         "saved": "Mode akses tersimpan. Memuat ulang…"
       }
+    },
+    "sandbox": {
+      "label": "Mode Demo",
+      "summary": "Aktifkan mode latihan: aplikasi memakai database demo terpisah, data asli aman.",
+      "activeTitle": "Mode Demo aktif",
+      "inactiveTitle": "Mode Demo nonaktif",
+      "activeDescription": "Aplikasi sedang menyentuh database demo terpisah. Backup otomatis dilewati selama mode demo aktif.",
+      "inactiveDescription": "Mengaktifkan mode demo akan menyalin database asli ke demo.db lalu memuat ulang aplikasi. Perubahan berikutnya tidak akan menyentuh data asli.",
+      "enable": "Aktifkan Mode Demo",
+      "disable": "Kembali ke Mode Asli",
+      "activeDb": "DB aktif",
+      "prodDb": "DB asli",
+      "demoDb": "DB demo",
+      "bannerMessage": "Mode Demo aktif — perubahan tidak menyentuh data asli.",
+      "confirmEnableTitle": "Aktifkan Mode Demo?",
+      "confirmEnableDescription": "Database asli akan disalin ke demo.db. Aplikasi akan dimuat ulang dan semua perubahan berikutnya tidak menyentuh data asli.",
+      "confirmDisableTitle": "Nonaktifkan Mode Demo?",
+      "confirmDisableDescription": "Database demo akan diarsipkan dan aplikasi kembali ke data asli setelah memuat ulang.",
+      "enabledToast": "Mode Demo aktif. Memuat ulang…",
+      "disabledToast": "Mode Demo dinonaktifkan. Memuat ulang…",
+      "error": "Gagal mengubah Mode Demo"
     }
   }
 }

--- a/apps/desktop/src/lib/sandbox.ts
+++ b/apps/desktop/src/lib/sandbox.ts
@@ -1,0 +1,61 @@
+import { invoke } from '@tauri-apps/api/core';
+import { isTauri } from '@/lib/auth';
+
+/**
+ * D5-SandboxDemoMode — operational status of the sandbox toggle. Mirrored
+ * 1:1 from the Rust `SandboxStatus` struct (camelCase via serde).
+ */
+export interface SandboxStatus {
+  active: boolean;
+  dbPath: string;
+  demoDbPath: string;
+  prodDbPath: string;
+}
+
+export interface SandboxRpc {
+  status: () => Promise<SandboxStatus>;
+  enable: () => Promise<SandboxStatus>;
+  disable: () => Promise<SandboxStatus>;
+}
+
+const tauriRpc: SandboxRpc = {
+  status: () => invoke<SandboxStatus>('sandbox_status'),
+  enable: () => invoke<SandboxStatus>('sandbox_enable'),
+  disable: () => invoke<SandboxStatus>('sandbox_disable'),
+};
+
+/**
+ * Mock implementation used in the dev browser (where there is no Tauri
+ * backend). Keeps an in-memory flag so the SettingsPage and SandboxBanner
+ * can be exercised end-to-end without a real DB swap.
+ */
+function makeMockRpc(): SandboxRpc {
+  let active = false;
+  const status = (): SandboxStatus => ({
+    active,
+    dbPath: active ? '/mock/perpustakaan-v2-demo.db' : '/mock/perpustakaan-v2.db',
+    demoDbPath: '/mock/perpustakaan-v2-demo.db',
+    prodDbPath: '/mock/perpustakaan-v2.db',
+  });
+  return {
+    async status() {
+      return status();
+    },
+    async enable() {
+      active = true;
+      return status();
+    },
+    async disable() {
+      active = false;
+      return status();
+    },
+  };
+}
+
+const mockRpc: SandboxRpc = makeMockRpc();
+
+export const sandboxApi: SandboxRpc = {
+  status: () => (isTauri() ? tauriRpc.status() : mockRpc.status()),
+  enable: () => (isTauri() ? tauriRpc.enable() : mockRpc.enable()),
+  disable: () => (isTauri() ? tauriRpc.disable() : mockRpc.disable()),
+};

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as AuthedAnggotaIndexRouteImport } from './routes/_authed/anggota
 import { Route as AuthedSettingsTentangRouteImport } from './routes/_authed/settings/tentang'
 import { Route as AuthedSettingsTampilanRouteImport } from './routes/_authed/settings/tampilan'
 import { Route as AuthedSettingsSinkronisasiRouteImport } from './routes/_authed/settings/sinkronisasi'
+import { Route as AuthedSettingsSandboxRouteImport } from './routes/_authed/settings/sandbox'
 import { Route as AuthedSettingsMasterDataRouteImport } from './routes/_authed/settings/master-data'
 import { Route as AuthedSettingsManualRouteImport } from './routes/_authed/settings/manual'
 import { Route as AuthedSettingsLabelBukuRouteImport } from './routes/_authed/settings/label-buku'
@@ -156,6 +157,11 @@ const AuthedSettingsSinkronisasiRoute =
     path: '/sinkronisasi',
     getParentRoute: () => AuthedSettingsRoute,
   } as any)
+const AuthedSettingsSandboxRoute = AuthedSettingsSandboxRouteImport.update({
+  id: '/sandbox',
+  path: '/sandbox',
+  getParentRoute: () => AuthedSettingsRoute,
+} as any)
 const AuthedSettingsMasterDataRoute =
   AuthedSettingsMasterDataRouteImport.update({
     id: '/master-data',
@@ -325,6 +331,7 @@ export interface FileRoutesByFullPath {
   '/settings/label-buku': typeof AuthedSettingsLabelBukuRoute
   '/settings/manual': typeof AuthedSettingsManualRoute
   '/settings/master-data': typeof AuthedSettingsMasterDataRoute
+  '/settings/sandbox': typeof AuthedSettingsSandboxRoute
   '/settings/sinkronisasi': typeof AuthedSettingsSinkronisasiRoute
   '/settings/tampilan': typeof AuthedSettingsTampilanRoute
   '/settings/tentang': typeof AuthedSettingsTentangRoute
@@ -370,6 +377,7 @@ export interface FileRoutesByTo {
   '/settings/label-buku': typeof AuthedSettingsLabelBukuRoute
   '/settings/manual': typeof AuthedSettingsManualRoute
   '/settings/master-data': typeof AuthedSettingsMasterDataRoute
+  '/settings/sandbox': typeof AuthedSettingsSandboxRoute
   '/settings/sinkronisasi': typeof AuthedSettingsSinkronisasiRoute
   '/settings/tampilan': typeof AuthedSettingsTampilanRoute
   '/settings/tentang': typeof AuthedSettingsTentangRoute
@@ -419,6 +427,7 @@ export interface FileRoutesById {
   '/_authed/settings/label-buku': typeof AuthedSettingsLabelBukuRoute
   '/_authed/settings/manual': typeof AuthedSettingsManualRoute
   '/_authed/settings/master-data': typeof AuthedSettingsMasterDataRoute
+  '/_authed/settings/sandbox': typeof AuthedSettingsSandboxRoute
   '/_authed/settings/sinkronisasi': typeof AuthedSettingsSinkronisasiRoute
   '/_authed/settings/tampilan': typeof AuthedSettingsTampilanRoute
   '/_authed/settings/tentang': typeof AuthedSettingsTentangRoute
@@ -468,6 +477,7 @@ export interface FileRouteTypes {
     | '/settings/label-buku'
     | '/settings/manual'
     | '/settings/master-data'
+    | '/settings/sandbox'
     | '/settings/sinkronisasi'
     | '/settings/tampilan'
     | '/settings/tentang'
@@ -513,6 +523,7 @@ export interface FileRouteTypes {
     | '/settings/label-buku'
     | '/settings/manual'
     | '/settings/master-data'
+    | '/settings/sandbox'
     | '/settings/sinkronisasi'
     | '/settings/tampilan'
     | '/settings/tentang'
@@ -561,6 +572,7 @@ export interface FileRouteTypes {
     | '/_authed/settings/label-buku'
     | '/_authed/settings/manual'
     | '/_authed/settings/master-data'
+    | '/_authed/settings/sandbox'
     | '/_authed/settings/sinkronisasi'
     | '/_authed/settings/tampilan'
     | '/_authed/settings/tentang'
@@ -720,6 +732,13 @@ declare module '@tanstack/react-router' {
       path: '/sinkronisasi'
       fullPath: '/settings/sinkronisasi'
       preLoaderRoute: typeof AuthedSettingsSinkronisasiRouteImport
+      parentRoute: typeof AuthedSettingsRoute
+    }
+    '/_authed/settings/sandbox': {
+      id: '/_authed/settings/sandbox'
+      path: '/sandbox'
+      fullPath: '/settings/sandbox'
+      preLoaderRoute: typeof AuthedSettingsSandboxRouteImport
       parentRoute: typeof AuthedSettingsRoute
     }
     '/_authed/settings/master-data': {
@@ -944,6 +963,7 @@ interface AuthedSettingsRouteChildren {
   AuthedSettingsLabelBukuRoute: typeof AuthedSettingsLabelBukuRoute
   AuthedSettingsManualRoute: typeof AuthedSettingsManualRoute
   AuthedSettingsMasterDataRoute: typeof AuthedSettingsMasterDataRoute
+  AuthedSettingsSandboxRoute: typeof AuthedSettingsSandboxRoute
   AuthedSettingsSinkronisasiRoute: typeof AuthedSettingsSinkronisasiRoute
   AuthedSettingsTampilanRoute: typeof AuthedSettingsTampilanRoute
   AuthedSettingsTentangRoute: typeof AuthedSettingsTentangRoute
@@ -963,6 +983,7 @@ const AuthedSettingsRouteChildren: AuthedSettingsRouteChildren = {
   AuthedSettingsLabelBukuRoute: AuthedSettingsLabelBukuRoute,
   AuthedSettingsManualRoute: AuthedSettingsManualRoute,
   AuthedSettingsMasterDataRoute: AuthedSettingsMasterDataRoute,
+  AuthedSettingsSandboxRoute: AuthedSettingsSandboxRoute,
   AuthedSettingsSinkronisasiRoute: AuthedSettingsSinkronisasiRoute,
   AuthedSettingsTampilanRoute: AuthedSettingsTampilanRoute,
   AuthedSettingsTentangRoute: AuthedSettingsTentangRoute,

--- a/apps/desktop/src/routes/_authed/settings/sandbox.tsx
+++ b/apps/desktop/src/routes/_authed/settings/sandbox.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { SandboxPage } from '@/features/settings/SandboxPage';
+
+export const Route = createFileRoute('/_authed/settings/sandbox')({
+  component: SandboxPage,
+});

--- a/apps/desktop/tests/unit/sandboxBanner.test.tsx
+++ b/apps/desktop/tests/unit/sandboxBanner.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '@/i18n';
+
+// Mock the sandbox RPC so we control the active flag and observe disable() calls.
+vi.mock('@/lib/sandbox', () => {
+  const status = vi.fn();
+  const enable = vi.fn();
+  const disable = vi.fn();
+  return {
+    sandboxApi: { status, enable, disable },
+  };
+});
+
+import { SandboxBanner } from '@/components/layout/SandboxBanner';
+import { sandboxApi } from '@/lib/sandbox';
+
+function renderBanner() {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <SandboxBanner />
+    </I18nextProvider>,
+  );
+}
+
+describe('SandboxBanner', () => {
+  const reloadSpy = vi.fn();
+  const originalReload = window.location.reload;
+
+  beforeEach(() => {
+    vi.mocked(sandboxApi.status).mockReset();
+    vi.mocked(sandboxApi.enable).mockReset();
+    vi.mocked(sandboxApi.disable).mockReset();
+    reloadSpy.mockReset();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: originalReload },
+    });
+  });
+
+  it('renders nothing when sandbox is inactive', async () => {
+    vi.mocked(sandboxApi.status).mockResolvedValue({
+      active: false,
+      dbPath: '/p',
+      demoDbPath: '/d',
+      prodDbPath: '/p',
+    });
+    renderBanner();
+    // Banner only mounts asynchronously; assert it stays absent.
+    await waitFor(() => {
+      expect(sandboxApi.status).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByTestId('sandbox-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders banner + disable button when sandbox is active', async () => {
+    vi.mocked(sandboxApi.status).mockResolvedValue({
+      active: true,
+      dbPath: '/d',
+      demoDbPath: '/d',
+      prodDbPath: '/p',
+    });
+    renderBanner();
+    expect(await screen.findByTestId('sandbox-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('sandbox-banner-disable')).toBeInTheDocument();
+  });
+
+  it('calls sandboxApi.disable() and reloads when disable button clicked', async () => {
+    vi.mocked(sandboxApi.status).mockResolvedValue({
+      active: true,
+      dbPath: '/d',
+      demoDbPath: '/d',
+      prodDbPath: '/p',
+    });
+    vi.mocked(sandboxApi.disable).mockResolvedValue({
+      active: false,
+      dbPath: '/p',
+      demoDbPath: '/d',
+      prodDbPath: '/p',
+    });
+    renderBanner();
+    const btn = await screen.findByTestId('sandbox-banner-disable');
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(sandboxApi.disable).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('hides itself if status() rejects (treats as inactive)', async () => {
+    vi.mocked(sandboxApi.status).mockRejectedValue(new Error('rpc down'));
+    renderBanner();
+    await waitFor(() => {
+      expect(sandboxApi.status).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByTestId('sandbox-banner')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **D5-SandboxDemoMode** from the v1.1.0 batch (BUGS.md line 932): a Settings toggle that switches the live app to a separate `demo.db` so admins can train staff or experiment without touching real data.

**Backend (`apps/desktop/src-tauri`):**
- `AppState.sandbox_mode: Mutex<bool>` mirrors the on-disk flag for fast checks in hot paths (e.g. backup scheduler).
- `db/mod.rs`: new helpers `prod_db_path`, `demo_db_path`, `sandbox_flag_path`, `read_sandbox_flag`, `write_sandbox_flag`. `resolve_db_path` now picks `demo.db` when the flag is on, so existing callers (dashboard system-health, manual backup) keep working without changes.
- New `commands/sandbox.rs` exposes 3 RPCs: `sandbox_status`, `sandbox_enable`, `sandbox_disable`.
  - `enable`: copies prod → demo, runs migrations + seed on demo, swaps the connection on `state.db`, writes the persistence flag, appends `enable` audit row.
  - `disable`: reopens prod, archives `demo.db` to `<app_data>/demo-archive/<ts>.db` (best-effort), clears the flag, appends `disable` audit row.
- New table `sandbox_audit_log` (id, ts, action CHECK enable|disable, user_id, note) lives in the **production** DB so toggle history is preserved across demo wipes.
- `commands/backup_runner::tick` short-circuits when sandbox is active so the cron-driven auto-backup never targets demo data. Manual backups still flow normally against the active connection.
- Startup migrates both prod and the active DB so the audit log table is always available, regardless of which DB boots first.

**Frontend (`apps/desktop/src`):**
- `lib/sandbox.ts` — typed RPC wrapper with a small in-memory mock for the dev browser.
- `components/layout/SandboxBanner.tsx` — yellow global banner mounted above the AppShell `Header`. Renders only when `status().active`. Disable button reloads after RPC succeeds so React Query / Zustand caches rebuild from the new connection.
- `features/settings/SandboxPage.tsx` — Settings sub-page with status panel, DB-path diagnostics, enable/disable buttons, and a `ConfirmDialog` describing the side effects.
- `routes/_authed/settings/sandbox.tsx` — file-based route (route tree regenerated).
- `features/settings/sections.ts` — adds the `sandbox` SectionDef so it appears in the Settings sidebar and global search.
- i18n: full id/en parity for the new `settings:sections.sandbox.*` keys.

**Tests:**
- `apps/desktop/tests/unit/sandboxBanner.test.tsx` — 4 tests: hidden when inactive, visible+button when active, click -> `disable` + reload, status() rejection treated as inactive.
- Rust unit tests in `commands/sandbox.rs` — 3 tests: migration creates the audit table, CHECK constraint rejects unknown actions, file-level enable/disable roundtrip preserves prod when demo is mutated.

**Local gates (all green):**
- `pnpm typecheck` — Done
- `pnpm lint` — Done (max-warnings=0)
- `pnpm i18n:lint` — id ↔ en parity OK
- `pnpm test` — 581 passed (4 new sandbox-banner tests)
- `pnpm build` — Done
- `cargo check --all-targets` — Finished
- `cargo clippy --all-targets -- -D warnings` — Finished
- `cargo test sandbox` — 3/3 sandbox tests pass; full backend suite untouched

## Review & Testing Checklist for Human

Risk: yellow (touches AppState + DB connection swap + backup runner).

- [ ] Toggle ON from Settings -> Mode Demo, verify banner appears after reload, verify `<app_data>/perpustakaan-v2-demo.db` and `<app_data>/sandbox.flag` exist.
- [ ] Make a destructive change in demo mode (e.g. delete an anggota), toggle OFF, verify the change is gone after reload (data should be from the live DB).
- [ ] Restart the app while in demo mode — sandbox should still be active on next launch (flag is persisted).
- [ ] Verify the auto-backup scheduler is silent during demo mode (check logs for `backup-scheduler tick failed` or `wrote auto-backup` — should not fire). Manual backup from Settings should still work but writes a snapshot of the demo DB.

### Notes

- `demo.db` is archived to `<app_data>/demo-archive/demo-<timestamp>.db` on disable. The directory grows over time; future polish can add a "clear archive" button.
- The audit log row for `enable`/`disable` always lands in the **production** DB so toggle history survives a demo wipe. `user_id` is captured from `current_user` if logged in.
- React Query caches are reset by a hard `window.location.reload()` after every toggle, mirroring the existing pattern used by `AksesModePage`.
