### PR TITLE
release: v1.1.0 — sirkulasi QoL, OPAC interaktif, sandbox, command palette + README rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,106 @@ back to GitHub's auto-generated release notes.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-06
+
+Rilis fitur besar: 14 item baru — quality-of-life sirkulasi, OPAC interaktif
+penuh, dashboard sehat, dan **Mode Demo (Sandbox)** untuk pelatihan tanpa
+risiko ke data produksi. Semua perubahan offline-first, no network calls.
+
+### Added
+
+- **Inline Bayar Denda di PeminjamanDetail (#146)** — preset row 1×/2×/3×
+  `dendaPerHari` + tiga preset tetap (Rp 5.000 / 10.000 / 15.000) langsung di
+  atas input bayar, sama persis dengan `PengembalianPage`. Logika dedup
+  diekstrak ke helper `dendaPresets.ts` agar tidak ada copy-paste.
+- **Dashboard KPI cards clickable (#147)** — Total Anggota / Total Buku /
+  Buku Dipinjam navigasi langsung ke `/anggota`, `/buku`,
+  `/peminjaman?status=aktif`. Insight "Buku Terlaris bulan ini" + "Peminjam
+  Teraktif" navigasi ke halaman detail entitas. Card statis (rata-rata)
+  tetap non-clickable.
+- **Quote rotasi 2 menit + manual next (#148)** — `QUOTE_ROTATE_MS` turun
+  dari 5 menit → 2 menit, ditambah tombol `ChevronRight` untuk advance manual
+  tanpa menunggu timer. Animasi slide-up tetap.
+- **+30 quotes perpustakaan (#149)** — `quotes.json` ditambah 30 entri
+  spesifik tentang buku / literasi / perpustakaan dari penulis Indonesia
+  (Pram, Kartini, Hamka, Habibie) dan internasional (Borges, Sagan,
+  Calvino).
+- **Sirkulasi: search dropdown anggota + buku (#150)** — komponen
+  `ScanSearchInput` (combobox) menggantikan input scan polos di
+  `SirkulasiPage`. Ketik 3+ karakter (alpha) → dropdown muncul dengan
+  section Anggota + section Buku (buku hanya muncul mode pinjam +
+  anggota terpilih). USB hand-scanner burst tetap diteruskan langsung
+  ke handler scan tanpa membuka dropdown.
+- **OPAC post-scan profile (#151)** — setelah scan KTA muncul panel
+  full-screen `OpacMemberProfile` berisi avatar + identitas, peminjaman
+  aktif (badge `aktif`/`terlambat`), denda outstanding, riwayat 10
+  pinjaman terakhir, dan section reservasi. Setiap scan otomatis
+  menulis row `kunjungan` (deduplikasi 5 menit).
+- **OPAC scan-locked dialog (#152)** — saat `member` masih ter-set,
+  klik "Scan KTA Saya" mendapat dialog konfirmasi (`Anggota lain masih
+  login: <nama>` + tombol `Logout & Scan` / `Batal`) sebelum membuka
+  scan flow.
+- **Command palette (Ctrl/Cmd+K) lengkap (#153)** — `GlobalSearchDialog`
+  diperluas dari pure data-search jadi command palette penuh: 8+ aksi
+  cepat (Backup Sekarang, Cetak Laporan Bulanan, Tambah Anggota,
+  Tambah Buku, Toggle Tema, Toggle Mode Demo, Buka OPAC, Logout) +
+  6+ rute (Dashboard, Anggota, Buku, Peminjaman, Pengembalian,
+  Pengaturan, dst). Empty query tetap menampilkan `Aksi Cepat` +
+  `Halaman` tanpa membutuhkan ketikan.
+- **Skeleton screens (#154)** — komponen `TableSkeleton` (untuk
+  AnggotaListPage, BukuListPage, PeminjamanListPage,
+  PengembalianPage results panel) + `CardSkeleton` (untuk OPAC home
+  & search grid) menggantikan spinner. Hormati
+  `prefers-reduced-motion`, `aria-busy="true"` untuk screen reader.
+- **Laporan Eksekutif PDF (#155)** — tombol "Cetak Laporan Eksekutif"
+  di halaman Laporan menghasilkan PDF 3-halaman: cover + KPI summary,
+  charts (peminjaman per minggu, top 5 buku, top 5 anggota), action
+  items otomatis (denda > 50k, reservasi tertumpuk). Date-range picker
+  default = bulan berjalan. Operasi sepenuhnya offline (font + chart
+  bundled).
+- **Dashboard System Health card (#156)** — card baru di bawah KPI grid
+  menampilkan ukuran DB (KB/MB), backup terakhir (relatif),
+  backup berikutnya, jumlah reservasi tertunda (badge hijau saat 0,
+  oranye saat > 0), versi aplikasi + pill "Update tersedia". Click
+  baris navigasi: backup → Settings → Backup, reservasi → /reservasi.
+- **Mode Demo / Sandbox (#157)** — toggle di Pengaturan → Mode Demo
+  yang menukar app ke `perpustakaan-v2-demo.db` (auto-copy dari prod
+  pada enable). Banner kuning persisten saat aktif. Semua tulis di
+  mode demo terisolasi dari prod DB. Saat dinonaktifkan, demo DB
+  diarsipkan ke `demo-archive/<ts>.db`. Backup scheduler skip otomatis
+  saat sandbox aktif. Berguna untuk pelatihan petugas baru / demo
+  sekolah lain tanpa risiko menyentuh data asli.
+- **OPAC Buku Pilihan (carousel curated) (#158)** — admin pin sampai 5
+  buku featured dari halaman baru `/buku/buku-pilihan` (akses via
+  tombol "Atur Pilihan OPAC" di Buku list). OPAC home menampilkan
+  carousel auto-rotate 5s di atas grid katalog, pause-on-hover,
+  arrow + dot navigation, keyboard accessible (←/→ + Enter), respect
+  `prefers-reduced-motion`. Carousel tidak tampil sama sekali saat 0
+  pin aktif (tidak ada placeholder kosong). Cap 5 pin di-enforce di
+  client + server.
+
+### Fixed
+
+- **Detail Pengembalian: 6 tombol denda dengan nilai duplikat (#145)** —
+  saat `dendaPerHari = 5000`, preset multiplier (`5_000 / 10_000 / 15_000`)
+  dan preset tetap (`5_000 / 10_000 / 15_000`) bertumpuk → 6 tombol dengan
+  3 nilai duplikat. Sekarang dedup via `useMemo` set; saat collide hanya
+  3 tombol unique yang render. Dengan `dendaPerHari = 2000`, ke-6 tombol
+  unik (`2.000 / 4.000 / 6.000 / 5.000 / 10.000 / 15.000`).
+
+### Schema changes
+
+- Table baru `buku_pilihan` (FK ke `buku.id` ON DELETE CASCADE) untuk
+  E1-OPACBukuPilihan. Migration additif, idempotent.
+- Flag file `<app_data>/sandbox.flag` untuk persistensi state Mode
+  Demo lintas restart. Tidak menyentuh schema produksi.
+
+### Dependencies
+
+- Tidak ada upgrade dependency mayor di v1.1.0 — semua fitur
+  diimplementasi pakai dependency yang sudah ada (lucide-react,
+  pdf-lib, recharts, dst).
+
 ## [1.0.12] - 2026-05-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,128 +1,267 @@
 # Perpustakaan Nusantara
 
-> Aplikasi manajemen perpustakaan **offline-first** untuk sekolah / madrasah —
-> berjalan di Windows, Linux, dan macOS, semua data tersimpan lokal di SQLite.
+> **Aplikasi manajemen perpustakaan offline-first untuk sekolah & madrasah Indonesia.**
+> Berjalan di Windows, Linux, dan macOS. Semua data tersimpan lokal di SQLite.
+> Tanpa langganan, tanpa server, tanpa internet.
 
 [![Latest release](https://img.shields.io/github/v/release/alviarts/perpustakaan-offline?label=release)](https://github.com/alviarts/perpustakaan-offline/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![CI v2](https://github.com/alviarts/perpustakaan-offline/actions/workflows/ci-v2.yml/badge.svg?branch=main)](https://github.com/alviarts/perpustakaan-offline/actions/workflows/ci-v2.yml)
 
-📥 **[Download installer terbaru →](https://github.com/alviarts/perpustakaan-offline/releases/latest)** (Windows MSI / NSIS)
+📥 **[Download installer terbaru →](https://github.com/alviarts/perpustakaan-offline/releases/latest)**
+📖 **[Manual pengguna lengkap →](docs/manual.md)**
+
+---
+
+## 🎯 Untuk Siapa Aplikasi Ini?
+
+Sekolah / madrasah / komunitas yang mengelola perpustakaan tapi:
+
+- **Tidak punya server** atau IT staff khusus.
+- **Internet sering mati** atau biaya SaaS bulanan terlalu mahal.
+- Data peminjaman masih di **Excel / buku tulis** dan rawan hilang.
+- Butuh **KTA cetak**, **barcode scanner**, **laporan bulanan**, dan **OPAC kios** untuk siswa.
+
+Setelah dipasang, satu komputer tua dengan webcam pun cukup untuk menjalankan
+sirkulasi harian — tinggal scan KTA siswa, scan barcode buku, selesai. Backup
+otomatis ke USB / Google Drive.
 
 ---
 
 ## ✨ Fitur
 
-### 📚 Katalog Buku
-- Master data buku + cover + klasifikasi DDC
-- **Bulk import dari Excel/CSV** + **bulk import via ISBN** (Open Library + Google Books)
-- Cetak label barcode per eksemplar (single atau batch)
-- Filter, sort, dan pencarian fuzzy
+<details open>
+<summary><b>📚 Katalog Buku</b></summary>
 
-### 👥 Anggota
-- Master data anggota + foto + KTA per anggota
-- **Bulk import Excel/CSV** dengan mode "perbarui anggota yang sudah ada"
-- **Naik kelas batch** + **Surat Bebas Pustaka (SBP)** otomatis
-- Cetak KTA single / batch dari **20+ template** desain (front + back editor)
+- Master data buku + cover + klasifikasi DDC + kategori + bahasa.
+- **Bulk import dari Excel / CSV** + **bulk import via ISBN** (Open Library + Google Books, fallback offline).
+- Cetak label barcode per eksemplar (single atau batch, format Code-128).
+- Filter, sort, dan **pencarian fuzzy** (Ctrl+K, palette global).
+- **Buku Pilihan / Featured** — admin pin sampai 5 buku untuk carousel di OPAC.
 
-### 🔄 Sirkulasi (Peminjaman & Pengembalian)
-- Scanner barcode webcam dengan **overlay frame + ROI decode** + manual fallback
-- **Perpanjangan otomatis** 1-klik dengan batas konfigurabel
-- **Reservasi/booking** — antrian saat buku dipinjam, auto-promote saat kembali
-- Quick-input denda 1×/2×/3× dari aturan peminjaman
-- Riwayat per anggota + audit log per transaksi
+</details>
 
-### 📊 Dashboard & Laporan
-- Real-time: total anggota, buku, peminjaman aktif, kunjungan hari ini
-- **Trend chart** 30/90/365 hari + **heatmap kalender** aktivitas
-- Insights cards: top kategori, top anggota, buku populer minggu ini
-- Quote-of-the-day rotasi tiap 5 menit
-- Laporan Top Peminjam, Top Buku, Grafik Kunjungan, Kas (auto dari denda)
+<details open>
+<summary><b>👥 Anggota</b></summary>
 
-### 🌐 OPAC (Public Catalog)
-- Mode publik tanpa login — pengunjung browse katalog mandiri
-- **Kiosk lock** full-screen dengan idle reset 60 detik
-- Anggota submit **wishlist** (request pengadaan buku) langsung dari OPAC
+- Master data anggota + foto + KTA per anggota.
+- **Bulk import Excel / CSV** dengan mode "perbarui anggota yang sudah ada".
+- **Naik kelas batch** (akhir tahun ajaran) + **Surat Bebas Pustaka (SBP)** otomatis.
+- **Cetak KTA** single atau batch dari **20+ template** desain (front + back editor visual).
+- **Sinkronisasi Google Sheets** dua-arah (last-write-wins, optional).
 
-### 📦 Stocktake / Opname
-- Sesi opname terisolasi: scan barcode batch (kamera atau hand-scanner)
-- Real-time tally found / missing
-- Export laporan PDF + CSV per sesi
+</details>
 
-### ☁️ Backup & Sinkronisasi
-- Backup manual + scheduler cron-like
-- **Cloud target via rclone** (Google Drive, S3, Dropbox, dll) — **AES-256-GCM encrypted**
-- History audit 50 backup terakhir, decrypt langsung dari UI
-- **Sinkronisasi Google Sheets** dua-arah untuk anggota (last-write-wins)
+<details open>
+<summary><b>🔄 Sirkulasi (Peminjaman & Pengembalian)</b></summary>
 
-### ⚙️ Lainnya
-- **Login multi-user** dengan RBAC + lupa password offline (security question)
-- **Bilingual** Indonesia / English — toggle live, parity dijaga oleh CI
-- **Ctrl+K global search** (anggota + buku + peminjaman)
-- 12 tab Pengaturan: identitas, akun, hak akses, aturan peminjaman, tampilan, master data, backup, sync, audit log, manual book, tentang
-- System tray + close-behavior (minimize-to-tray vs close)
+- **Scanner barcode webcam** dengan overlay frame + ROI decode + manual fallback.
+- **USB hand-scanner auto-detection** (deteksi burst keystroke, langsung diproses).
+- **Search dropdown** (anggota + buku) di Sirkulasi — ketik nama / judul kalau scan gagal.
+- **Perpanjangan otomatis** 1-klik dengan batas konfigurabel (default 1× per pinjaman).
+- **Reservasi / antrian** saat eksemplar habis — auto-promote saat buku kembali.
+- **Inline Bayar Denda** dengan preset 1×/2×/3× × `dendaPerHari` + preset tetap (5k/10k/15k).
+- Riwayat per anggota + audit log per transaksi.
+
+</details>
+
+<details open>
+<summary><b>📊 Dashboard & Laporan</b></summary>
+
+- **Real-time KPI** (clickable): Total Anggota, Total Buku, Buku Dipinjam.
+- **Trend chart** 30/90/365 hari + **heatmap kalender** aktivitas.
+- **Insight cards**: Buku Terlaris, Peminjam Teraktif (clickable ke detail).
+- **Quote-of-the-day** rotasi 2 menit + tombol manual next.
+- **System Health card** — ukuran DB, backup terakhir, reservasi tertunda, versi.
+- **Laporan Top Peminjam, Top Buku, Grafik Kunjungan, Kas** (auto dari denda).
+- **Laporan Eksekutif PDF** 3-halaman (cover + KPI / charts / action items) buat rapat bulanan.
+
+</details>
+
+<details open>
+<summary><b>🌐 OPAC (Public Catalog)</b></summary>
+
+- **Mode publik tanpa login** — pengunjung browse katalog mandiri.
+- **Featured Carousel** di OPAC home — pinned books auto-rotate 5s, pause-on-hover, keyboard accessible.
+- **Post-scan profile** — setelah scan KTA muncul peminjaman aktif + denda outstanding + riwayat + reservasi.
+- **Auto absen kunjungan** setiap scan (deduplikasi 5 menit).
+- **Reservasi langsung dari OPAC** saat eksemplar 0 — antrian FIFO.
+- **Scan-locked dialog** — kalau anggota lain masih login, konfirmasi dulu sebelum scan baru.
+- **Kiosk lock** full-screen dengan idle reset 60 detik.
+- **Wishlist** — anggota request pengadaan buku langsung dari OPAC.
+
+</details>
+
+<details open>
+<summary><b>📦 Stocktake / Opname</b></summary>
+
+- Sesi opname terisolasi: scan barcode batch (kamera atau hand-scanner).
+- Real-time tally found / missing / extra.
+- Export laporan PDF + CSV per sesi.
+
+</details>
+
+<details open>
+<summary><b>☁️ Backup & Sinkronisasi</b></summary>
+
+- Backup manual + scheduler cron-like.
+- **Cloud target via rclone** (Google Drive, S3, Dropbox, dll) — **AES-256-GCM encrypted**.
+- History audit 50 backup terakhir, decrypt langsung dari UI.
+- **Sinkronisasi Google Sheets** dua-arah untuk anggota.
+
+</details>
+
+<details open>
+<summary><b>🧪 Mode Demo / Sandbox</b></summary>
+
+- Toggle di Pengaturan → Mode Demo untuk **switch ke DB demo terpisah**.
+- Banner kuning aktif persisten lintas restart.
+- **Semua perubahan terisolasi** — DB asli aman.
+- Demo DB diarsipkan otomatis saat dinonaktifkan.
+- Cocok buat: training petugas baru, demo ke sekolah lain, debugging.
+
+</details>
+
+<details open>
+<summary><b>⚙️ Lainnya</b></summary>
+
+- **Login multi-user** dengan **RBAC** + lupa password offline (security question).
+- **Bilingual** Indonesia / English — toggle live, parity dijaga oleh CI.
+- **Command palette (Ctrl/Cmd+K)** — jump ke halaman / aksi cepat (Backup Sekarang, Cetak Laporan, Toggle Tema, dst).
+- **Skeleton screens** menggantikan spinner (loading lebih halus, hormati `prefers-reduced-motion`).
+- 12 tab Pengaturan: identitas, akun, hak akses, aturan peminjaman, tampilan, master data, backup, sync, audit log, manual book, tentang, mode demo.
+- System tray + close-behavior (minimize-to-tray vs close).
+
+</details>
 
 ---
 
-## 🚀 Quick Start
+## 🚀 Cara Pasang (untuk Pustakawan / Pengguna Akhir)
 
-### Untuk pengguna akhir
+### Windows
 
-1. Download installer dari [Releases](https://github.com/alviarts/perpustakaan-offline/releases/latest):
-   - **Windows:** `PerpustakaanNusantara_<version>_x64-setup.exe` (NSIS) atau `.msi`
-2. Jalankan installer.
-3. Login default: `admin` / `admin123` — **wajib diubah saat login pertama**.
+1. Download installer terbaru dari **[Releases](https://github.com/alviarts/perpustakaan-offline/releases/latest)**:
+   - `PerpustakaanNusantara_<version>_x64-setup.exe` (NSIS, recommended) **atau**
+   - `PerpustakaanNusantara_<version>_x64_en-US.msi` (MSI, untuk deployment via GPO).
+2. Klik kanan installer → **Run as administrator** → ikuti wizard → selesai.
+3. Buka aplikasi dari Start Menu: **Perpustakaan Nusantara**.
+4. **Login pertama:**
+   - Username: `admin`
+   - Password: `admin123`
+   - **WAJIB ganti password** saat login pertama (form akan muncul otomatis).
 
-### Untuk developer
+### Linux
+
+Belum ada `.deb` / `.AppImage` resmi di releases — sementara build sendiri dari source (lihat [Untuk Developer](#-untuk-developer)).
+
+### macOS
+
+Belum ada `.dmg` resmi di releases — sementara build sendiri dari source.
+
+---
+
+## 🎬 Setup Pertama Kali (5 Menit Sampai Pakai)
+
+Setelah login pertama dan ganti password admin:
+
+1. **Pengaturan → Identitas Sekolah** — isi nama sekolah, alamat, logo. Akan muncul di KTA, surat bebas pustaka, dan PDF laporan.
+2. **Pengaturan → Aturan Peminjaman** — atur lama pinjam (default 7 hari), denda per hari (default Rp 0 = tidak ada denda), maksimal pinjaman per anggota.
+3. **Pengaturan → Backup** — set folder lokal (default `<app_data>/backups/`) atau target rclone (Google Drive / S3). Aktifkan scheduler harian / mingguan.
+4. **Master Data → Kategori / DDC / Penerbit / Bahasa** — isi master data dasar atau biarkan default.
+5. **Anggota → Tambah / Impor Excel** — input siswa. Bisa via `+ Tambah Anggota` (manual) atau `Impor Excel` (bulk dari template `.xlsx`).
+6. **Buku → Tambah / Impor Excel / Impor via ISBN** — input koleksi. ISBN scanner otomatis ambil judul/penulis/cover dari Open Library + Google Books.
+7. **Cetak KTA** — dari halaman Anggota, pilih anggota → `Cetak KTA` → pilih template → print.
+8. **Mulai sirkulasi** — Sidebar → **Sirkulasi** → mode `Pinjam` → scan KTA siswa → scan barcode buku → selesai.
+
+> Butuh latihan tanpa risiko? Aktifkan **Pengaturan → Mode Demo** — semua perubahan masuk DB terpisah. Saat dinonaktifkan, DB asli kembali utuh.
+
+---
+
+## 📍 Lokasi Data
+
+SQLite + asset files dibuat otomatis di app data dir per OS:
+
+| OS | Path |
+|---|---|
+| Linux | `~/.local/share/id.alviarts.perpustakaan/` |
+| Windows | `%APPDATA%\id.alviarts.perpustakaan\` |
+| macOS | `~/Library/Application Support/id.alviarts.perpustakaan/` |
+
+Berisi:
+- `perpustakaan-v2.db` — database utama (SQLite, WAL mode).
+- `perpustakaan-v2-demo.db` — DB sandbox (kalau Mode Demo pernah diaktifkan).
+- `uploads/{anggota,buku,identitas}/` — foto + cover + logo.
+- `backups/perpustakaan-<timestamp>.db[.sha256]` — output backup.
+- `demo-archive/<ts>.db` — arsip DB demo dari sesi sebelumnya.
+
+> **Untuk migrasi ke komputer baru:** tinggal copy seluruh folder `id.alviarts.perpustakaan/` ke komputer baru di lokasi yang sama. Pasang aplikasi → buka → semua data sudah ada.
+
+---
+
+## ❓ FAQ
+
+**T: Aplikasi butuh internet?**
+J: Tidak. Semua fitur jalan offline. Internet hanya dibutuhkan untuk: (a) Bulk import via ISBN (opsional, ada fallback offline), (b) Backup ke cloud via rclone (opsional), (c) Sinkronisasi Google Sheets (opsional).
+
+**T: Bagaimana kalau lupa password admin?**
+J: Login screen → "Lupa kata sandi?" → jawab security question yang di-set saat first-run. Kalau security question pun lupa, lihat [docs/manual.md](docs/manual.md) section "Reset password manual via SQLite".
+
+**T: Apakah bisa multi-user / akses dari komputer lain?**
+J: Saat ini single-machine, multi-user lokal (banyak akun di satu komputer dengan RBAC). Akses lintas komputer rencananya via Sheets sync (lihat roadmap).
+
+**T: Kalau saya rusak DB / hapus tidak sengaja?**
+J: Restore dari backup terakhir via Pengaturan → Backup → History → Restore. Kalau tidak ada backup, export manual ke Excel sebelum operasi destruktif.
+
+**T: Berapa beban lisensi?**
+J: **Gratis (MIT)** — bebas dipakai sekolah negeri / swasta / komunitas / komersial. Sumber kode publik di repo ini.
+
+---
+
+## 🛠️ Untuk Developer
+
+### Stack
+
+**Backend:** Rust + Tauri 2 + rusqlite + bcrypt + chrono
+**Frontend:** React 18 + TypeScript + Vite + Tailwind + shadcn/ui + TanStack Router + Zustand + React Query
+**i18n:** i18next (id / en, parity-checked)
+**Charts:** Recharts • **Excel:** SheetJS • **PDF:** pdf-lib • **Markdown:** react-markdown
+**Workspace:** pnpm monorepo (`apps/desktop`, `apps/manual`, `packages/shared`)
+
+### Persyaratan Build
+
+- **Node ≥ 20**, **pnpm ≥ 9.15.1**, **Rust stable ≥ 1.95**
+- Plus prereqs Tauri per OS:
+  - **Linux (Ubuntu 22.04+):**
+    ```bash
+    sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev \
+      librsvg2-dev patchelf libssl-dev pkg-config
+    ```
+  - **macOS:** Xcode Command Line Tools (`xcode-select --install`)
+  - **Windows:** WebView2 (sudah ada di Windows 11) + [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+
+### Dev
 
 ```bash
 git clone https://github.com/alviarts/perpustakaan-offline.git
 cd perpustakaan-offline
 pnpm install --frozen-lockfile
-pnpm tauri:dev
+pnpm tauri:dev    # buka aplikasi dengan hot-reload
 ```
 
-Persyaratan: **Node ≥ 20**, **pnpm ≥ 9**, **Rust stable ≥ 1.95**, plus prereqs Tauri per OS (lihat detail di bawah).
-
----
-
-## 🛠️ Stack
-
-**Backend:** Rust + Tauri 2 + rusqlite + bcrypt
-**Frontend:** React 18 + TypeScript + Vite + Tailwind + shadcn/ui + TanStack Router + Zustand
-**i18n:** i18next (id / en, parity-checked)
-**Charts:** Recharts • **Excel:** SheetJS • **Markdown:** react-markdown
-**Workspace:** pnpm monorepo (`apps/desktop`, `apps/manual`, `packages/shared`)
-
----
-
-## 📦 Build Production
+### Build Production
 
 ```bash
 pnpm tauri:build
 ```
 
-Output di `apps/desktop/src-tauri/target/release/bundle/`:
+Output ada di `apps/desktop/src-tauri/target/release/bundle/`:
 - **Windows:** `msi/*.msi` + `nsis/*-setup.exe`
 - **Linux:** `deb/*.deb` + `appimage/*.AppImage`
 - **macOS:** `dmg/*.dmg`
 
-Tauri tidak mendukung cross-build — build di OS target masing-masing atau pakai CI matrix.
+> Tauri tidak mendukung cross-build — build di OS target masing-masing atau pakai CI matrix.
 
----
-
-## 🗄️ Lokasi Data
-
-SQLite + asset files dibuat otomatis di app data dir per OS:
-
-- **Linux:** `~/.local/share/id.alviarts.perpustakaan/`
-- **Windows:** `%APPDATA%\id.alviarts.perpustakaan\`
-- **macOS:** `~/Library/Application Support/id.alviarts.perpustakaan/`
-
-Berisi: `perpustakaan-v2.db` (database utama), `uploads/{anggota,buku,identitas}/` (foto + cover + logo), `backups/perpustakaan-<timestamp>.db[.sha256]` (output backup).
-
----
-
-## ✅ Quality Gates (sebelum commit)
+### Quality Gates (sebelum commit)
 
 ```bash
 # Frontend
@@ -139,29 +278,15 @@ cargo clippy --all-targets -- -D warnings
 cargo test --lib
 ```
 
-CI (`.github/workflows/ci-v2.yml`) menjalankan semua gate di atas pada tiap PR. Tag `v*` push memicu build Windows installer + publish GitHub Release otomatis.
+CI (`.github/workflows/ci-v2.yml`) menjalankan semua gate di atas pada tiap PR.
+Tag `v*` push memicu build Windows installer + publish GitHub Release otomatis.
 
----
+### Kontribusi
 
-## 🔧 Persyaratan Development per OS
-
-- **Linux (Ubuntu 22.04+):**
-  ```bash
-  sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev \
-    librsvg2-dev patchelf libssl-dev pkg-config
-  ```
-- **macOS:** Xcode Command Line Tools (`xcode-select --install`)
-- **Windows:** WebView2 (sudah ada di Windows 11) + [Microsoft Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
-
----
-
-## 🤝 Kontribusi
-
-Konvensi:
 - **Conventional commits** (English): `feat(scope): description`, `fix(scope): ...`, dst.
-- **Branch:** `devin/<unix-ts>-<short-kebab-name>`
-- **i18n parity wajib** — setiap string baru harus ada di `i18n/id/<ns>.json` **dan** `i18n/en/<ns>.json`
-- **Jangan commit:** `*.db`, `target/`, `node_modules/`, binary, secret
+- **Branch:** `devin/<unix-ts>-<short-kebab-name>` atau `feat/<short>` / `fix/<short>`.
+- **i18n parity wajib** — setiap string baru harus ada di `i18n/id/<ns>.json` **dan** `i18n/en/<ns>.json`.
+- **Jangan commit:** `*.db`, `target/`, `node_modules/`, binary, secret.
 
 Lihat [`docs/manual.md`](docs/manual.md) untuk panduan end-user dan [CHANGELOG.md](CHANGELOG.md) untuk riwayat rilis.
 
@@ -169,8 +294,10 @@ Lihat [`docs/manual.md`](docs/manual.md) untuk panduan end-user dan [CHANGELOG.m
 
 ## 📜 Lisensi & Credits
 
-[MIT](LICENSE) — bebas dipakai, dimodifikasi, dan didistribusikan.
+[MIT](LICENSE) — bebas dipakai, dimodifikasi, dan didistribusikan untuk keperluan apapun (termasuk komersial).
 
-- **SIM-Perpus original** oleh Kang Sur (Excel + VBA)
-- **DDC (Dewey Decimal Classification)** — public domain
-- Built with [Tauri](https://tauri.app/), [React](https://react.dev/), [Vite](https://vite.dev/), [Tailwind CSS](https://tailwindcss.com/), [shadcn/ui](https://ui.shadcn.com/), [TanStack Router](https://tanstack.com/router), [Recharts](https://recharts.org/), [SheetJS](https://sheetjs.com/)
+- **SIM-Perpus original** — Kang Sur (Excel + VBA) — inspirasi awal aplikasi ini.
+- **DDC (Dewey Decimal Classification)** — public domain.
+- Built with [Tauri](https://tauri.app/), [React](https://react.dev/), [Vite](https://vite.dev/), [Tailwind CSS](https://tailwindcss.com/), [shadcn/ui](https://ui.shadcn.com/), [TanStack Router](https://tanstack.com/router), [Recharts](https://recharts.org/), [SheetJS](https://sheetjs.com/), [pdf-lib](https://pdf-lib.js.org/).
+
+Bug / saran? **[Buka issue di GitHub →](https://github.com/alviarts/perpustakaan-offline/issues/new)**

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perpustakaan/desktop",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2967,7 +2967,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perpustakaan-desktop"
-version = "1.0.12"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpustakaan-desktop"
-version = "1.0.12"
+version = "1.1.0"
 description = "Perpustakaan Nusantara v2 desktop (Tauri 2)"
 authors = ["alvi arts"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PerpustakaanNusantara",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "identifier": "id.alviarts.perpustakaan",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perpustakaan-offline",
   "private": true,
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Perpustakaan Nusantara v2 — Tauri 2 + React 18 + TypeScript",
   "license": "Proprietary",
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
## Summary

Release **v1.1.0** — bumps version 1.0.12 → 1.1.0 across all 4 manifest files (root `package.json`, `apps/desktop/package.json`, `apps/desktop/src-tauri/Cargo.toml`, `apps/desktop/src-tauri/tauri.conf.json`) + `Cargo.lock`, adds the [1.1.0] CHANGELOG section, and rewrites `README.md` as a complete self-onboarding user guide.

**14 items** sudah merged ke main sebelumnya (PR #145–#158):

- **#145** BUG-Pengembalian-DendaDup — dedup 6→3 tombol denda saat preset multiplier collision
- **#146** FEAT-Peminjaman-DendaInline — preset bayar denda di PeminjamanDetail
- **#147** FEAT-Dashboard-Clickable-KPI — KPI cards navigasi ke list pages
- **#148** FEAT-Dashboard-Quotes-2min — rotasi 2 menit + manual next
- **#149** FEAT-Quotes-Library — +30 quotes perpustakaan
- **#150** FEAT-Sirkulasi-Search — combobox anggota+buku dropdown
- **#151** FEAT-OPAC-PostScanProfile — full-screen profile panel post-scan
- **#152** FEAT-OPAC-Scan-Locked — confirm dialog saat anggota lain login
- **#153** A1-CommandPalette — Ctrl+K dengan rute + aksi cepat
- **#154** A2-SkeletonScreens — TableSkeleton + CardSkeleton menggantikan spinner
- **#155** C1-LaporanEksekutifPDF — laporan eksekutif 3-halaman (cover/charts/action items)
- **#156** D1-SystemHealthWidget — dashboard health card 5 baris
- **#157** D5-SandboxDemoMode — toggle DB demo terisolasi + banner
- **#158** E1-OPACBukuPilihan — featured carousel + admin curation page

Detail lengkap di `CHANGELOG.md`.

**README rewrite** difokuskan ke pengalaman first-time user:
- Target audience yang jelas (sekolah / madrasah, tanpa server, internet sering mati).
- Fitur lengkap dalam <details open> collapsible groups.
- Step-by-step Windows install (NSIS vs MSI, default credentials, mandatory password change).
- 5-menit setup walkthrough (identitas → aturan pinjam → backup → master data → anggota → buku → cetak KTA → mulai sirkulasi).
- FAQ untuk pertanyaan paling umum (offline-only? lupa password? multi-user? lisensi?).
- Tabel lokasi data per OS untuk migrasi antar komputer.
- Developer section dipindah ke bawah dengan stack, persyaratan build, quality gates, kontribusi.

Setelah PR ini merge, push tag `v1.1.0` akan memicu `release-v2` workflow yang otomatis: build Windows installer (NSIS + MSI), extract `## [1.1.0]` section dari CHANGELOG ke release body, publish GitHub Release.

## Review & Testing Checklist for Human

Risk: **green** (release plumbing only — no behavioural code changes; semua 14 fitur sudah merged + CI green sebelum PR ini).

- [ ] Cek `CHANGELOG.md` section `[1.1.0]` — semua 14 item ada, deskripsi akurat, format konsisten dengan release sebelumnya.
- [ ] Cek `README.md` — install instructions dan setup walkthrough cukup jelas untuk pustakawan non-teknis.
- [ ] Setelah merge: push tag `v1.1.0` (saya bisa push otomatis kalau diizinkan, atau alviarts push manual).

### Notes

- Versi sekarang sinkron di 4 file: `1.1.0`. `Cargo.lock` ikut ter-update.
- Tidak ada perubahan kode runtime di PR ini — release-only.
- Workflow `release-v2` akan extract section CHANGELOG via `scripts/extract-changelog.mjs v1.1.0` saat tag push.